### PR TITLE
feat(manifest-v2): migrate to universal widget manifest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/lang-json": "^6.0.0",
-				"@conduction/nextcloud-vue": "^1.0.0-beta.42",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.58",
 				"@fortawesome/fontawesome-svg-core": "^6.5.2",
 				"@fortawesome/free-solid-svg-icons": "^6.5.2",
 				"@nextcloud/axios": "^2.5.0",
@@ -2069,9 +2069,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.42",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.42.tgz",
-			"integrity": "sha512-6ITMUXPNdfmaitFIeDMk4VjffrNKfAM5kjFUFl/XtORz4A6nD0DpEIrxdtZF1ltODlQoI+d4ADijP8pEr02U6g==",
+			"version": "1.0.0-beta.58",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.58.tgz",
+			"integrity": "sha512-tFoV9jCNv+62c/MKbMgxwbOKH0pUTxnYGYW6pfjdhTLiSJts+BzGffZnK6khs6KDVbEssmAA3ntcpPp0hZqS/Q==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -2089,6 +2089,8 @@
 				"@nextcloud/notify_push": "^1.0.0",
 				"@uiw/codemirror-theme-github": "^4.25.8",
 				"@vueuse/core": "^10.0.0",
+				"ajv": "^8.20.0",
+				"ajv-formats": "^3.0.1",
 				"apexcharts": "^4.7.0",
 				"codemirror": "^6.0.0",
 				"dompurify": "^3.0.0",
@@ -2102,6 +2104,9 @@
 				"vue-codemirror6": "^1.4.3",
 				"vue-color": "^2.8.2",
 				"vue-template-compiler": "^2.7.16"
