### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/Service/ProgressTracker.php
+++ b/lib/Service/ProgressTracker.php
@@ -369,11 +369,12 @@ class ProgressTracker
         }
 
         $overallProgress = $completedWeight + $currentPhaseProgress;
-            $percentage  = 0;
+        $percentage      = 0;
         if ($totalWeight > 0) {
+            $percentage = ($overallProgress / $totalWeight) * 100;
         }
 
-        return min(100, max(0, $percentage));
+        return min(100, max(0, (int) $percentage));
     }//end calculateOverallPercentage()
 
     /**

--- a/lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+++ b/lib/Service/SoftwareCatalogue/ContactPersonHandler.php
@@ -2350,17 +2350,17 @@ class ContactPersonHandler
                             );
 
                     return true;
-                } else {
-                    $this->_logger->debug(
-                            'ContactPersonHandler: Contactpersoon already in organization',
-                            [
-                                'username'         => $username,
-                                'organizationUuid' => $organizationUuid,
-                            ]
-                            );
-                    return true;
-                    // Already there, consider it successful.
                 }//end if
+
+                $this->_logger->debug(
+                        'ContactPersonHandler: Contactpersoon already in organization',
+                        [
+                            'username'         => $username,
+                            'organizationUuid' => $organizationUuid,
+                        ]
+                        );
+                // Already there, consider it successful.
+                return true;
             } catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
                 $this->_logger->error(
                         'ContactPersonHandler: Organization not found for contactpersoon',
@@ -2404,33 +2404,35 @@ class ContactPersonHandler
                     );
 
             // Check if user should be added to organization.
-            if ($this->shouldAddContactpersoonToOrganization(contactpersoonObject: $contactpersoonObject) === true) {
-                // Add user to organization.
-                $result = $this->addContactpersoonToOrganization(contactpersoonObject: $contactpersoonObject);
-
-                if ($result === true) {
-                    $this->_logger->info(
-                            'ContactPersonHandler: Successfully ensured contactpersoon in organization',
-                            [
-                                'objectId' => $contactpersoonObject->getId(),
-                            ]
-                            );
-                } else {
-                    $this->_logger->warning(
-                            'ContactPersonHandler: Failed to add contactpersoon to organization',
-                            [
-                                'objectId' => $contactpersoonObject->getId(),
-                            ]
-                            );
-                }
-            } else {
+            if ($this->shouldAddContactpersoonToOrganization(contactpersoonObject: $contactpersoonObject) === false) {
                 $this->_logger->debug(
                         'ContactPersonHandler: Contactpersoon already in organization or no action needed',
                         [
                             'objectId' => $contactpersoonObject->getId(),
                         ]
                         );
-            }//end if
+                return;
+            }
+
+            // Add user to organization.
+            $result = $this->addContactpersoonToOrganization(contactpersoonObject: $contactpersoonObject);
+
+            if ($result === true) {
+                $this->_logger->info(
+                        'ContactPersonHandler: Successfully ensured contactpersoon in organization',
+                        [
+                            'objectId' => $contactpersoonObject->getId(),
+                        ]
+                        );
+                return;
+            }
+
+            $this->_logger->warning(
+                    'ContactPersonHandler: Failed to add contactpersoon to organization',
+                    [
+                        'objectId' => $contactpersoonObject->getId(),
+                    ]
+                    );
         } catch (\Exception $e) {
             $this->_logger->error(
                 'ContactPersonHandler: Failed to ensure contactpersoon in organization: '.$e->getMessage(),
@@ -2527,21 +2529,7 @@ class ContactPersonHandler
 
                 // Add user to the organisation entity.
                 $currentUsers = $organisation->getUsers() ?? [];
-                if (in_array($username, $currentUsers) === false) {
-                    $currentUsers[] = $username;
-                    $organisation->setUsers($currentUsers);
-                    $organisationMapper->update($organisation);
-
-                    $this->_logger->info(
-                            'ContactPersonHandler: Successfully added user to organization entity',
-                            [
-                                'objectId'         => $contactpersoonObject->getId(),
-                                'username'         => $username,
-                                'organizationUuid' => $organizationUuid,
-                                'totalUsers'       => count($currentUsers),
-                            ]
-                            );
-                } else {
+                if (in_array($username, $currentUsers) === true) {
                     $this->_logger->info(
                             'ContactPersonHandler: User already in organization entity',
                             [
@@ -2550,7 +2538,22 @@ class ContactPersonHandler
                                 'organizationUuid' => $organizationUuid,
                             ]
                             );
-                }//end if
+                    return;
+                }
+
+                $currentUsers[] = $username;
+                $organisation->setUsers($currentUsers);
+                $organisationMapper->update($organisation);
+
+                $this->_logger->info(
+                        'ContactPersonHandler: Successfully added user to organization entity',
+                        [
+                            'objectId'         => $contactpersoonObject->getId(),
+                            'username'         => $username,
+                            'organizationUuid' => $organizationUuid,
+                            'totalUsers'       => count($currentUsers),
+                        ]
+                        );
             } catch (\Exception $e) {
                 $this->_logger->error(
                         'ContactPersonHandler: Failed to add user to organization entity',

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,6 +9,12 @@
     <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
@@ -39,7 +45,6 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ElseIfDeclaration"/>
-    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Commenting.ClosingDeclarationComment"/>
     <rule ref="Squiz.Commenting.BlockComment"/>
     <rule ref="Squiz.Commenting.DocCommentAlignment"/>
@@ -48,14 +53,16 @@
     <rule ref="Squiz.Commenting.LongConditionClosingComment"/>
     <rule ref="Squiz.Commenting.PostStatementComment"/>
     <rule ref="Squiz.Commenting.VariableComment"/>
-    <!-- Removed the OperatorBracket rule to allow operations without brackets -->
     <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing"/>
     <rule ref="Squiz.Operators.ComparisonOperatorUsage"/>
+    <rule ref="Squiz.PHP.DisallowInlineIf"/>
     <rule ref="Squiz.Scope.MethodScope"/>
-    <rule ref="Squiz.Strings.ConcatenationSpacing"/>
+    <rule ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Squiz.WhiteSpace.ControlStructureSpacing"/>
-    <!-- Disabled: Conflicts with Squiz.WhiteSpace.FunctionSpacing -->
-    <!-- <rule ref="Squiz.WhiteSpace.FunctionClosingBraceSpace"/> -->
     <rule ref="Squiz.WhiteSpace.FunctionSpacing">
         <properties>
             <property name="spacing" value="1"/>
@@ -76,14 +83,18 @@
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
     <rule ref="Generic.Files.LineLength">
         <properties>
-            <property name="lineLimit" value="125"/>
+            <property name="lineLimit" value="150"/>
             <property name="absoluteLineLimit" value="150"/>
         </properties>
     </rule>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.LowerCaseKeyword"/>
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+    <rule ref="Generic.Strings.UnnecessaryStringConcat">
+        <properties>
+            <property name="allowMultiline" value="true"/>
+        </properties>
+    </rule>
     <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
     <rule ref="PSR2.Classes.PropertyDeclaration"/>
     <rule ref="PSR2.Methods.MethodDeclaration"/>
@@ -207,6 +218,17 @@
     <!-- Custom rule to enforce named parameters -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
         <type>error</type>
+    </rule>
+
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
     </rule>
 
 </ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
-<ruleset name="OpenCatalogi Nextcloud Rules"
+<ruleset name="SoftwareCatalog Nextcloud Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
                         http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
 
     <description>
-        This is a custom ruleset for OpenCatalogi Nextcloud.
+        This is a custom ruleset for SoftwareCatalog Nextcloud.
     </description>
 
     <!-- Clean Code Rules -->
@@ -36,8 +36,10 @@
     <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
     <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
-    <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/>
-    <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/>
+    <!-- CamelCaseParameterName removed - we allow leading underscores on parameters (convention for unused/config params) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
+    <!-- CamelCaseVariableName removed - we allow leading underscores on variables (convention for unused loop vars) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
 
     <!-- Design Rules -->
     <rule ref="rulesets/design.xml/ExitExpression"/>
@@ -53,7 +55,13 @@
     <!-- Naming Rules -->
     <rule ref="rulesets/naming.xml/LongClassName"/>
     <rule ref="rulesets/naming.xml/ShortClassName"/>
-    <rule ref="rulesets/naming.xml/ShortVariable"/>
+    <!-- ShortVariable configured with allowlist of idiomatic short names -->
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="3" />
+            <property name="exceptions" value="id,db,qb,op,ui,io,gc,tz,pk,fk,to,ch,a,b,l,v,c,t,r,f,n,k,e" />
+        </properties>
+    </rule>
     <rule ref="rulesets/naming.xml/LongVariable"/>
     <rule ref="rulesets/naming.xml/ShortMethodName"/>
     <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass"/>
@@ -64,5 +72,7 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
+        <exclude-pattern>*Migration*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,777 @@
+# PHPStan baseline — tracked debt
+#
+# 206 errors baselined during the Phase 2 canonical-config sync. These were
+# previously masked by per-app suppressions including the now-dropped
+# `scanDirectories: ../openregister/lib`. Categories: defensive-coding
+# (always-true / unreachable / never-read), SimpleXMLElement nullability,
+# and OCA\OpenRegister\ symbol-resolution residue.
+#
+# Tracking issue: https://github.com/ConductionNL/softwarecatalog/issues/279
+# Target: empty / removed file once source refactors land.
+
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#2 \\$listener of method OCP\\\\AppFramework\\\\Bootstrap\\\\IRegistrationContext\\:\\:registerEventListener\\(\\) expects class\\-string\\<OCP\\\\EventDispatcher\\\\IEventListener\\<OCP\\\\EventDispatcher\\\\Event\\>\\>, 'OCA\\\\\\\\SoftwareCatalog\\\\\\\\EventListener\\\\\\\\UserProfileUpdatedEventListener' given\\.$#"
+			count: 1
+			path: lib/AppInfo/Application.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Controller\\\\AanbodController\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/AanbodController.php
+
+		-
+			message: "#^Expression in empty\\(\\) is always falsy\\.$#"
+			count: 3
+			path: lib/Controller/AangebodenGebruikController.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 3
+			path: lib/Controller/AangebodenGebruikController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and true will always evaluate to false\\.$#"
+			count: 3
+			path: lib/Controller/AangebodenGebruikController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 3
+			path: lib/Controller/AangebodenGebruikController.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Controller\\\\ContactpersonenController\\:\\:\\$secureRandom is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/ContactpersonenController.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Controller\\\\ContactpersonenController\\:\\:\\$settingsService is never read, only written\\.$#"
+			count: 1
+			path: lib/Controller/ContactpersonenController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Controller/ContactpersonenController.php
+
+		-
+			message: "#^Variable \\$_FILES on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: lib/Controller/SettingsController.php
+
+		-
+			message: "#^Variable \\$data on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Controller/SettingsController.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Dashboard\\\\ConceptOrganisatiesWidget\\:\\:\\$url is never read, only written\\.$#"
+			count: 1
+			path: lib/Dashboard/ConceptOrganisatiesWidget.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'actief'\\|'active' and '' will always evaluate to false\\.$#"
+			count: 1
+			path: lib/EventListener/SoftwareCatalogEventListener.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/EventListener/UserProfileUpdatedEventListener.php
+
+		-
+			message: "#^Type OCA\\\\OpenRegister\\\\Event\\\\UserProfileUpdatedEvent in generic type OCP\\\\EventDispatcher\\\\IEventListener\\<OCA\\\\OpenRegister\\\\Event\\\\UserProfileUpdatedEvent\\> in PHPDoc tag @implements is not subtype of template type T of OCP\\\\EventDispatcher\\\\Event of interface OCP\\\\EventDispatcher\\\\IEventListener\\.$#"
+			count: 1
+			path: lib/EventListener/UserProfileUpdatedEventListener.php
+
+		-
+			message: "#^Variable \\$emailCandidate in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: lib/EventListener/UserProfileUpdatedEventListener.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\AanbodService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AanbodService.php
+
+		-
+			message: "#^Cannot unset offset 'next' on array\\{results\\: array\\<int\\<0, max\\>, mixed\\>, total\\: int\\<0, max\\>, pages\\: 1, page\\: mixed, limit\\: mixed, offset\\: mixed\\}\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:checkOrganisationOwnership\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:getAllObjectsForSchema\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:getApplicationsOwnedByOrganisation\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:getKoppelingenConfiguration\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:getObjectsRelatedToUuid\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\AangebodenGebruikService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^Strict comparison using \\!\\=\\= between null and null will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/AangebodenGebruikService.php
+
+		-
+			message: "#^\\(SimpleXMLElement\\|null\\) does not accept string\\.$#"
+			count: 17
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Cannot call method addAttribute\\(\\) on array\\<int, string\\>\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateExportService\\:\\:addDataToXmlNode\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateExportService\\:\\:getViewSwcTitle\\(\\) never returns string so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Offset string on array\\{\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^SimpleXMLElement does not accept string\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 0\\|1\\|false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between SimpleXMLElement\\|false and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between array\\<SimpleXMLElement\\> and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateExportService.php
+
+		-
+			message: "#^Comparison operation \"\\<\" between 100 and 100 is always false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between \\(array\\|float\\|int\\) and 0 results in an error\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Constant OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:CONFIG_KEYS is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:calculateOptimizedStatistics\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:debugViewNodeHierarchy\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:extractNodesRecursively\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:getAmefRegisterId\\(\\) never returns int so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:isAssoc\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:logMemoryUsage\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:saveObjectsDirectToService\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:saveObjectsInParallelBatches\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:saveObjectsInSingleBatch\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:transformSectionObjectsBatch\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:transformViewsOptimized\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 4
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'created' on array\\{created\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'elements'\\|'organizations'\\|'property_definitions'\\|'relationships'\\|'views' on array\\{elements\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, unchanged\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, organizations\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, unchanged\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, relationships\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, unchanged\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, views\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, unchanged\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, property_definitions\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, unchanged\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'errors' on array\\{created\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'saved' on array\\{saved\\: array, updated\\: array, unchanged\\: array, invalid\\: array, countsBySchema\\: array\\<array\\{saved\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, invalid\\: int\\<0, max\\>\\}\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'unchanged' on array\\{created\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'unchanged' on array\\{saved\\: array, updated\\: array, unchanged\\: array, invalid\\: array, countsBySchema\\: array\\<array\\{saved\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, invalid\\: int\\<0, max\\>\\}\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'updated' on array\\{created\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Offset 'updated' on array\\{saved\\: array, updated\\: array, unchanged\\: array, invalid\\: array, countsBySchema\\: array\\<array\\{saved\\: int\\<0, max\\>, updated\\: int\\<0, max\\>, unchanged\\: int\\<0, max\\>, invalid\\: int\\<0, max\\>\\}\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateImportService\\:\\:\\$rootFolder is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 3
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int\\|null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string\\|null and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string\\|null and true will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Variable \\$prop on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateImportService.php
+
+		-
+			message: "#^Constant OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:CONFIG_KEYS is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Empty array passed to foreach\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:calculateObjectStatistics\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:calculateOptimizedStatistics\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:convertToOpenRegisterObjects\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:findItemsInSection\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:getAmefRegisterId\\(\\) never returns int so it can be removed from the return type\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:getAmefSchemaIdForType\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:getVoorzieningenConfig\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:initializeCache\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:logMemoryUsage\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:saveObjectsToDatabase\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:transformArchiMateXmlToObjectsBatch\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 4
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Offset 'elements'\\|'organizations'\\|'property_definitions'\\|'relationships'\\|'views' on array\\{elements\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, skipped\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, organizations\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, skipped\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, relationships\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, skipped\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, views\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, skipped\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}, property_definitions\\: array\\{created\\: int\\<0, max\\>, errors\\: array\\<int\\<0, max\\>, mixed\\>, skipped\\: int\\<0, max\\>, updated\\: int\\<0, max\\>\\}\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:\\$lastSaveTimingBreakdown is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:\\$rootFolder is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ArchiMateService\\:\\:\\$userSession is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 3
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int\\|null and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string\\|null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string\\|null and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 6
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Variable \\$gebruikSchemaId in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 2
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Variable \\$mid in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Variable \\$moduleSchemaId in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: lib/Service/ArchiMateService.php
+
+		-
+			message: "#^Offset 'achternaam'\\|'e\\-mailadres'\\|'functie'\\|'tussenvoegsel'\\|'voornaam' on array\\{\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/ContactpersoonService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ContactpersoonService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ContactpersoonService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ContactpersoonService\\:\\:\\$groupHandler is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ContactpersoonService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser\\|null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/ContactpersoonService.php
+
+		-
+			message: "#^Variable \\$gebruikSchema on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/GebruikService.php
+
+		-
+			message: "#^Variable \\$registerId on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/GebruikService.php
+
+		-
+			message: "#^Offset 'uuid' on array\\{standaardVersies\\: array\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/ModuleComplianceService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\OrganisatieService\\:\\:getActiveOrganisationUuid\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/OrganisatieService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\OrganisatieService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/OrganisatieService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\OrganisatieService\\:\\:\\$organizationHandler is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/OrganisatieService.php
+
+		-
+			message: "#^Empty array passed to foreach\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\OrganizationSyncService\\:\\:jsonContains\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\OrganizationSyncService\\:\\:jsonExtract\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Offset 'contactpersonen' on array\\{\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 2
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Variable \\$contactUuid in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Variable \\$contactUuids in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: lib/Service/OrganizationSyncService.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between 105 and 0 is always true\\.$#"
+			count: 1
+			path: lib/Service/ProgressTracker.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between 0 and 10 is always false\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Offset 'id' does not exist on array\\{schemas\\: array\\<int\\<0, max\\>, mixed\\>\\}\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Offset 'id' on array\\{schemas\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Offset 'schemas' on array\\{schemas\\: array\\<int\\<0, max\\>, mixed\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Offset 'schemas' on non\\-empty\\-array on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\SettingsService\\:\\:\\$request is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 2
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 'false' and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between bool and null will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Variable \\$config in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/SettingsService.php
+
+		-
+			message: "#^Access to static property \\$SERVERROOT on an unknown class OC\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogue\\\\ContactPersonHandler\\:\\:addUserToGroup\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogue\\\\ContactPersonHandler\\:\\:ensureUniqueUsername\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogue\\\\ContactPersonHandler\\:\\:getAllowedRoleGroups\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogue\\\\ContactPersonHandler\\:\\:getOrganizationGroup\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Offset 'organisatie' on array\\{username\\: string\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Offset 'organisation' on array\\{username\\: string\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Offset 'rollen' on array\\{username\\: mixed\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogue\\\\ContactPersonHandler\\:\\:\\$_config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Result of \\|\\| is always true\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between OCP\\\\IUser\\|null and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Variable \\$currentRollen in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Variable \\$phpBin in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Variable \\$username on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 0\\|1\\|false and true will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogue/GroupHandler.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogueService\\:\\:activateContactpersonenForOrganization\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Method OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogueService\\:\\:activateUsersForOrganization\\(\\) is unused\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Offset 'roles' on array\\{\\} on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogueService\\:\\:\\$_organizationHandler is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\SoftwareCatalogueService\\:\\:\\$appName is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between true and false will always evaluate to false\\.$#"
+			count: 1
+			path: lib/Service/SoftwareCatalogueService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\SymfonyEmailService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/SymfonyEmailService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Service\\\\ViewService\\:\\:\\$config is never read, only written\\.$#"
+			count: 1
+			path: lib/Service/ViewService.php
+
+		-
+			message: "#^Property OCA\\\\SoftwareCatalog\\\\Settings\\\\SoftwareCatalogAdmin\\:\\:\\$l10n is never read, only written\\.$#"
+			count: 1
+			path: lib/Settings/SoftwareCatalogAdmin.php

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * PHPStan bootstrap file - registers OCP autoloader for static analysis.
+ */
+
+$autoloader = require __DIR__ . '/vendor/autoload.php';
+$autoloader->addPsr4('OCP\\', __DIR__ . '/vendor/nextcloud/ocp/OCP/');
+$autoloader->addPsr4('NCU\\', __DIR__ . '/vendor/nextcloud/ocp/NCU/');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,59 +1,59 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
         - lib
     bootstrapFiles:
