### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@babel/core": "^7.29.0",
 				"@codemirror/lang-json": "^6.0.0",
-				"@conduction/nextcloud-vue": "^1.0.0-beta.61",
+				"@conduction/nextcloud-vue": "^1.0.0-beta.66",
 				"@fortawesome/fontawesome-svg-core": "^6.5.2",
 				"@fortawesome/free-solid-svg-icons": "^6.5.2",
 				"@nextcloud/axios": "^2.5.0",
@@ -2084,9 +2084,9 @@
 			}
 		},
 		"node_modules/@conduction/nextcloud-vue": {
-			"version": "1.0.0-beta.61",
-			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.61.tgz",
-			"integrity": "sha512-VIN6p+I5Lh0NQ62/hpBQ88ezZ9V+GP21Vp8RddsouYp1iVvXVwlsXryQVVFbyPCDHya7RQ3hXLnWwhj1ok8Dmg==",
+			"version": "1.0.0-beta.66",
+			"resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.66.tgz",
+			"integrity": "sha512-Igd9KdaA90JA0i96CG4zyQxM7NmAyYfkdrT6rBWjuNZBkNwwW2TnxbP1NG3Qev6bc99yqWYbRcBVgnnP8SJnNw==",
 			"license": "EUPL-1.2",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@babel/core": "^7.29.0",
 		"@codemirror/lang-json": "^6.0.0",
-		"@conduction/nextcloud-vue": "^1.0.0-beta.61",
+		"@conduction/nextcloud-vue": "^1.0.0-beta.66",
 		"@fortawesome/fontawesome-svg-core": "^6.5.2",
 		"@fortawesome/free-solid-svg-icons": "^6.5.2",
 		"@nextcloud/axios": "^2.5.0",


### PR DESCRIPTION
Picks up schema 2.7.0 + CnPageRenderer top-level field forwarding + CnDetailPage `_lockState` rename + `config.schema → objectType` bridging from nextcloud-vue#317/#319/#320. Mechanical dependency bump.