### PR TITLE
chore(docs): sync @conduction/docusaurus-preset lockfile to 1.5.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "softwarecatalog-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@conduction/docusaurus-preset": "^1.4.3",
+        "@conduction/docusaurus-preset": "^1.5.1",
         "@docusaurus/core": "^3.7.0",
         "@docusaurus/preset-classic": "^3.7.0",
         "@docusaurus/theme-mermaid": "^3.7.0",
@@ -2043,9 +2043,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.4.3.tgz",
-      "integrity": "sha512-64F8A0qal/EfNYJKqsXMGjsOV2X0WYi72plO6MTC/9h60Fz85cMwzEiRpi58e9lloHAc3UBVMuffrzmDimsfwA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-1.7.0.tgz",
+      "integrity": "sha512-JH7aXaRGZCvkHZTLTLRh3gDWhj/2zAc8S4eBGS67hCfDIwzP5SK+Uj5BidoqbSi0FEEnekEoya2AVVLXbNv/OQ==",
       "license": "EUPL-1.2",
       "peerDependencies": {
         "@docusaurus/core": "^3.0.0",


### PR DESCRIPTION
package.json declared ^1.5.1 but the lockfile resolved 1.4.3, breaking `npm ci` on `development`. Regenerated lockfile; verified `npm ci --legacy-peer-deps`.