+			},
+			"bin": {
+				"manifest-migrate": "src/cli/manifest-migrate.js"
 			},
 			"peerDependencies": {
 				"@nextcloud/auth": "^2.0.0 || ^3.0.0",
@@ -7258,7 +7263,6 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -7275,7 +7279,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.0.0"
@@ -11170,7 +11173,6 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -11221,7 +11223,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
 			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -15240,7 +15241,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
@@ -19582,7 +19582,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	],
 	"dependencies": {
 		"@codemirror/lang-json": "^6.0.0",
-		"@conduction/nextcloud-vue": "^1.0.0-beta.42",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.58",
 		"@fortawesome/fontawesome-svg-core": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@nextcloud/axios": "^2.5.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -93,6 +93,16 @@ export default {
 			default: () => ({}),
 		},
 		/**
+		 * 5-kind component registry (v2 manifest pattern per hydra ADR-036).
+		 * Each entry: { kind, component, ...kindMetadata }. Replaces
+		 * customComponents for v2 manifests; both coexist during the
+		 * transition window.
+		 */
+		registry: {
+			type: Object,
+			default: () => ({}),
+		},
+		/**
 		 * Page-type registry — `{ index, detail, dashboard, settings, ... }`.
 		 * Wired through to descendant `CnPageRenderer` instances via
 		 * provide/inject.

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@
 		<CnAppRoot
 			:manifest="manifest"
 			:custom-components="customComponents"
+			:registry="registry"
 			:page-types="pageTypes"
 			app-id="softwarecatalog"
 			:translate="translateForApp"

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ import pinia from './pinia.js'
 import App from './App.vue'
 import bundledManifest from './manifest.json'
 import customComponents from './customComponents.js'
+import registry from './registry.js'
 import { routesFromManifest } from './router.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
@@ -77,6 +78,7 @@ tryLoadTranslations()
 // the values the lib resolves at render time.
 const pageTypesProp = { ...defaultPageTypes }
 const customComponentsProp = { ...customComponents }
+const registryProp = { ...registry }
 
 // Resolve `@resolve:<key>` IAppConfig sentinels in `manifest.pages[].config`
 // (e.g. `@resolve:voorzieningen_register`) via the lib's

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,18 +1,82 @@
 {
-	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest.schema.json",
-	"version": "1.0.0",
-	"dependencies": ["openregister"],
+	"$schema": "https://raw.githubusercontent.com/ConductionNL/nextcloud-vue/main/src/schemas/app-manifest-v2.schema.json",
+	"version": "2.0.0",
+	"dependencies": [
+		"openregister"
+	],
 	"menu": [
-		{ "id": "Dashboard", "label": "Dashboard", "icon": "icon-category-dashboard", "route": "Dashboard", "order": 10 },
-		{ "id": "Organisaties", "label": "Organisations", "icon": "icon-group", "route": "Organisaties", "order": 20 },
-		{ "id": "Contactpersonen", "label": "Contacts", "icon": "icon-user", "route": "Contactpersonen", "order": 30 },
-		{ "id": "Contracten", "label": "Contracts", "icon": "icon-file", "route": "Contracten", "order": 40 },
-		{ "id": "Standaarden", "label": "Standards", "icon": "icon-checkmark", "route": "Standaarden", "order": 50 },
-		{ "id": "Reviews", "label": "Reviews", "icon": "icon-comment", "route": "Reviews", "order": 60 },
-		{ "id": "Komplianties", "label": "Compliance", "icon": "icon-checkmark", "route": "Komplianties", "order": 70 },
-		{ "id": "Moduleversies", "label": "Module versions", "icon": "icon-files", "route": "Moduleversies", "order": 80 },
-		{ "id": "Documentation", "label": "Documentation", "icon": "icon-info", "href": "https://github.com/ConductionNL/SoftwareCatalogus", "section": "settings", "order": 90 },
-		{ "id": "SettingsMenu", "label": "Settings", "icon": "icon-settings", "route": "Settings", "section": "settings", "order": 99 }
+		{
+			"id": "Dashboard",
+			"label": "Dashboard",
+			"icon": "icon-category-dashboard",
+			"route": "Dashboard",
+			"order": 10
+		},
+		{
+			"id": "Organisaties",
+			"label": "Organisations",
+			"icon": "icon-group",
+			"route": "Organisaties",
+			"order": 20
+		},
+		{
+			"id": "Contactpersonen",
+			"label": "Contacts",
+			"icon": "icon-user",
+			"route": "Contactpersonen",
+			"order": 30
+		},
+		{
+			"id": "Contracten",
+			"label": "Contracts",
+			"icon": "icon-file",
+			"route": "Contracten",
+			"order": 40
+		},
+		{
+			"id": "Standaarden",
+			"label": "Standards",
+			"icon": "icon-checkmark",
+			"route": "Standaarden",
+			"order": 50
+		},
+		{
+			"id": "Reviews",
+			"label": "Reviews",
+			"icon": "icon-comment",
+			"route": "Reviews",
+			"order": 60
+		},
+		{
+			"id": "Komplianties",
+			"label": "Compliance",
+			"icon": "icon-checkmark",
+			"route": "Komplianties",
+			"order": 70
+		},
+		{
+			"id": "Moduleversies",
+			"label": "Module versions",
+			"icon": "icon-files",
+			"route": "Moduleversies",
+			"order": 80
+		},
+		{
+			"id": "Documentation",
+			"label": "Documentation",
+			"icon": "icon-info",
+			"href": "https://github.com/ConductionNL/SoftwareCatalogus",
+			"section": "settings",
+			"order": 90
+		},
+		{
+			"id": "SettingsMenu",
+			"label": "Settings",
+			"icon": "icon-settings",
+			"route": "Settings",
+			"section": "settings",
+			"order": 99
+		}
 	],
 	"pages": [
 		{
@@ -20,14 +84,16 @@
 			"route": "/",
 			"type": "custom",
 			"title": "Dashboard",
-			"component": "DashboardCustomView"
+			"component": "DashboardCustomView",
+			"_note": "TODO: manual migration required — custom page not auto-converted"
 		},
 		{
 			"id": "Organisaties",
 			"route": "/organisaties",
 			"type": "custom",
 			"title": "Organisations",
-			"component": "OrganisatieIndexView"
+			"component": "OrganisatieIndexView",
+			"_note": "TODO: manual migration required — custom page not auto-converted"
 		},
 		{
 			"id": "Contactpersonen",
@@ -37,8 +103,17 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "contactpersoon",
-				"columns": ["voornaam", "achternaam", "email", "telefoonnummer", "organisatie"],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"voornaam",
+					"achternaam",
+					"email",
+					"telefoonnummer",
+					"organisatie"
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -49,10 +124,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "contactpersoon",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -63,8 +161,29 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "contract",
-				"columns": ["naam", "leverancier", { "key": "ingangsdatum", "label": "Start", "formatter": "date" }, { "key": "einddatum", "label": "End", "formatter": "date" }, { "key": "status", "label": "Status", "widget": "badge" }],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"naam",
+					"leverancier",
+					{
+						"key": "ingangsdatum",
+						"label": "Start",
+						"formatter": "date"
+					},
+					{
+						"key": "einddatum",
+						"label": "End",
+						"formatter": "date"
+					},
+					{
+						"key": "status",
+						"label": "Status",
+						"widget": "badge"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -75,10 +194,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "contract",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -89,8 +231,24 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "standaard",
-				"columns": ["naam", "versie", { "key": "categorie", "label": "Category", "widget": "badge" }, { "key": "status", "label": "Status", "widget": "badge" }],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"naam",
+					"versie",
+					{
+						"key": "categorie",
+						"label": "Category",
+						"widget": "badge"
+					},
+					{
+						"key": "status",
+						"label": "Status",
+						"widget": "badge"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -101,10 +259,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "standaard",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -115,8 +296,20 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "beoordeeling",
-				"columns": ["titel", "auteur", "score", { "key": "datum", "label": "Date", "formatter": "date" }],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"titel",
+					"auteur",
+					"score",
+					{
+						"key": "datum",
+						"label": "Date",
+						"formatter": "date"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -127,10 +320,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "beoordeeling",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -141,8 +357,24 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "compliancy",
-				"columns": ["naam", "standaard", { "key": "status", "label": "Status", "widget": "badge" }, { "key": "datum", "label": "Date", "formatter": "date" }],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"naam",
+					"standaard",
+					{
+						"key": "status",
+						"label": "Status",
+						"widget": "badge"
+					},
+					{
+						"key": "datum",
+						"label": "Date",
+						"formatter": "date"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -153,10 +385,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "compliancy",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -167,8 +422,24 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "moduleVersie",
-				"columns": ["versie", "module", { "key": "releaseDatum", "label": "Released", "formatter": "date" }, { "key": "status", "label": "Status", "widget": "badge" }],
-				"sidebar": { "enabled": true, "showMetadata": true }
+				"columns": [
+					"versie",
+					"module",
+					{
+						"key": "releaseDatum",
+						"label": "Released",
+						"formatter": "date"
+					},
+					{
+						"key": "status",
+						"label": "Status",
+						"widget": "badge"
+					}
+				],
+				"sidebar": {
+					"enabled": true,
+					"showMetadata": true
+				}
 			}
 		},
 		{
@@ -179,10 +450,33 @@
 			"config": {
 				"register": "@resolve:voorzieningen_register",
 				"schema": "moduleVersie",
-				"sidebarTabs": [
-					{ "id": "overview", "label": "Overview", "icon": "icon-info", "widgets": [{ "type": "data" }, { "type": "metadata" }], "order": 10 },
-					{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [{ "type": "audit-trail" }], "order": 90 }
-				]
+				"sidebarProps": {
+					"tabs": [
+						{
+							"id": "overview",
+							"label": "Overview",
+							"icon": "icon-info",
+							"widgets": [
+								{
+									"type": "data"
+								},
+								{
+									"type": "metadata"
+								}
+							]
+						},
+						{
+							"id": "audit",
+							"label": "Audit trail",
+							"icon": "icon-history",
+							"widgets": [
+								{
+									"type": "audit-trail"
+								}
+							]
+						}
+					]
+				}
 			}
 		},
 		{
@@ -198,7 +492,8 @@
 						"component": "SoftwareCatalogSettingsPage"
 					}
 				]
-			}
+			},
+			"widgets": []
 		}
 	]
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Conduction B.V.
+//
+// 5-kind component registry for v2 manifest (per hydra ADR-036).
+//
+// The v1 customComponents.js map is preserved alongside this file for
+// backward-compat during the migration window. CnAppRoot accepts both
+// props; the v2 renderer emits a one-shot deprecation warning when both
+// are present and the manifest is v2.
+//
+// Resolution at runtime (v2 path):
+//   1. Built-in widgets registry (CnWidgetGrid built-ins)
+//   2. registry prop (this file) — keyed by widgetKey / target / appliesTo
+//
+// References:
+//   - hydra ADR-036
+//   - nextcloud-app-template scaffold-v2 (#44) — canonical layout
+//   - procest #512 / mydash #206 — first reference migrations
+
+import OrganisatieIndexView from './views/organisaties/OrganisatieIndex.vue'
+import SoftwareCatalogSettingsPage from './views/settings/SoftwareCatalogSettings.vue'
+import DashboardCustomView from './views/Dashboard.vue'
+
+export default {
+	// --- Lib gap: bespoke OrganisatieCard + AddContactpersoonModal flow. ---
+	// Bespoke modal/dialog/deep-link wiring around CnIndexPage. The
+	// Organisaties manifest entry is type:'custom' with a _note pointing
+	// here; the page mounts this view, which internally uses CnIndexPage.
+	OrganisatieIndexView: {
+		kind: 'page',
+		component: OrganisatieIndexView,
+	},
+
+	// --- Lib gap: settings sub-section orchestration. ---
+	// Multi-tab nav + ArchiMate status polling + register selector that
+	// the lib's type:'settings' rich-section widgets can't express yet.
+	SoftwareCatalogSettingsPage: {
+		kind: 'page',
+		component: SoftwareCatalogSettingsPage,
+	},
+
+	// --- Lib gap: dashboard widget extraction pending. ---
+	// Preserved verbatim until extraction to a generic schema-stats widget.
+	DashboardCustomView: {
+		kind: 'page',
+		component: DashboardCustomView,
+	},
+}


### PR DESCRIPTION
Phase 2 v2 manifest migration. Bumps nc-vue to ^1.0.0-beta.58 and runs the codemod. Adds 5-kind registry (3 page kinds). @resolve: sentinels preserved verbatim. References procest #512, mydash #206. Hydra paused — no review labels.