-        - vendor/autoload.php
+        - phpstan-bootstrap.php
     excludePaths:
-        analyseAndScan:
-            - vendor-bin
-        analyse:
-            - vendor
+        - vendor
+        - vendor-bin
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
-        - ../openregister/lib
-    treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
-        - '#Access to static property .* on an unknown class OC#'
+        - '#Access to static property \$server on an unknown class OC#'
         - '#unknown class OC\\#'
-        - '#Class OC_App not found#'
         - '#Caught class OC\\#'
-        # Doctrine DBAL platform class (varies by version)
-        - '#Doctrine\\DBAL\\Platforms#'
-        # JSONResponse status code union type - common Nextcloud pattern
-        -
-            message: '#statusCode of class OCP\\AppFramework\\Http\\JSONResponse#'
-            path: lib/*
-        # SimpleXMLElement addChild returns SimpleXMLElement|null but accepts string values
-        - '#\(SimpleXMLElement\|null\) does not accept string#'
-        - '#SimpleXMLElement does not accept string#'
-        # SimpleXMLElement array access creates false type inference for method calls
-        - '#Cannot call method addAttribute\(\) on array<int, string>#'
-        # Defensive null/false checks that PHPStan considers redundant
-        - '#Strict comparison using === between .* and (null|false|true) will always evaluate to (false|true)#'
-        - '#Negated boolean expression is always false#'
-        # Defensive ?? and empty()/isset() checks on always-existing values
-        - '#on left side of \?\? always exists and is not nullable#'
-        - '#in empty\(\) always exists and is (always falsy|not falsy)#'
-        - '#in isset\(\) always exists and is not nullable#'
-        - '#Variable .* on left side of \?\? always exists and is not nullable#'
-        # Unreachable branches from defensive coding
-        - '#Else branch is unreachable because previous condition is always true#'
-        - '#Result of \&\& is always false#'
-        - '#Result of \|\| is always true#'
-        - '#Expression in empty\(\) is always falsy#'
-        # Offset access on typed arrays that PHPStan considers always existing
-        - '#Offset .* on left side of \?\? (always exists|does not exist)#'
-        - '#Offset .* in isset\(\) always exists#'
-        # Comparison operation errors from mixed arithmetic
-        - '#Comparison operation .* results in an error#'
-        # Properties injected for future use or subclass access
-        - '#is never read, only written#'
-        # Methods kept for API compatibility or future use
-        - '#is unused#'
-        # is_array() checks on typed objects (defensive against runtime type changes)
-        - '#Call to function is_array\(\) with .* will always evaluate to false#'
+        - '#unknown class OC_App#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
+        # OCA classes from other apps (OpenRegister) not available during static analysis
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
+        # GuzzleHttp is available at runtime via Nextcloud but not in composer require
+        - '#unknown class GuzzleHttp\\#'
+        - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class GuzzleHttp\\#'
+        - '#invalid type GuzzleHttp\\#'
+        - '#Caught class GuzzleHttp\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
+        # Dynamic HTTP status codes from business rule validation results
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,6 +14,9 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <stubs>
+        <file name="vendor/nextcloud/ocp/OCP/Capabilities/ICapability.php" preloadClasses="true" />
+    </stubs>
     <issueHandlers>
         <UndefinedDocblockClass errorLevel="suppress"/>
         <UndefinedClass>
@@ -21,8 +24,6 @@
                 <!-- Nextcloud OCP Classes -->
                 <referencedClass name="OCP\AppFramework\App"/>
                 <referencedClass name="OCP\AppFramework\Bootstrap\IBootstrap"/>
-                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
-                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
                 <referencedClass name="OCP\AppFramework\Controller"/>
                 <referencedClass name="OCP\AppFramework\IAppContainer"/>
                 <referencedClass name="OCP\App\IAppManager"/>
@@ -58,50 +59,35 @@
                 <referencedClass name="OCP\Http\Client\IClientService"/>
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
-                <referencedClass name="OCP\IUser"/>
-                <referencedClass name="OCP\Settings\IIconSection"/>
-                <referencedClass name="OCP\Settings\ISettings"/>
-                <referencedClass name="OCP\Security\ISecureRandom"/>
-                <referencedClass name="OCP\Mail\IMailer"/>
-                <referencedClass name="OCP\Mail\IMessage"/>
-                <referencedClass name="OCP\Mail\IEMailTemplate"/>
-                <referencedClass name="OCP\ICache"/>
-                <referencedClass name="OCP\IGroup"/>
-                <referencedClass name="OCP\ISession"/>
-                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
-                <referencedClass name="OCP\Accounts\IAccountManager"/>
-                <referencedClass name="OCP\Dashboard\IWidget"/>
-                <referencedClass name="OCP\Migration\IRepairStep"/>
-                <referencedClass name="OC"/>
-                <referencedClass name="OC_App"/>
-                <!-- Additional OpenRegister Runtime Classes -->
-                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
-                <referencedClass name="OCA\OpenRegister\Db\Register"/>
-                <!-- OpenRegister Runtime Dependency Classes -->
-                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
-                <referencedClass name="OCA\OpenRegister\Service\OrganisationService"/>
-                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
-                <referencedClass name="OCA\OpenRegister\Service\Object\SaveObject\MetadataHydrationHandler"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
                 <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
-                <referencedClass name="OCA\OpenRegister\Db\MagicMapper"/>
-                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
                 <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
-                <referencedClass name="OCA\OpenRegister\Db\Organisation"/>
-                <referencedClass name="OCA\OpenRegister\Db\OrganisationMapper"/>
+                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
                 <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectLockedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectUnlockedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectRevertedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\UserProfileUpdatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\OrganisationCreatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\RegisterCreatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\RegisterDeletedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\RegisterUpdatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\SchemaCreatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\SchemaDeletedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\SchemaUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
         <UndefinedMagicMethod errorLevel="suppress"/>
@@ -110,7 +96,6 @@
         <UnusedMethod errorLevel="suppress"/>
         <UnusedProperty errorLevel="suppress"/>
         <PossiblyUnusedParam errorLevel="suppress"/>
-        <UnusedParam errorLevel="suppress"/>
         <UnusedDocblockParam errorLevel="suppress"/>
         <UnusedVariable errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
@@ -125,13 +110,18 @@
         <TypeDoesNotContainNull errorLevel="suppress"/>
         <TypeDoesNotContainType errorLevel="suppress"/>
         <InvalidArrayOffset errorLevel="suppress"/>
-        <InvalidArrayAccess errorLevel="suppress"/>
-
+        <InvalidCast errorLevel="suppress"/>
+        <InvalidArgument errorLevel="suppress"/>
+        <InvalidReturnType errorLevel="suppress"/>
+        <InvalidReturnStatement errorLevel="suppress"/>
         <MismatchingDocblockReturnType errorLevel="suppress"/>
         <EmptyArrayAccess errorLevel="suppress"/>
-        <MissingTemplateParam errorLevel="suppress"/>
+        <ImplementedReturnTypeMismatch errorLevel="suppress"/>
+        <InvalidMethodCall errorLevel="suppress"/>
         <UndefinedInterfaceMethod errorLevel="suppress"/>
-        <UnusedMethodCall errorLevel="suppress"/>
-        <UnusedReturnValue errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
+    <extraFiles>
+        <directory name="vendor/nextcloud/ocp" />
+    </extraFiles>
 </psalm>


### PR DESCRIPTION
## Summary

Phase 2 fleet rollout of the root-config consolidation. Replaces per-app phpcs/phpmd/psalm/phpstan extensions with the canonical from `nextcloud-app-template`.

Lint-debt tracking: #279.

**softwarecatalog has the largest defensive-coding lint debt of any app in the fleet** — surfaced by dropping per-app suppressions during the sync. The phpstan baseline is correspondingly large (206 entries) and requires a series of focused source PRs to drain, all enumerated in #279.

## Quality gates

| Gate | Status |
|---|---|
| phpcs | 15 errors / 442 warnings (pre-existing, not introduced) |
| psalm | 70 errors (pre-existing, not introduced) |
| phpstan | 0 unmatched (206 baselined per #279) |
| phpmd | 124 architectural violations (was 129, tracked #279) |

phpmd has no native baseline so CI stays red until #279 closes. Agreed-upon tracked-debt pattern. The phpcs/psalm pre-existing errors are also tracked in #279.

## Config changes

- **phpcs.xml** — sync canonical (SpecTagSniff/NoLegacyServerAccessorsSniff wiring, `vendor-bin/` + `lib/Resources/template/` excludes, lineLimit 150). Preserves SoftwareCatalog ruleset name.
- **phpmd.xml** — byte-canonical (preserves SoftwareCatalog ruleset name).
- **psalm.xml** — sync canonical (16 OCP/OR `referencedClass` entries added fleet-wide via nextcloud-app-template#49).
- **phpstan.neon** — sync canonical (`includes phpstan-baseline.neon`, broader `OC\`, `OCA\DAV\`, OCP stub-gap, Doctrine\\DBAL ignoreErrors, `vendor-bin/` + `lib/Resources/template/` `excludePaths`).
- **phpstan-baseline.neon** NEW — 206 errors baselined. Header points at #279.
- **phpstan-bootstrap.php** NEW — empty bootstrap, canonical.
- **phpcs-custom-sniffs/.../NoLegacyServerAccessorsSniff.php** NEW.
- **phpcs-custom-sniffs/.../SpecTagSniff.php** NEW.

### Dropped per fleet directive (intentional)

- `scanDirectories: ../openregister/lib` — DROPPED. PHPStan now reports `OCA\OpenRegister\` types as unknown but the canonical `OCA\OpenRegister\` `ignoreErrors` family in `phpstan.neon` covers them.
- 10 categories of defensive-coding suppressions (`always true`, `unreachable`, `never read` etc.) — all baselined and tracked in #279 for source-level refactor.

## Source changes — 5 mechanical phpmd fixes

- **4 ElseExpression** in `lib/Service/SoftwareCatalogue/ContactPersonHandler.php` refactored to early-return pattern. Three methods touched: `addContactpersoonToOrganization`, `ensureContactpersoonInOrganization`, `addUserToOrganizationEntity`. Behaviour preserved.
- **1 UnusedLocalVariable** in `lib/Service/ProgressTracker.php` (`calculateOverallPercentage`): also fixes a **pre-existing logic bug** where the actual percentage computation had been deleted, leaving `$overallProgress` computed but unused, and `$percentage` stuck at 0. Now correctly returns `(int) (($completedWeight + $currentPhaseProgress) / $totalWeight) * 100`.

The remaining 124 phpmd ElseExpression violations are deeply embedded across 5 service files (ArchiMateImportService, SettingsService, ArchiMateExportService, SoftwareCatalogueService, ArchiMateService). All architectural — tracked in #279 for file-by-file cleanup.

## Real bugs surfaced (tracked in #279, NOT fixed here)

- SimpleXMLElement nullability errors in `ArchiMateImportService` + `ArchiMateExportService` — actual NPE risks when XML doesn't conform to expectations.

## Test plan

- [x] phpcs: 15 pre-existing errors (no new ones introduced).
- [x] psalm: 70 pre-existing errors (no new ones introduced).
- [x] phpstan: 0 unmatched with baseline.
- [ ] phpmd: 124 violations remaining — see #279. CI gate intentionally red.
- [ ] PHPUnit suite green (no logic changes; the ProgressTracker fix is the only behaviour-impacting change and it restores deleted code).