### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/lang-json": "^6.0.0",
-				"@conduction/nextcloud-vue": "^1.0.0-beta.30",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 				"@fortawesome/fontawesome-svg-core": "^6.5.2",
 				"@fortawesome/free-solid-svg-icons": "^6.5.2",
 				"@nextcloud/axios": "^2.5.0",
@@ -63,6 +63,8 @@
 				"@vue/eslint-config-typescript": "^13.0.0",
 				"@vue/test-utils": "^2.4.6",
 				"@vue/vue2-jest": "^29.0.0",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
 				"browserslist": "^4.25.2",
 				"caniuse-lite": "^1.0.30001733",
 				"eslint": "^8.57.0",
@@ -2067,9 +2069,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.30",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
-			"integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
+			"version": "1.0.0-beta.40",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+			"integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -2082,12 +2084,14 @@
 				"@codemirror/search": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
+				"@microsoft/fetch-event-source": "^2.0.1",
 				"@nextcloud/dialogs": "^7.3.0",
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
+				"dompurify": "^3.0.0",
 				"gridstack": "^10.3.1",
 				"leaflet": "^1.9.0",
 				"lodash": "^4.17.21",
@@ -2099,6 +2103,7 @@
 				"vue-template-compiler": "^2.7.16"
 			},
 			"peerDependencies": {
+				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
 				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/capabilities": "^1.2.1",
 				"@nextcloud/l10n": "^2.0.0 || ^3.0.0",
@@ -2838,43 +2843,6 @@
 				}
 			}
 		},
-		"node_modules/@cyclonedx/cyclonedx-npm/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@cyclonedx/cyclonedx-npm/node_modules/ajv-formats": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependencies": {
-				"ajv": "^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"ajv": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@cyclonedx/cyclonedx-npm/node_modules/commander": {
 			"version": "14.0.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2897,14 +2865,6 @@
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
-		},
-		"node_modules/@cyclonedx/cyclonedx-npm/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/@cyclonedx/cyclonedx-npm/node_modules/lru-cache": {
 			"version": "11.2.7",
@@ -3072,6 +3032,23 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/eslint-visitor-keys": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
@@ -3102,6 +3079,13 @@
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
+		},
+		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.39.4",
@@ -4398,6 +4382,12 @@
 			"resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
 			"integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/@microsoft/fetch-event-source": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -7288,16 +7278,16 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -7305,9 +7295,9 @@
 			}
 		},
 		"node_modules/ajv-formats": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7338,30 +7328,6 @@
 			"peerDependencies": {
 				"ajv": "*"
 			}
-		},
-		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/ajv-formats/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/ansi-escapes": {
 			"version": "4.3.2",
@@ -10855,6 +10821,23 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/eslint/node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
 		"node_modules/eslint/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10964,6 +10947,13 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/eslint/node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/supports-color": {
 			"version": "7.2.0",
@@ -15270,9 +15260,9 @@
 			"license": "MIT"
 		},
 		"node_modules/json-schema-traverse": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -19902,21 +19892,22 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+		"node_modules/schema-utils/node_modules/ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
+				"ajv": "^8.0.0"
 			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv-keywords": {
@@ -19931,13 +19922,6 @@
 			"peerDependencies": {
 				"ajv": "^8.8.2"
 			}
-		},
-		"node_modules/schema-utils/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/schemes": {
 			"version": "1.4.0",
@@ -21211,30 +21195,6 @@
 			"engines": {
 				"node": ">=10.0.0"
 			}
-		},
-		"node_modules/table/node_modules/ajv": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/table/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.0",
-		"@conduction/nextcloud-vue": "^1.0.0-beta.30",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.40",
 		"@fortawesome/fontawesome-svg-core": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@nextcloud/axios": "^2.5.0",
@@ -70,6 +70,8 @@
 		"@babel/eslint-parser": "^7.28.6",
 		"@babel/preset-env": "^7.25.3",
 		"@cyclonedx/cyclonedx-npm": "^4.2.1",
+		"ajv": "^8.17.1",
+		"ajv-formats": "^3.0.1",
 		"@eslint/config-helpers": "^0.5.0",
 		"@eslint/eslintrc": "^3.3.3",
 		"@eslint/js": "^9.39.1",

--- a/src/customComponents.js
+++ b/src/customComponents.js
@@ -23,9 +23,15 @@ import DashboardCustomView from './views/Dashboard.vue'
 
 export default {
 	// --- Lib gap: bespoke OrganisatieCard + AddContactpersoonModal flow. ---
-	// CnIndexPage exposes a #card slot but the manifest cannot reference
-	// a customComponents entry to fill it. Until a `cardComponent` config
-	// field lands on type='index', Organisaties stays type='custom'.
+	// `cardComponent` on type='index' landed (CnIndexPage resolves a
+	// registered card by name), but Organisaties also owns a bespoke flow
+	// the manifest can't express yet: OrganisationModal CRUD + the
+	// AddContactpersoonModal, the activate/deactivate status dialogs,
+	// `_extend: contactpersonen` on the collection fetch, URL-hash deep
+	// links (search/filters/page) and the cross-component `organisation*`
+	// store subscriptions. So it stays type='custom' for now — but it does
+	// drive a CnIndexPage internally; the residual custom surface is the
+	// modal/dialog/deep-link wiring around it.
 	OrganisatieIndexView,
 
 	// --- Lib gap: settings sub-section orchestration. ---


### PR DESCRIPTION
## What

softwarecatalog is already on the Tier-4 `CnAppRoot` manifest shell (`softwarecatalog-manifest-v1`). This bumps `@conduction/nextcloud-vue` from `^1.0.0-beta.30` → `^1.0.0-beta.40` so it picks up the manifest column abstractions and — the big one — the `CnIndexPage` store-backed self-fetch mode shipped in nc-vue #219/#221/#222/#223:

- **`CnIndexPage` self-fetch** — when a `type:"index"` page has `register` + `schema` and no `objects` prop (the manifest path), `CnIndexPage` now derives `${register}-${schema}`, registers it in the object store and drives the list via `useListView`. So the six declarative index pages (Contactpersonen, Contracten, Standaarden, Reviews, Komplianties, Moduleversies) **render their object collection instead of an empty table**.
- `columns[].formatter` / `columns[].widget` / `columns[].aggregate` and `pages[].config.filter` are now available for those pages (no usages added in this PR — wiring them per-page is a follow-up).

## Also

- **`ajv` + `ajv-formats` → devDependencies.** `npm run check:manifest` was crashing (`TypeError: Cannot read properties of undefined (reading 'code')`) because the only top-level `ajv` was v6 (a transitive dep of eslint/webpack) while `ajv-formats` needs v8; the validate-manifest script's `require('ajv/dist/2020')` now resolves. → `check:manifest` PASS (0 errors).
- Updated the `OrganisatieIndexView` note in `customComponents.js`: the `cardComponent` config field it was waiting on landed, but the `OrganisationModal`/`AddContactpersoonModal`/status-dialog/`_extend`/URL-hash flow around it keeps that page `type:"custom"` for now.

## Verification (local)

- `npm run build` ✓ (only the usual entrypoint-size warnings)
- `npm run check:manifest` ✓ — manifest valid against schema 1.5.0, 0 errors
- `npm test` ✓ — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)