### PR TITLE
feat: activate ConceptOrganisaties dashboard widget with shared chunks

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Vrij en open source onder de EUPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.1.140</version>
+    <version>0.1.141</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>SoftwareCatalog</namespace>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -19,6 +19,7 @@ namespace OCA\SoftwareCatalog\AppInfo;
 
 use OCA\SoftwareCatalog\BackgroundJob\OrganizationContactSyncJob;
 use OCA\SoftwareCatalog\Controller\ContactpersonenController;
+use OCA\SoftwareCatalog\Dashboard\ConceptOrganisatiesWidget;
 use OCA\SoftwareCatalog\EventListener\SoftwareCatalogEventListener;
 use OCA\SoftwareCatalog\EventListener\TestEventListener;
 use OCA\SoftwareCatalog\EventListener\ModuleComplianceSubscriber;
@@ -428,6 +429,9 @@ class Application extends App implements IBootstrap
                     );
                 }
                 );
+
+        // Dashboard widgets — see lib/Dashboard/*.php and src/*Widget.js.
+        $context->registerDashboardWidget(ConceptOrganisatiesWidget::class);
     }//end register()
 
     /**

--- a/lib/Dashboard/ConceptOrganisatiesWidget.php
+++ b/lib/Dashboard/ConceptOrganisatiesWidget.php
@@ -93,9 +93,13 @@ class ConceptOrganisatiesWidget implements IWidget
      */
     public function load(): void
     {
-        $appId      = Application::APP_ID;
-        $scriptName = $appId.'-conceptOrganisatiesWidget';
-        Util::addScript(application: $appId, file: $scriptName);
+        $appId = Application::APP_ID;
+        // Shared chunks emitted by webpack splitChunks + runtimeChunk (see webpack.config.js).
+        // Order: runtime → vendor → nc-vue → widget.
+        Util::addScript(application: $appId, file: $appId.'-runtime');
+        Util::addScript(application: $appId, file: $appId.'-shared-vendor');
+        Util::addScript(application: $appId, file: $appId.'-shared-nc-vue');
+        Util::addScript(application: $appId, file: $appId.'-conceptOrganisatiesWidget');
         Util::addStyle(application: $appId, file: 'dashboardWidgets');
     }//end load()
 }//end class

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,10 @@ webpackConfig.entry = {
 		import: path.join(__dirname, 'src', 'settings.js'),
 		filename: appId + '-settings.js',
 	},
+	conceptOrganisatiesWidget: {
+		import: path.join(__dirname, 'src', 'conceptOrganisatiesWidget.js'),
+		filename: appId + '-conceptOrganisatiesWidget.js',
+	},
 }
 
 // Use local source when available (monorepo dev), otherwise fall back to npm package
@@ -48,12 +52,6 @@ webpackConfig.module = {
 			loader: 'vue-loader',
 		},
 		{
-			test: /\.ts$/,
-			loader: 'ts-loader',
-			exclude: /node_modules/,
-			options: { appendTsSuffixTo: [/\.vue$/] },
-		},
-		{
 			test: /\.css$/,
 			use: ['style-loader', 'css-loader'],
 		},
@@ -67,5 +65,36 @@ webpackConfig.plugins = [
 // Force @nextcloud/dialogs to resolve from this app's node_modules,
 // preventing the nextcloud-vue submodule's nested deps (Vue 3) from leaking in.
 webpackConfig.resolve.alias['@nextcloud/dialogs'] = path.resolve(__dirname, 'node_modules/@nextcloud/dialogs')
+
+// Shared chunks so widgets reuse Vue / Pinia / @nextcloud/vue + @conduction/nextcloud-vue
+// instead of bundling them per entry. Slashes \\/ used to match both posix and win paths.
+webpackConfig.optimization = {
+	...(webpackConfig.optimization || {}),
+	runtimeChunk: { name: 'runtime' },
+	splitChunks: {
+		...(webpackConfig.optimization?.splitChunks || {}),
+		chunks: 'all',
+		cacheGroups: {
+			default: false,
+			defaultVendors: false,
+			ncVue: {
+				name: appId + '-shared-nc-vue',
+				test: /[\\/]node_modules[\\/](@nextcloud[\\/]vue|@conduction[\\/]nextcloud-vue)[\\/]|[\\/]nextcloud-vue[\\/]src[\\/]/,
+				priority: 30,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-nc-vue.js',
+			},
+			vendor: {
+				name: appId + '-shared-vendor',
+				test: /[\\/]node_modules[\\/](vue|pinia|vue-material-design-icons|@vueuse|core-js)[\\/]/,
+				priority: 20,
+				reuseExistingChunk: true,
+				enforce: true,
+				filename: appId + '-shared-vendor.js',
+			},
+		},
+	},
+}
 
 module.exports = webpackConfig


### PR DESCRIPTION
## Summary
- Activates the previously orphaned **ConceptOrganisaties** dashboard widget by registering it in `lib/AppInfo/Application.php`. The widget already had a Vue mount and `load()` method but was never exposed to the dashboard.
- Brings the bundle in line with the ADR-004 widget pattern: `splitChunks` emits `softwarecatalog-shared-vendor.js` + `softwarecatalog-shared-nc-vue.js`, `runtimeChunk` emits `softwarecatalog-runtime.js`, widget `load()` attaches runtime → vendor → nc-vue → widget in order.
- Drops the unused `ts-loader` rule (0 `.ts` files under `src/`).
- Bumps appinfo `0.1.140` → `0.1.141` so Nextcloud invalidates the cached widget script.

## Test plan
- [ ] npm run build — produces shared-vendor / shared-nc-vue / runtime chunks plus softwarecatalog-conceptOrganisatiesWidget.js
- [ ] composer check:strict passes
- [ ] After deploy, dashboard exposes "Concept organisaties" widget; mounting does not throw