### PR TITLE
feat(manifest): render status/category columns as badges

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -63,7 +63,7 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "contract",
-				"columns": ["naam", "leverancier", "ingangsdatum", "einddatum", "status"],
+				"columns": ["naam", "leverancier", "ingangsdatum", "einddatum", { "key": "status", "label": "Status", "widget": "badge" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -89,7 +89,7 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "standaard",
-				"columns": ["naam", "versie", "categorie", "status"],
+				"columns": ["naam", "versie", { "key": "categorie", "label": "Category", "widget": "badge" }, { "key": "status", "label": "Status", "widget": "badge" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -141,7 +141,7 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "compliancy",
-				"columns": ["naam", "standaard", "status", "datum"],
+				"columns": ["naam", "standaard", { "key": "status", "label": "Status", "widget": "badge" }, "datum"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -167,7 +167,7 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "moduleVersie",
-				"columns": ["versie", "module", "releaseDatum", "status"],
+				"columns": ["versie", "module", "releaseDatum", { "key": "status", "label": "Status", "widget": "badge" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},


### PR DESCRIPTION
Wires the built-in `widget:"badge"` (→ `CnStatusBadge`, nc-vue beta.40) on the enum columns of the `type:"index"` pages: Contracten/Komplianties/Moduleversies `status`, Standaarden `status`+`categorie`. Pure manifest change — `"badge"` resolves to the lib's built-in widget (no `cellWidgets` registry needed); object-shaped columns require a `label` so each carries one. Part of the fleet manifest-index wave (pipelinq #351, procest #436, scholiq #71, zaakafhandelapp #203); fuller formatter wiring tracked in #229. Verified: `node tests/validate-manifest.js` PASS, `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)