### PR TITLE
fix(quality): wire registryProp to App render — fixes eslint no-unused-vars

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -108,6 +108,7 @@ new Vue({
 				manifest: manifestRef.value,
 				customComponents: customComponentsProp,
 				pageTypes: pageTypesProp,
+				registry: registryProp,
 			},
 		})
 	},


### PR DESCRIPTION
## Summary

- Passes `registry: registryProp` in the `main.js` render function so the v2 component registry (`registry.js`) is forwarded to `CnAppRoot`
- Fixes the single `no-unused-vars` ESLint failure that blocked CI on #268 (admin-merged through)
- Matches the established pattern from procest/mydash migrations

## Root cause

`registryProp` was declared (line 81) and the `registry.js` module imported, but the value was never wired into the `App` render props — so ESLint correctly flagged an assigned-but-never-used variable.

## Test plan

- [ ] `npm run lint` exits 0 (verified locally)
- [ ] `quality / Vue Quality (eslint)` CI check passes on this PR

Closes https://github.com/ConductionNL/hydra/issues/307