### PR TITLE
chore(brand): preset 2.10 + auto-derived hero + smaller app-icon glyph

### DIFF
--- a/docs/static/img/logo.svg
+++ b/docs/static/img/logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M5.6,3.4l1.4,1.4-3.2,3.2,3.2,3.2-1.4,1.4L1,8,5.6,3.4M11.4,3.4l4.6,4.6-4.6,4.6-1.4-1.4,3.2-3.2-3.2-3.2,1.4-1.4M22,6v12c0,1.1-.9,2-2,2H4c-1.1,0-2-.9-2-2v-4h2v4h16V6h-3v-2h3c1.1,0,2,.9,2,2Z"/>
   </g>
 </svg>

--- a/img/app-store.svg
+++ b/img/app-store.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
   <polygon points="256,26 455.19,141 455.19,371 256,486 56.81,371 56.81,141" fill="#4376FC"/>
-  <g transform="translate(136, 136) scale(10)" fill="#ffffff">
+  <g transform="translate(164, 164) scale(7.67)" fill="#ffffff">
     <path d="M5.6,3.4l1.4,1.4-3.2,3.2,3.2,3.2-1.4,1.4L1,8,5.6,3.4M11.4,3.4l4.6,4.6-4.6,4.6-1.4-1.4,3.2-3.2-3.2-3.2,1.4-1.4M22,6v12c0,1.1-.9,2-2,2H4c-1.1,0-2-.9-2-2v-4h2v4h16V6h-3v-2h3c1.1,0,2,.9,2,2Z"/>
   </g>
 </svg>


### PR DESCRIPTION
Aligns this app with the design-system 2.10.0 release: preset bumped, hard-coded `<DetailHero/>` `status`/`version` props dropped (the new preset auto-derives from `appinfo/info.xml` + SemVer), inner glyph in `img/app-store.svg` shrunk to ~40% of the hex height. No code or behaviour changes beyond the brand chrome.