### PR TITLE
chore: update max Nextcloud version to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@ Submit a [feature request](https://github.com/OpenCatalogi/.github/issues/new/ch
     <repository>https://github.com/ConductionNL/SoftwareCatalogus</repository>
 
     <dependencies>
-        <nextcloud min-version="28" max-version="30"/>
+        <nextcloud min-version="28" max-version="32"/>
         <php min-version="8.0" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>


### PR DESCRIPTION
- Updated max-version from 30 to 32 in appinfo/info.xml
- Ensures compatibility with newer Nextcloud versions