### PR TITLE
fix(#221): provision @resolve: keys via IInitialState

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -63,6 +63,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\AppFramework\Services\IInitialState;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -447,6 +448,30 @@ class Application extends App implements IBootstrap
     {
         // Background jobs are registered declaratively in appinfo/info.xml.
         // Initialization is handled by the Repair step (InitializeSettings).
-        // No per-request work needed here.
+        // Provision IAppConfig keys referenced as `@resolve:<key>` sentinels in
+        // src/manifest.json so @conduction/nextcloud-vue's resolver chain can
+        // pick them up synchronously via @nextcloud/initial-state (Step 1)
+        // without falling through to the deferred backend fetch (Step 2).
+        // See node_modules/@conduction/nextcloud-vue/src/utils/resolveManifestSentinels.js
+        // — readInitialState() calls loadState(appId, key, undefined).
+        $container    = $this->getContainer();
+        $initialState = $container->get(IInitialState::class);
+        $appConfig    = $container->get(IAppConfig::class);
+
+        // Keys must match every distinct `@resolve:<key>` sentinel in
+        // src/manifest.json. Discover with:
+        // grep -oE '@resolve:[a-z_]+' src/manifest.json | sort -u.
+        $resolveKeys = [
+            'voorzieningen_register',
+        ];
+        foreach ($resolveKeys as $key) {
+            $value       = $appConfig->getValueString(self::APP_ID, $key, '');
+            $provisioned = null;
+            if ($value !== '') {
+                $provisioned = $value;
+            }
+
+            $initialState->provideInitialState($key, $provisioned);
+        }
     }//end boot()
 }//end class


### PR DESCRIPTION
## Summary

Closes #221.

The 12 `@resolve:voorzieningen_register` sentinels in `src/manifest.json` were not being resolved at runtime because `@conduction/nextcloud-vue`'s `useAppManifest` only runs sentinel resolution inside the backend-fetch success path, and softwarecatalog has no `/api/manifest` controller. PR #220 (lib bump to `1.0.0-beta.30`) brought in the resolver but it could not fire without backend wiring — all 12 voorzieningen pages were silently routing to a literal `@resolve:voorzieningen_register` string.

This patch provisions every distinct `@resolve:<key>` sentinel from `src/manifest.json` via `OCP\AppFramework\Services\IInitialState` in `Application::boot()`. The lib's resolver chain (`node_modules/@conduction/nextcloud-vue/src/utils/resolveManifestSentinels.js`) consumes initial state synchronously before the deferred backend fetch:

1. **Step 1 — initial-state** (`readInitialState(appId, key)`) calls `loadState(appId, key, undefined)`. If provisioned, returns immediately.
2. **Step 2 — runtime fetch** falls back to `GET /apps/{appId}/api/configs/{key}` (which softwarecatalog does not implement).

Provisioning via `IInitialState` short-circuits at Step 1 and unblocks the 12 voorzieningen pages immediately. Brings the 12 voorzieningen pages back online — they were silently routing to a literal `@resolve:voorzieningen_register` string before.

A full `/api/manifest` backend controller (Option A) is deferred as a future follow-up — Option B (this patch) is the minimal fix.

## Keys provisioned

Discovered via `grep -oE '@resolve:[a-z_]+' src/manifest.json | sort -u`:

- `voorzieningen_register`

(Only one distinct key across all 12 sentinel occurrences.)

## Files changed

- `lib/AppInfo/Application.php` — adds `IInitialState` import + 24-line `boot()` body that loops over `$resolveKeys` and calls `provideInitialState($key, $value !== '' ? $value : null)` for each. Empty config falls through to `null` so the resolver's "key unset" branch logs a clear warning rather than provisioning an empty string.

## Gates

Against `origin/development` baseline (only `lib/AppInfo/Application.php` differs):

- `composer lint` — clean
- `./vendor/bin/phpcs --standard=phpcs.xml lib/AppInfo/Application.php` — clean
- `./vendor/bin/psalm --threads=1 --no-cache lib/AppInfo/Application.php` — `No errors found!`
- `./vendor/bin/phpmd lib/AppInfo/Application.php text phpmd.xml` — clean
- `./vendor/bin/phpstan analyse --memory-limit=1G lib/AppInfo/Application.php` — `[OK] No errors`
- Frontend (`npm run build` / `npm run lint`) — skipped; PHP-only change, no JS/Vue/manifest touched.

## Pre-existing quality issues (flagged for separate cleanup)

`composer phpcs` over the full tree surfaces 2 pre-existing PHPCS errors in unrelated files (also present on `origin/development`):

- `lib/Service/SymfonyEmailService.php:53` — `@SuppressWarnings(PHPMD.StaticAccess)` tag-value indentation
- `lib/Service/SettingsService.php:57` — same sniff

Not touched here per the scope of #221. Worth a follow-up `chore(phpcs):` PR.

## Manual smoke test

Skipped — the dev container at `localhost:8080` mounts the parent `softwarecatalog/` checkout (on `development` HEAD), not this worktree, so a smoke test from the worktree would not reflect the patch. After merge + lib reload, verify with:

```js
window.OCP.InitialState.loadState('softwarecatalog', 'voorzieningen_register')
// should return the configured register slug, not null
```

## Test plan

- [ ] After merge, confirm the 12 voorzieningen pages load with a real register slug (not a literal `@resolve:voorzieningen_register` string) at `localhost:8080`.
- [ ] Confirm `loadState('softwarecatalog', 'voorzieningen_register')` returns the configured slug from `IAppConfig`.
- [ ] Confirm the `[resolveManifestSentinels] Manifest sentinel '@resolve:voorzieningen_register' resolved to null (key unset)` warning fires only when `IAppConfig` is genuinely unset (cleared during repair / fresh install).