### PR TITLE
fix(autoload): don't PSR-4-map OCA\OpenRegister\ in autoload-dev (shadows real OR in prod) — closes #230

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,6 @@
 			"OCA\\SoftwareCatalog\\": "lib/"
 		}
 	},
-	"autoload-dev": {
-		"psr-4": {
-			"OCA\\OpenRegister\\": "tests/Stubs/"
-		}
-	},
 	"scripts": {
 		"post-install-cmd": [
 			"@composer bin all install --ansi"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,10 +36,23 @@ if (!defined('OC_CONSOLE')) {
 
     // Load all enabled apps
     \OC_App::loadApps();
-    
+
     // Load our specific app
     \OC_App::loadApp('softwarecatalog');
-    
+
     // Clear hooks for testing
     OC_Hook::clear();
+}
+
+// OpenRegister test stubs. The real OCA\OpenRegister\Db\ObjectEntity has
+// __call magic getters that PHPUnit can't configure on a mock, so the unit
+// tests use the explicit stub in tests/Stubs/. It is loaded HERE — not via a
+// composer `autoload-dev` PSR-4 mapping of the foreign `OCA\OpenRegister\`
+// namespace, which would shadow the real OpenRegister classes in any
+// deployment whose vendor/ includes dev autoload entries (breaking every
+// OR-backed app). Only loaded when OpenRegister isn't actually installed.
+if (!class_exists('OCA\\OpenRegister\\Db\\ObjectEntity')) {
+    foreach (glob(__DIR__ . '/Stubs/{,**/}*.php', GLOB_BRACE) ?: [] as $stub) {
+        require_once $stub;
+    }
 }


### PR DESCRIPTION
Closes #230. Drops the `autoload-dev` `OCA\OpenRegister\ → tests/Stubs/` PSR-4 mapping, and loads the stub from `tests/bootstrap.php` instead — conditionally, only when the real `OCA\OpenRegister\Db\ObjectEntity` isn't autoloadable. Verified: `composer dump-autoload -o` no longer emits an `OCA\OpenRegister\` PSR-4 entry or an `OCA\OpenRegister\Db\ObjectEntity → tests/...` classmap entry; locally re-enabled SoftwareCatalog in the dev container and OR's `new ObjectEntity()` path now resolves to the real `/var/www/html/custom_apps/openregister/lib/Db/ObjectEntity.php` (`isAbstract: no`) — OpenBuilt's manifest endpoint resolves and `decidesk`/`opencatalogi`/`openbuilt` all serve 200 again. **Same pattern lives in 5 sister apps** (openbuilt, decidesk, pipelinq, procest, scholiq) — filing a fleet-cleanup issue separately.