### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -294,7 +294,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="SoftwareCatalog"
+      title="SoftwareCatalog, IT-asset and licence register for Nextcloud"
       description="IT-asset management on Nextcloud. Software inventory, licences, contracts, dependencies. One register, every install."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and closes ConductionNL/.github#80. Single-prop edit.