### PR TITLE
chore(deps): preset lockfile 3.6.1 -> 3.6.2 (validator patch)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2043,9 +2043,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.1.tgz",
-      "integrity": "sha512-LjA2lwaVkjfUH9qJhXvSJBed2qyKMCcxnWymu2PaYMZLQSbW0/JZ2nZsavQgbq5lqvrddD1m0OtBSORxisBdHA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.6.2.tgz",
+      "integrity": "sha512-Ee8CKQknUZ0zDzh9NLWL91kCwz3FzwMOcBDvgR0LygmMOGn9z44LHBK6qoncAnqhRTqLLovMUjyw8ku3dtb1PQ==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Preset 3.6.2 relaxes the lastmod check from hard-fail to advisory. Lockfile bumped via npm update --package-lock-only --min-release-age=0.