### PR TITLE
feat: implement PATCH requests for efficient partial updates

### DIFF
--- a/src/modals/OrganisationModal.vue
+++ b/src/modals/OrganisationModal.vue
@@ -263,6 +263,40 @@ export default {
 		closeModal() {
 			this.$emit('close')
 		},
+		/**
+		 * Get only the changed properties between original and current form data
+		 * @return {object} Object containing only the changed properties
+		 */
+		getChangedProperties() {
+			if (!this.isEditMode) {
+				// For create/copy mode, return all form data
+				return this.formData
+			}
+
+			const changes = {}
+			const originalData = this.organisation
+
+			// Compare each form field with original data
+			Object.keys(this.formData).forEach(key => {
+				const formValue = this.formData[key]
+				const originalValue = originalData[key]
+
+				// Handle different types of comparisons
+				if (Array.isArray(formValue) && Array.isArray(originalValue)) {
+					// Compare arrays (for deelnemers, contactpersonen, etc.)
+					if (JSON.stringify(formValue) !== JSON.stringify(originalValue)) {
+						changes[key] = formValue
+					}
+				} else if (formValue !== originalValue) {
+					// Simple value comparison
+					changes[key] = formValue
+				}
+			})
+
+			console.info('Detected changes:', changes)
+			return changes
+		},
+
 		async saveOrganisation() {
 			if (!this.isFormValid) {
 				showError(this.t('softwarecatalog', 'Please fill in all required fields'))
@@ -278,15 +312,21 @@ export default {
 				let result
 
 				if (this.isEditMode) {
-					// Update existing organisation - preserve @self metadata
-					const updateData = {
-						...this.formData,
-						'@self': this.organisation['@self'] || {}
+					// Get only the changed properties for PATCH request
+					const changes = this.getChangedProperties()
+					
+					if (Object.keys(changes).length === 0) {
+						// No changes detected
+						this.successMessage = this.t('softwarecatalog', 'No changes to save')
+						this.success = true
+						setTimeout(() => {
+							this.closeModal()
+						}, 1500)
+						return
 					}
-					result = await objectStore.saveObject(updateData, {
-						register: schemaConfig.register,
-						schema: schemaConfig.schema
-					})
+
+					// Update existing organisation using PATCH - only send changed properties
+					result = await objectStore.patchObject('organisatie', this.organisation.id, changes)
 					this.successMessage = this.t('softwarecatalog', 'Organisation updated successfully')
 				} else {
 					// Create new organisation (both create and copy modes)

--- a/src/modals/object/ChangeOrganisatieStatusDialog.vue
+++ b/src/modals/object/ChangeOrganisatieStatusDialog.vue
@@ -127,9 +127,8 @@ export default {
 					throw new Error('Organisatie of nieuwe status ontbreekt')
 				}
 
-				// Prepare the update data
-				const updateData = {
-					...organisatie,
+				// Prepare the patch data - only include changed properties
+				const patchData = {
 					status: newStatus,
 				}
 
@@ -139,21 +138,21 @@ export default {
 					const organisatieUuid = organisatie.id || organisatie.uuid || organisatie['@self']?.id
 					
 					// Set the owner and organisation in @self metadata to the organisation's own UUID
-					if (!updateData['@self']) {
-						updateData['@self'] = { ...organisatie['@self'] }
+					patchData['@self'] = {
+						...organisatie['@self'],
+						owner: organisatieUuid,
+						organisation: organisatieUuid
 					}
-					updateData['@self'].owner = organisatieUuid
-					updateData['@self'].organisation = organisatieUuid
 					
 					console.info('Setting @self owner and organisation properties to own UUID during activation:', {
 						organisatieId: organisatieUuid,
-						ownerProperty: updateData['@self'].owner,
-						selfOrganisationProperty: updateData['@self'].organisation
+						ownerProperty: patchData['@self'].owner,
+						selfOrganisationProperty: patchData['@self'].organisation
 					})
 				}
 
-				// Update the organisation status using the object store
-				const updatedOrganisatie = await objectStore.updateObject('organisatie', organisatie.id, updateData)
+				// Update only the status (and @self if activating) using PATCH
+				const updatedOrganisatie = await objectStore.patchObject('organisatie', organisatie.id, patchData)
 
 				this.success = true
 

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -1225,7 +1225,7 @@ export const useObjectStore = defineStore('object', {
 		},
 
 		/**
-		 * Update existing object
+		 * Update existing object (full replacement)
 		 * @param {string} type - Object type
 		 * @param {string} id - Object ID
 		 * @param {object} data - Updated object data
@@ -1267,6 +1267,57 @@ export const useObjectStore = defineStore('object', {
 				return updatedObject
 			} catch (error) {
 				console.error(`Error updating ${type} object:`, error)
+				this.setError(`${type}_${id}`, error.message)
+				this.setState(type, { success: false, error: error.message })
+				throw error
+			} finally {
+				this.setLoading(`${type}_${id}`, false)
+			}
+		},
+
+		/**
+		 * Patch existing object (partial update)
+		 * @param {string} type - Object type
+		 * @param {string} id - Object ID
+		 * @param {object} changes - Object with only the changed properties
+		 * @return {Promise<object>}
+		 */
+		async patchObject(type, id, changes) {
+			this.setLoading(`${type}_${id}`, true)
+			this.setError(`${type}_${id}`, null)
+			this.setState(type, { success: null, error: null })
+
+			try {
+				// Ensure settings are loaded first
+				if (!this.settings) {
+					await this.fetchSettings()
+				}
+
+				const response = await fetch(this._constructApiUrl(type, id), {
+					method: 'PATCH',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(changes),
+				})
+				if (!response.ok) throw new Error(`Failed to patch ${type} object`)
+
+				const updatedObject = await response.json()
+				if (!this.objects[type]) this.objects[type] = {}
+				this.objects[type][id] = updatedObject
+
+				// Refresh the collection to ensure it's up to date
+				await this.fetchCollection(type)
+
+				// If this is the active object, update it
+				if (this.activeObjects[type]?.id === id) {
+					this.activeObjects[type] = updatedObject
+				}
+
+				// Set success state
+				this.setState(type, { success: true, error: null })
+
+				return updatedObject
+			} catch (error) {
+				console.error(`Error patching ${type} object:`, error)
 				this.setError(`${type}_${id}`, error.message)
 				this.setState(type, { success: false, error: error.message })
 				throw error


### PR DESCRIPTION
- Add patchObject method to object store for partial updates
- Update status change dialog to use PATCH instead of PUT (only sends status)
- Update organisation edit modal to detect and send only changed properties
- Improves performance by reducing payload size and network traffic
- Follows REST best practices for partial resource updates
- Prevents overwriting unchanged data and reduces potential conflicts