### PR TITLE
Bump version to 0.1.138

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ Submit a [bug report](https://github.com/OpenCatalogi/.github/issues/new/choose)
 
 Submit a [feature request](https://github.com/OpenCatalogi/.github/issues/new/choose).
     ]]></description>
-    <version>0.1.136</version>
+    <version>0.1.138</version>
     <licence>agpl</licence>
     <category>organization</category>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>


### PR DESCRIPTION
## Summary
- Bumps app version from 0.1.136 to 0.1.138 for Nextcloud app store release

🤖 Generated with [Claude Code](https://claude.com/claude-code)