### PR TITLE
fix: update facetable properties for SOLR DocValues optimization

### DIFF
--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -469,7 +469,7 @@
             "objectConfiguration": {},
             "fileConfiguration": {},
             "oneOf": [],
-            "facetable": true,
+            "facetable": false,
             "title": "Hosting vorm",
             "example": ["SaaS"]
           },
@@ -479,7 +479,7 @@
             "visible": true,
             "order": 0,
             "enum": ["NL", "EU", "US", "Elders"],
-            "facetable": true,
+            "facetable": false,
             "title": "In welk land wordt de data opgeslagen?",
             "example": "Bijvoorbeeld: NL"
           },
@@ -489,7 +489,7 @@
             "visible": true,
             "order": 0,
             "enum": ["NL", "EU", "US", "Elders"],
-            "facetable": true,
+            "facetable": false,
             "title": "Waar wordt de applicatie gehost?",
             "example": "Bijvoorbeeld: NL"
           },
@@ -961,7 +961,7 @@
             "pattern": "^CVE-\\d{4}-\\d{4,}$",
             "visible": true,
             "order": 4,
-            "facetable": true,
+            "facetable": false,
             "title": "CVE Code",
             "maxLength": 20,
             "example": "Bijvoorbeeld: CVE-2021-44228"
@@ -973,7 +973,7 @@
             "maximum": 10.0,
             "visible": true,
             "order": 5,
-            "facetable": true,
+            "facetable": false,
             "title": "CVSS Score",
             "example": "Bijvoorbeeld: 9.8"
           },
@@ -1755,7 +1755,7 @@
             "type": "string",
             "visible": false,
             "hideOnCollection": true,
-            "facetable": true,
+            "facetable": false,
             "order": 14,
             "minLength": null,
             "maxLength": null,
@@ -2636,6 +2636,7 @@
             "type": "string",
             "order": 8,
             "title": "Gegevensuitwisseling Richting",
+            "facetable": false,
             "enum": ["AnaarB", "BnaarA", "bi-directioneel"]
           },
           "moduleA": {
@@ -2792,7 +2793,7 @@
             "maximum": 10,
             "visible": true,
             "required": true,
-            "facetable": true,
+            "facetable": false,
             "title": "Waardering",
             "order": 4
           },


### PR DESCRIPTION
## Summary

This PR optimizes SOLR performance by updating facetable properties for fields that need DocValues but not faceting capabilities.

## Changes Made

- ✅ Set `facetable: false` for properties that need DocValues but not faceting:
  - `cloudDienstverleningsmodel`
  - `hostingJurisdictie`
  - `hostingLocatie`
  - `cveCode`
  - `cvssScore`
  - `waardering`
  - `samenwerkingtype`
  - `gegevensuitwisselingRichting` (added facetable property)
- ✅ Kept `referentieComponenten` and `type` as `facetable: true`

## Benefits

- **Performance**: DocValues enabled for sorting/filtering without unnecessary faceting overhead
- **Resource Usage**: Reduced memory and CPU usage by disabling faceting on fields that don't need it
- **SOLR Optimization**: Better field configuration for large datasets

## Technical Details

DocValues are used for sorting, grouping, and function queries, while faceting is used for aggregation counts. Many fields need DocValues for performance but don't need the overhead of faceting capabilities.

## Testing

- [x] All modified properties maintain their data types and constraints
- [x] DocValues functionality preserved for sorting/filtering
- [x] Faceting disabled only where not needed