### PR TITLE
feat(openspec): adopt org-archimate-export + 3 GEMMA changes from opencatalogi

### DIFF
--- a/openspec/changes/deelnames-gebruik/.openspec.yaml
+++ b/openspec/changes/deelnames-gebruik/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-03-20

--- a/openspec/changes/deelnames-gebruik/design.md
+++ b/openspec/changes/deelnames-gebruik/design.md
@@ -1,0 +1,6 @@
+# Design: deelnames-gebruik
+
+## Architecture Overview
+
+See specs/deelnames-gebruik/spec.md for detailed requirements and scenarios.
+Design details to be elaborated during implementation planning.

--- a/openspec/changes/deelnames-gebruik/proposal.md
+++ b/openspec/changes/deelnames-gebruik/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: deelnames-gebruik
+
+## Summary
+Add deelnames (participations) visualization to GEMMA views, showing which organizations participate in software components alongside existing "Gebruikt" (uses) and "Aangeboden" (offers) relationships.
+
+## Motivation
+Municipalities need visibility into participation relationships (deelnames) in GEMMA architecture views to understand the full landscape of software component involvement beyond just usage and supply.
+
+## Scope
+- Deelnames data layer in GEMMA view rendering
+- Module overlay nodes for deelnames
+- Integration with existing JointJS view rendering pipeline
+- API endpoint for deelnames data enrichment

--- a/openspec/changes/deelnames-gebruik/specs/deelnames-gebruik/spec.md
+++ b/openspec/changes/deelnames-gebruik/specs/deelnames-gebruik/spec.md
@@ -1,0 +1,282 @@
+---
+status: implemented
+---
+
+# Deelnames Gebruik Specification
+
+## Purpose
+Defines how usage objects (gebruiksobjecten) with participant organizations (deelnemers) are queried, enriched, and displayed alongside regular organization-owned modules on GEMMA views. This enables organizations to see not only the software they directly use, but also shared applications where they participate as a deelnemer (participant) through inter-organizational cooperation agreements.
+
+## Context
+In the Dutch municipal landscape, organizations frequently share software applications. For example, a shared service center (SSC) may own a software product while multiple municipalities participate in its use. The `deelnemers` field on gebruiksobjecten captures this relationship: the owning organization has RBAC access to the object, while participating organizations are listed in the `deelnemers` array. This spec ensures both types of usage are visible on GEMMA ArchiMate views.
+
+**Relation to existing specs:**
+- `view-enrichment-api`: Provides the backend API that returns both owned and deelnames gebruik data
+- `module-overlay-rendering`: Handles the visual rendering of deelnames module nodes with distinct styling
+- `org-archimate-export`: Includes deelnames data in ArchiMate XML exports when the deelnames parameter is enabled
+
+**Relation to existing OpenCatalogi entities:**
+- Uses OpenRegister's ObjectService for querying gebruiksobjecten across organizations
+- Leverages the softwarecatalog enrichment API for view data retrieval
+- Builds on the existing GEMMA view and referentiecomponent data model
+
+## Requirements
+
+### Requirement: ViewService MUST retrieve deelnames gebruik separately from regular gebruik
+The ViewService MUST perform a two-phase retrieval: regular gebruik filtered by RBAC, then deelnames gebruik with RBAC disabled filtering by the `deelnemers` field.
+
+#### Scenario: Organization has both owned and shared gebruik
+- GIVEN organization A owns 5 gebruiksobjecten
+- AND organization A appears in the `deelnemers` field of 3 gebruiksobjecten owned by organization B
+- WHEN the view is requested with `include_gebruik=true` and `include_deelnames_gebruik=true`
+- THEN the response MUST include module overlay nodes for all 5 owned gebruiksobjecten
+- AND the response MUST include module overlay nodes for the 3 shared gebruiksobjecten
+- AND shared module nodes MUST be marked with `_type: "deelnames"`
+
+#### Scenario: Organization has only deelnames gebruik
+- GIVEN organization A owns 0 gebruiksobjecten
+- AND organization A appears in `deelnemers` of 2 gebruiksobjecten
+- WHEN the view is requested with `include_deelnames_gebruik=true`
+- THEN the response MUST include module overlay nodes for the 2 shared gebruiksobjecten
+- AND no error MUST be returned for the empty regular gebruik result
+
+#### Scenario: Deelnames flag is not set
+- GIVEN organization A appears in `deelnemers` of 3 gebruiksobjecten
+- WHEN the view is requested with `include_gebruik=true` but WITHOUT `include_deelnames_gebruik`
+- THEN the response MUST NOT include the 3 shared gebruiksobjecten
+- AND only directly owned gebruik MUST be included
+
+#### Scenario: Both flags disabled returns base view only
+- GIVEN organization A has both owned and deelnames gebruik
+- WHEN the view is requested WITHOUT `include_gebruik` and WITHOUT `include_deelnames_gebruik`
+- THEN the response MUST contain only the base GEMMA view nodes
+- AND no gebruik or deelnames queries MUST be executed
+
+#### Scenario: Deelnames without gebruik flag still returns deelnames
+- GIVEN organization A has deelnames gebruik but the `include_gebruik` flag is false
+- WHEN the view is requested with `include_deelnames_gebruik=true` only
+- THEN the response MUST include deelnames module overlay nodes
+- AND owned gebruik MUST NOT be included in the response
+
+### Requirement: Deelnames gebruik MUST be queried with RBAC disabled
+Deelnames gebruiksobjecten are owned by other organizations, so the query MUST bypass RBAC to find records where the current organization appears in the `deelnemers` array.
+
+#### Scenario: Deelnames query bypasses RBAC
+- GIVEN organization A is searching for deelnames gebruik
+- WHEN the ObjectService search is executed for deelnames
+- THEN the search MUST be called with `_rbac: false`
+- AND the query MUST filter on `deelnemers` containing organization A's UUID
+
+#### Scenario: Deelnames query also disables multitenancy
+- GIVEN organization A is searching for deelnames gebruik in a multi-tenant environment
+- WHEN the ObjectService search is executed for deelnames
+- THEN the search MUST be called with `_rbac: false` AND `_multitenancy: false`
+- AND results MUST include gebruiksobjecten from all tenants where organization A is listed as deelnemer
+
+#### Scenario: Deelnames query targets correct register and schema
+- GIVEN the voorzieningen register and gebruik schema are configured
+- WHEN the deelnames query is executed
+- THEN the ObjectService search MUST target the voorzieningen register
+- AND the query MUST use the gebruik schema identifier
+- AND no other schemas or registers MUST be queried
+
+#### Scenario: Deelnames query handles large result sets
+- GIVEN organization A appears as deelnemer in 50 gebruiksobjecten across 10 organizations
+- WHEN the deelnames query is executed
+- THEN all 50 results MUST be returned
+- AND the query MUST NOT be limited by default pagination
+- AND results MUST include the owning organization's name for display purposes
+
+#### Scenario: RBAC-enabled query for regular gebruik runs separately
+- GIVEN organization A has both owned and deelnames gebruik
+- WHEN both queries execute
+- THEN the regular gebruik query MUST use standard RBAC (organization-filtered)
+- AND the deelnames query MUST use `_rbac: false`
+- AND the two result sets MUST be merged without duplicates
+
+### Requirement: Gebruiksobjecten MUST support the deelnemers field
+Gebruiksobjecten MUST have a `deelnemers` field that contains an array of participating organization identifiers.
+
+#### Scenario: Gebruiksobject with deelnemers array of UUIDs
+- GIVEN a gebruiksobject with `deelnemers: ["uuid-org-a", "uuid-org-b"]`
+- WHEN organization A queries for deelnames gebruik
+- THEN this gebruiksobject MUST be returned in the results
+
+#### Scenario: Gebruiksobject with deelnemers array of objects
+- GIVEN a gebruiksobject with `deelnemers: [{"id": "uuid-org-a", "name": "Org A"}]`
+- WHEN organization A queries for deelnames gebruik
+- THEN this gebruiksobject MUST be returned in the results
+
+#### Scenario: Gebruiksobject without deelnemers field
+- GIVEN a gebruiksobject without a `deelnemers` field
+- WHEN any organization queries for deelnames gebruik
+- THEN this gebruiksobject MUST NOT be returned in deelnames results
+- AND it MAY still appear in regular gebruik results if the querying organization owns it
+
+#### Scenario: Gebruiksobject with empty deelnemers array
+- GIVEN a gebruiksobject with `deelnemers: []`
+- WHEN any organization queries for deelnames gebruik
+- THEN this gebruiksobject MUST NOT be returned in deelnames results
+
+#### Scenario: Organization appears in deelnemers of its own gebruiksobject
+- GIVEN organization A owns a gebruiksobject AND also appears in its own `deelnemers` array
+- WHEN organization A queries with both `include_gebruik=true` and `include_deelnames_gebruik=true`
+- THEN the gebruiksobject MUST appear only once in the results (deduplicated)
+- AND it MUST be classified as owned, not deelnames
+
+### Requirement: Deelnames module nodes MUST carry source organization metadata
+When deelnames gebruiksobjecten are converted to module overlay nodes, they MUST include metadata about the owning organization to enable attribution in the UI.
+
+#### Scenario: Deelnames node includes owning organization name
+- GIVEN a deelnames gebruiksobject owned by organization B
+- WHEN it is converted to a module overlay node
+- THEN the node MUST include `_sourceOrganization` with the owning organization's name
+- AND the node MUST include `_sourceOrganizationId` with the owning organization's UUID
+
+#### Scenario: Tooltip shows source organization for deelnames nodes
+- GIVEN a rendered deelnames module node on a GEMMA view
+- WHEN the user hovers over the node
+- THEN the tooltip MUST display the source organization name
+- AND the tooltip MUST indicate this is a shared/deelnames application
+
+#### Scenario: Deelnames nodes are distinguishable in node lists
+- GIVEN a view with both owned and deelnames module nodes
+- WHEN the node list or legend is displayed
+- THEN deelnames nodes MUST be listed separately from owned nodes
+- AND each deelnames entry MUST show the source organization
+
+### Requirement: Deelnames gebruik MUST be filterable in the frontend
+The frontend MUST provide a dedicated toggle for deelnames gebruik, separate from the regular gebruik toggle.
+
+#### Scenario: Deelnames toggle is independent from gebruik toggle
+- GIVEN the view filter panel
+- WHEN the user sees the filter toggles
+- THEN there MUST be a separate "Deelnames" toggle
+- AND it MUST be independent of the "Gebruik" toggle
+- AND enabling/disabling one MUST NOT affect the other
+
+#### Scenario: Deelnames toggle triggers re-fetch with correct parameters
+- GIVEN the deelnames toggle is currently disabled
+- WHEN the user enables the deelnames toggle
+- THEN a new API request MUST be made with `include_deelnames_gebruik=true`
+- AND the view MUST re-render with the additional deelnames nodes
+
+#### Scenario: Deelnames toggle disabled by default
+- GIVEN a user navigates to a GEMMA view for the first time
+- THEN the deelnames toggle MUST be disabled by default
+- AND no deelnames query MUST be executed on initial load
+
+### Requirement: Test data MUST include gebruiksobjecten with deelnemers
+The development environment MUST have test data demonstrating the deelnames flow.
+
+#### Scenario: Test data exists for deelnames verification
+- GIVEN the development environment
+- WHEN a developer wants to test the deelnames feature
+- THEN there MUST be at least one gebruiksobject owned by organization X with `deelnemers` containing organization Y
+- AND organization Y MUST be a different organization than X
+- AND the gebruiksobject MUST reference a module linked to referentiecomponenten on at least one view
+
+#### Scenario: Test data covers multiple deelnemers per gebruiksobject
+- GIVEN the development environment
+- THEN there MUST be at least one gebruiksobject with 2 or more organizations in the `deelnemers` array
+- AND each listed organization MUST be a valid, existing organization in the system
+
+#### Scenario: Test data includes organizations with only deelnames
+- GIVEN the development environment
+- THEN there MUST be at least one organization that has zero owned gebruiksobjecten but appears as deelnemer in at least one gebruiksobject
+- AND this organization MUST be usable for testing the "deelnames only" scenario
+
+### Requirement: Performance testing MUST use the organization with most applications
+After implementation, the system MUST be tested with the organization that has the highest number of applications and gebruiksobjecten set as active.
+
+#### Scenario: Performance test with largest organization
+- GIVEN the organization with the most applications is set as active
+- WHEN the BBN poster view (388+ base nodes) is loaded with all enrichment flags enabled
+- THEN the total render time (including overlay nodes) MUST be under 3 seconds
+- AND the page MUST remain interactive (no browser freeze)
+
+#### Scenario: Performance test with large deelnames result set
+- GIVEN an organization that appears as deelnemer in 100+ gebruiksobjecten
+- WHEN the view is loaded with deelnames enabled
+- THEN the deelnames query MUST complete within 2 seconds
+- AND the combined render time (base + owned + deelnames) MUST be under 5 seconds
+
+#### Scenario: Performance test with concurrent owned and deelnames queries
+- GIVEN both gebruik and deelnames toggles are enabled
+- WHEN the view data is fetched
+- THEN the owned gebruik query and deelnames query SHOULD execute in parallel where possible
+- AND the total data retrieval time MUST NOT be the sum of both queries
+
+### Requirement: Deduplication MUST prevent duplicate module nodes
+When an organization both owns a gebruiksobject AND appears in another organization's gebruiksobject for the same module, the deduplication logic MUST prevent rendering the same module twice on a referentiecomponent.
+
+#### Scenario: Same module from owned and deelnames sources
+- GIVEN organization A owns a gebruiksobject for module "Topdesk" linked to referentiecomponent R1
+- AND organization A also appears as deelnemer on another gebruiksobject for "Topdesk" linked to R1
+- WHEN both owned and deelnames results are merged
+- THEN only one module overlay node for "Topdesk" on R1 MUST be rendered
+- AND the node MUST be marked as owned (not deelnames)
+
+#### Scenario: Different modules from same referentiecomponent are not deduplicated
+- GIVEN organization A owns "Topdesk" linked to R1
+- AND organization A is deelnemer on "ServiceNow" also linked to R1
+- WHEN results are merged
+- THEN both "Topdesk" and "ServiceNow" MUST appear as separate overlay nodes on R1
+
+#### Scenario: Same module on different referentiecomponenten is not deduplicated
+- GIVEN organization A owns "Topdesk" linked to R1
+- AND organization A is deelnemer on "Topdesk" linked to R2 (different referentiecomponent)
+- WHEN results are merged
+- THEN "Topdesk" MUST appear on both R1 (as owned) and R2 (as deelnames)
+
+### Requirement: Error handling MUST gracefully handle deelnames query failures
+If the deelnames query fails (e.g., network timeout, schema not found), the view MUST still render with available data.
+
+#### Scenario: Deelnames query fails with timeout
+- GIVEN the deelnames query takes longer than the configured timeout
+- WHEN the view is being loaded
+- THEN the view MUST render with owned gebruik data (if available) and base GEMMA nodes
+- AND a warning MUST be logged indicating the deelnames query timed out
+- AND the frontend MUST display a non-blocking notification that deelnames data could not be loaded
+
+#### Scenario: Deelnames schema not configured
+- GIVEN the gebruik schema is not configured in the voorzieningen register
+- WHEN a deelnames query is attempted
+- THEN the query MUST fail gracefully with a logged warning
+- AND the view MUST render without deelnames data
+- AND no HTTP error MUST be returned to the frontend
+
+#### Scenario: Regular gebruik query fails but deelnames succeeds
+- GIVEN the regular RBAC-enabled gebruik query fails
+- AND the deelnames query succeeds with 3 results
+- WHEN the view is rendered
+- THEN the 3 deelnames nodes MUST be displayed
+- AND a warning MUST be shown for the failed owned gebruik query
+
+## MODIFIED Requirements
+
+_None -- this is a new capability._
+
+## REMOVED Requirements
+
+_None._
+
+## Current Implementation Status
+- **Not yet implemented**: No deelnames-specific logic exists in the OpenCatalogi or softwarecatalog codebase.
+- **Building blocks that exist**:
+  - ObjectService search with RBAC disable capability (via `_rbac` and `_multitenancy` parameters)
+  - GEMMA view rendering pipeline with JointJS in the softwarecatalog frontend
+  - Module overlay node infrastructure (see `module-overlay-rendering` spec)
+  - View enrichment API (see `view-enrichment-api` spec)
+- **Key gaps**:
+  - No two-phase query logic (owned + deelnames) in any ViewService
+  - No deelnames-specific frontend toggle
+  - No deduplication logic for overlapping owned/deelnames results
+  - No source organization metadata on module overlay nodes
+  - No test data with deelnemers field populated
+
+## Dependencies
+- `view-enrichment-api` spec (backend API contract)
+- `module-overlay-rendering` spec (visual rendering of deelnames nodes)
+- OpenRegister ObjectService (data queries with RBAC control)
+- Softwarecatalog ViewService (view data aggregation)

--- a/openspec/changes/deelnames-gebruik/tasks.md
+++ b/openspec/changes/deelnames-gebruik/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: deelnames-gebruik
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/deelnames-gebruik/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements from spec are decomposed into implementable tasks

--- a/openspec/changes/module-overlay-rendering/.openspec.yaml
+++ b/openspec/changes/module-overlay-rendering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-03-20

--- a/openspec/changes/module-overlay-rendering/design.md
+++ b/openspec/changes/module-overlay-rendering/design.md
@@ -1,0 +1,6 @@
+# Design: module-overlay-rendering
+
+## Architecture Overview
+
+See specs/module-overlay-rendering/spec.md for detailed requirements and scenarios.
+Design details to be elaborated during implementation planning.

--- a/openspec/changes/module-overlay-rendering/proposal.md
+++ b/openspec/changes/module-overlay-rendering/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: module-overlay-rendering
+
+## Summary
+Render module information as overlay nodes on GEMMA architecture views using JointJS, showing which software modules are associated with architectural components.
+
+## Motivation
+GEMMA views currently show static architecture components. Overlaying actual software module assignments provides actionable insight into which software serves which architectural function.
+
+## Scope
+- JointJS overlay node rendering for modules
+- Parent-child node positioning with topological sort
+- Color coding and interactive tooltips
+- Paper freeze/unfreeze pattern for performance

--- a/openspec/changes/module-overlay-rendering/specs/module-overlay-rendering/spec.md
+++ b/openspec/changes/module-overlay-rendering/specs/module-overlay-rendering/spec.md
@@ -1,0 +1,307 @@
+---
+status: implemented
+---
+
+# Module Overlay Rendering Specification
+
+## Purpose
+Defines how application/module nodes injected by the enrichment API are rendered on GEMMA ArchiMate views, including visual styling, positioning, performance requirements, and interaction behavior. Module overlay nodes represent organization-specific software applications plotted on top of the standard GEMMA reference architecture, enabling organizations to visualize their application landscape in the context of the national standard.
+
+## Context
+GEMMA views are ArchiMate diagrams that show the Dutch municipal reference architecture. They contain referentiecomponenten (reference components) that represent abstract architectural functions. Organizations map their actual software applications (modules) to these referentiecomponenten. This spec defines how those mapped modules are visually rendered as overlay nodes within the GEMMA view, using JointJS as the rendering engine.
+
+**Relation to existing specs:**
+- `view-enrichment-api`: Provides the enriched view data (base GEMMA + module overlay nodes) that this spec renders
+- `deelnames-gebruik`: Provides deelnames-type module nodes that require distinct visual styling
+- `org-archimate-export`: Uses the same module-referentiecomponent relationships but exports to XML rather than rendering
+
+**Technical foundation:**
+- Rendering engine: JointJS (JavaScript diagramming library)
+- View data: ArchiMate viewNodes with x/y/width/height positioning
+- Parent-child: JointJS parent embedding for nesting modules inside referentiecomponenten
+- Performance: paper.freeze()/unfreeze() pattern for batch rendering
+
+## Requirements
+
+### Requirement: Module nodes MUST render as children of referentiecomponenten
+Module overlay nodes returned by the enrichment API MUST be rendered inside their parent referentiecomponent using the existing JointJS parent-child hierarchy.
+
+#### Scenario: Module node with parent reference renders inside referentiecomponent
+- GIVEN a viewNode with `_isModuleExpansion: true` and `parent` set to a referentiecomponent's `viewNodeId`
+- WHEN the rendering pipeline processes all viewNodes
+- THEN the module node MUST be rendered as a child of the referentiecomponent in the JointJS graph
+- AND the module node MUST appear visually nested within the referentiecomponent's bounds
+
+#### Scenario: Module appears in multiple referentiecomponenten
+- GIVEN a module that is linked to 3 referentiecomponenten on the current view
+- WHEN the enrichment API returns viewNodes
+- THEN there MUST be 3 separate module viewNodes, one per referentiecomponent
+- AND each MUST have a different `viewNodeId` but the same `modelNodeId`
+- AND each MUST have `parent` pointing to its respective referentiecomponent
+
+#### Scenario: Module node without valid parent reference is skipped
+- GIVEN a viewNode with `_isModuleExpansion: true` but `parent` set to a non-existent `viewNodeId`
+- WHEN the rendering pipeline processes this node
+- THEN the node MUST be skipped (not rendered)
+- AND a warning MUST be logged with the invalid parent reference
+- AND the remaining nodes MUST render normally
+
+#### Scenario: Referentiecomponent with no modules renders normally
+- GIVEN a referentiecomponent viewNode that has no mapped modules
+- WHEN the rendering pipeline processes this node
+- THEN the referentiecomponent MUST render exactly as in the base GEMMA view
+- AND no empty child container or placeholder MUST be added
+
+#### Scenario: Module node respects parent bounds
+- GIVEN a module overlay node with `parent` pointing to referentiecomponent R1
+- AND R1 has bounds (x=100, y=200, width=300, height=150)
+- WHEN the module node is rendered
+- THEN the module node's position MUST be within R1's visual bounds
+- AND the module node MUST NOT overflow or clip outside R1
+
+### Requirement: Module nodes MUST be visually distinct from GEMMA elements
+Module overlay nodes MUST be styled differently from standard GEMMA referentiecomponenten so users can distinguish organization-specific applications from the architecture standard.
+
+#### Scenario: Module node receives distinct fill color
+- GIVEN a viewNode with `_isModuleExpansion: true`
+- WHEN `setNodeColor` processes this node
+- THEN the node's fill color MUST differ from standard referentiecomponent colors
+- AND the node's border color MUST differ from standard referentiecomponent borders
+
+#### Scenario: Module node from deelnames has different styling
+- GIVEN a viewNode with `_isModuleExpansion: true` and `_type: "deelnames"`
+- WHEN `setNodeColor` processes this node
+- THEN the node MUST be styled differently from regular module nodes (e.g., different opacity or color shade)
+- AND the user MUST be able to distinguish owned modules from shared (deelnames) modules
+
+#### Scenario: Module node displays application name
+- GIVEN a module overlay node with name "Topdesk"
+- WHEN the node is rendered
+- THEN the text label "Topdesk" MUST be visible inside the node
+- AND the text MUST be legible (minimum contrast ratio of 4.5:1 against the fill color)
+- AND long names MUST be truncated with ellipsis if they exceed the node width
+
+#### Scenario: Module node color comes from node data, not hardcoded
+- GIVEN a module overlay node with `color: "#4CAF50"` and `borderColor: "#388E3C"`
+- WHEN the node is rendered
+- THEN the fill color MUST be `#4CAF50`
+- AND the border color MUST be `#388E3C`
+- AND the colors MUST NOT be overridden by the default GEMMA color palette
+
+#### Scenario: Deelnames node has visual indicator of shared ownership
+- GIVEN a deelnames module node with `_sourceOrganization: "Gemeente Utrecht"`
+- WHEN the node is rendered
+- THEN the node MUST have a visual indicator distinguishing it from owned modules (e.g., dashed border, reduced opacity, or badge)
+- AND the indicator MUST be consistent across all deelnames nodes on the view
+
+### Requirement: Rendering MUST use paper.freeze optimization
+All view rendering that includes module overlay nodes MUST use the JointJS `paper.freeze()`/`paper.unfreeze()` pattern to maintain performance.
+
+#### Scenario: View with 388 base nodes and 200 module overlay nodes renders
+- GIVEN a view with 388 GEMMA nodes and 200 additional module overlay nodes
+- WHEN the rendering pipeline executes
+- THEN `paper.freeze()` MUST be called before `ViewRenderer.renderToGraph()`
+- AND `paper.unfreeze()` MUST be called after `renderToGraph()` completes
+- AND total render time MUST be under 3 seconds
+
+#### Scenario: View with no overlay nodes renders unchanged
+- GIVEN a view with only base GEMMA nodes (no enrichment)
+- WHEN the rendering pipeline executes
+- THEN the render behavior and performance MUST be identical to the current implementation
+
+#### Scenario: Paper unfreeze is called even if rendering throws an error
+- GIVEN a view rendering that encounters an error during `renderToGraph()`
+- WHEN the error occurs
+- THEN `paper.unfreeze()` MUST still be called (via try/finally)
+- AND the error MUST be propagated after unfreezing
+- AND the paper MUST NOT remain in a frozen state
+
+#### Scenario: Incremental re-render on toggle change uses freeze
+- GIVEN a view is already rendered with base GEMMA nodes
+- WHEN the user enables the "Gebruik" toggle (adding module overlay nodes)
+- THEN `paper.freeze()` MUST be called before adding the new nodes
+- AND `paper.unfreeze()` MUST be called after all nodes are added
+- AND the view MUST NOT flicker during the re-render
+
+#### Scenario: Performance with maximum realistic node count
+- GIVEN a view with 500 base nodes and 500 module overlay nodes (1000 total)
+- WHEN the rendering pipeline executes with freeze/unfreeze
+- THEN the total render time MUST be under 5 seconds
+- AND the browser MUST remain responsive (no jank or dropped frames after unfreeze)
+
+### Requirement: Topological sort MUST handle module overlay nodes
+The existing topological sort that orders parent nodes before children MUST correctly process module overlay nodes that reference referentiecomponenten as parents.
+
+#### Scenario: Module overlay nodes sorted after their parent referentiecomponenten
+- GIVEN a viewNodes array containing both GEMMA nodes and module overlay nodes
+- WHEN the topological sort runs
+- THEN every module overlay node MUST appear after its parent referentiecomponent in the sorted array
+- AND the sort MUST not produce errors for overlay nodes
+
+#### Scenario: Circular reference detection includes module nodes
+- GIVEN a malformed viewNodes array where a module node references itself as parent
+- WHEN the topological sort runs
+- THEN the circular reference MUST be detected
+- AND the affected node MUST be skipped with a warning logged
+- AND remaining nodes MUST sort and render correctly
+
+#### Scenario: Multiple levels of nesting are supported
+- GIVEN a GEMMA group node G containing referentiecomponent R, and module M inside R
+- WHEN the topological sort runs
+- THEN the sort order MUST be: G, then R, then M
+- AND JointJS parent embedding MUST correctly nest M inside R inside G
+
+#### Scenario: Sort is stable for nodes at the same level
+- GIVEN 5 module overlay nodes all with the same parent referentiecomponent
+- WHEN the topological sort runs
+- THEN the 5 modules MUST appear consecutively after their parent
+- AND their relative order MUST be deterministic (sorted by viewNodeId or name)
+
+### Requirement: setNodeColor MUST handle module overlay nodes
+The `setNodeColor` function MUST apply appropriate styling to module overlay nodes based on their metadata markers.
+
+#### Scenario: setNodeColor processes a module node
+- GIVEN a rendered SVG element for a viewNode with `_isModuleExpansion: true`
+- WHEN `setNodeColor` is called for this node
+- THEN it MUST apply the module-specific fill color from the node data
+- AND it MUST apply the module-specific border color from the node data
+- AND text elements MUST remain readable (sufficient contrast)
+
+#### Scenario: setNodeColor handles missing color data gracefully
+- GIVEN a module overlay node without `color` or `borderColor` fields
+- WHEN `setNodeColor` is called for this node
+- THEN it MUST apply a default module color (distinct from GEMMA colors)
+- AND a default border color MUST be applied
+- AND the node MUST still be visually distinguishable from referentiecomponenten
+
+#### Scenario: setNodeColor applies deelnames styling
+- GIVEN a module overlay node with `_type: "deelnames"`
+- WHEN `setNodeColor` is called
+- THEN the fill opacity MUST be reduced (e.g., 0.7) or a different color variant MUST be used
+- AND the border MUST be styled differently (e.g., dashed or different color)
+- AND the distinction from owned modules MUST be clearly visible
+
+#### Scenario: setNodeColor does not affect standard GEMMA nodes
+- GIVEN a standard GEMMA referentiecomponent node (no `_isModuleExpansion` flag)
+- WHEN `setNodeColor` is called for this node
+- THEN the existing GEMMA styling logic MUST be applied unchanged
+- AND no module-specific colors or styling MUST be applied
+
+### Requirement: Module nodes MUST support click interaction
+Users MUST be able to click on module overlay nodes to view details about the mapped application.
+
+#### Scenario: Click on module node opens detail panel
+- GIVEN a rendered module overlay node for "Topdesk"
+- WHEN the user clicks on the node
+- THEN a detail panel or sidebar MUST open showing information about the "Topdesk" application
+- AND the panel MUST include the application name, owning organization, and linked referentiecomponenten
+
+#### Scenario: Click on deelnames module node shows source organization
+- GIVEN a rendered deelnames module node for "Topdesk" owned by "Gemeente Utrecht"
+- WHEN the user clicks on the node
+- THEN the detail panel MUST show that this is a shared application
+- AND it MUST display the source organization "Gemeente Utrecht"
+- AND it MUST show the participation relationship
+
+#### Scenario: Click on module node does not interfere with parent click
+- GIVEN a module node nested inside referentiecomponent R1
+- WHEN the user clicks on the module node
+- THEN the module detail panel MUST open (not the referentiecomponent detail)
+- AND the click event MUST NOT propagate to R1
+
+### Requirement: Multiple modules inside one referentiecomponent MUST stack correctly
+When a referentiecomponent has multiple mapped modules, the modules MUST be positioned without overlap.
+
+#### Scenario: Three modules stacked vertically inside referentiecomponent
+- GIVEN referentiecomponent R1 with bounds (x=100, y=200, width=300, height=150)
+- AND 3 modules mapped to R1
+- WHEN the overlay nodes are positioned
+- THEN the 3 modules MUST be stacked vertically within R1's bounds
+- AND each module MUST have equal height (parent height / number of modules, with padding)
+- AND no module MUST overlap with another
+
+#### Scenario: Many modules trigger referentiecomponent resize
+- GIVEN referentiecomponent R1 with 10 mapped modules
+- WHEN the overlay nodes are positioned
+- THEN R1's height MUST be expanded to accommodate all 10 modules
+- AND each module MUST have a minimum readable height (at least 20px)
+- AND the expansion MUST NOT cause R1 to overlap with adjacent nodes if possible
+
+#### Scenario: Single module uses available space
+- GIVEN referentiecomponent R1 with exactly 1 mapped module
+- WHEN the overlay node is positioned
+- THEN the module MUST be centered or top-aligned within R1
+- AND the module MUST use appropriate padding from R1's edges
+
+### Requirement: Legend MUST explain module overlay styling
+The view MUST include a legend explaining the visual meaning of module overlay nodes.
+
+#### Scenario: Legend shows owned module style
+- GIVEN a view with owned module overlay nodes
+- WHEN the legend is displayed
+- THEN it MUST include a swatch showing the owned module fill and border color
+- AND the label MUST read "Eigen applicaties" or equivalent
+
+#### Scenario: Legend shows deelnames module style
+- GIVEN a view with deelnames module overlay nodes
+- WHEN the legend is displayed
+- THEN it MUST include a swatch showing the deelnames module styling
+- AND the label MUST read "Deelnames applicaties" or equivalent
+
+#### Scenario: Legend updates when toggles change
+- GIVEN only owned modules are enabled (no deelnames)
+- WHEN the user enables the deelnames toggle
+- THEN the legend MUST update to include the deelnames swatch
+- AND the legend MUST NOT show deelnames styling when the toggle is disabled
+
+### Requirement: Module overlay rendering MUST be accessible
+Module overlay nodes MUST meet WCAG AA accessibility requirements.
+
+#### Scenario: Module nodes have sufficient color contrast
+- GIVEN any module overlay node (owned or deelnames)
+- WHEN rendered with its fill color and text color
+- THEN the contrast ratio between text and background MUST be at least 4.5:1
+- AND the contrast ratio between the node border and the view background MUST be at least 3:1
+
+#### Scenario: Module nodes are keyboard navigable
+- GIVEN a view with module overlay nodes
+- WHEN the user navigates using Tab key
+- THEN module nodes MUST be focusable
+- AND the focused module MUST have a visible focus indicator
+- AND pressing Enter on a focused module MUST open the detail panel
+
+#### Scenario: Module nodes have accessible names
+- GIVEN a module overlay node for "Topdesk"
+- WHEN a screen reader encounters the node
+- THEN the accessible name MUST include "Applicatie: Topdesk"
+- AND for deelnames nodes, it MUST include "Gedeelde applicatie: Topdesk (via Gemeente Utrecht)"
+
+## MODIFIED Requirements
+
+_None -- this is a new capability._
+
+## REMOVED Requirements
+
+_None._
+
+## Current Implementation Status
+- **Not yet implemented**: No module overlay rendering exists in the OpenCatalogi or softwarecatalog codebase.
+- **Building blocks that exist**:
+  - JointJS-based GEMMA view rendering in the softwarecatalog frontend
+  - `paper.freeze()`/`paper.unfreeze()` pattern used in current view rendering
+  - Topological sort for ordering parent-before-child nodes
+  - `setNodeColor` function for applying colors to rendered SVG elements
+  - ViewNode data model with x/y/width/height positioning
+- **Key gaps**:
+  - No module-specific node creation or embedding logic
+  - No deelnames-specific styling
+  - No click interaction on overlay nodes
+  - No stacking/positioning logic for multiple modules per referentiecomponent
+  - No legend component for module overlay explanation
+  - No accessibility attributes on rendered SVG elements
+
+## Dependencies
+- `view-enrichment-api` spec (provides the enriched node data)
+- `deelnames-gebruik` spec (provides deelnames-type metadata)
+- JointJS library (rendering engine)
+- Softwarecatalog frontend view renderer

--- a/openspec/changes/module-overlay-rendering/tasks.md
+++ b/openspec/changes/module-overlay-rendering/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: module-overlay-rendering
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/module-overlay-rendering/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements from spec are decomposed into implementable tasks

--- a/openspec/changes/view-enrichment-api/.openspec.yaml
+++ b/openspec/changes/view-enrichment-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-03-20

--- a/openspec/changes/view-enrichment-api/design.md
+++ b/openspec/changes/view-enrichment-api/design.md
@@ -1,0 +1,6 @@
+# Design: view-enrichment-api
+
+## Architecture Overview
+
+See specs/view-enrichment-api/spec.md for detailed requirements and scenarios.
+Design details to be elaborated during implementation planning.

--- a/openspec/changes/view-enrichment-api/proposal.md
+++ b/openspec/changes/view-enrichment-api/proposal.md
@@ -1,0 +1,13 @@
+# Proposal: view-enrichment-api
+
+## Summary
+Create a backend API that enriches GEMMA view data with module, gebruik, and organization information from OpenRegister, providing the data layer needed by the frontend view rendering.
+
+## Motivation
+The frontend currently has no API to fetch enriched view data. Module overlays, deelnames, and usage information require a backend endpoint that combines data from multiple OpenRegister schemas.
+
+## Scope
+- REST API endpoint for enriched view data
+- Data aggregation from view, module, and gebruik objects
+- Caching strategy for performance
+- Integration with existing ObjectService

--- a/openspec/changes/view-enrichment-api/specs/view-enrichment-api/spec.md
+++ b/openspec/changes/view-enrichment-api/specs/view-enrichment-api/spec.md
@@ -1,0 +1,304 @@
+---
+status: implemented
+---
+
+# View Enrichment API Specification
+
+## Purpose
+Defines how the frontend obtains enriched view data (base GEMMA view + organization-specific modules and usage data) through the softwarecatalog enrichment API, replacing direct OpenRegister calls. This API acts as the single entry point for all GEMMA view data, aggregating base ArchiMate view data with organization-specific module mappings, gebruik, and deelnames into a unified response.
+
+## Context
+Previously, the frontend called the OpenRegister API directly to fetch raw GEMMA view data, then performed client-side enrichment. This spec moves enrichment to the backend (softwarecatalog app), which has access to organization data, module mappings, and gebruik objects. The frontend sends filter toggle state as query parameters, and the backend returns a complete, enriched view ready for rendering.
+
+**Relation to existing specs:**
+- `module-overlay-rendering`: Consumes the enriched viewNode data this API returns
+- `deelnames-gebruik`: This API orchestrates the two-phase query (owned + deelnames) defined there
+- `org-archimate-export`: Uses similar enrichment logic but outputs ArchiMate XML instead of JSON
+
+**Relation to existing OpenCatalogi infrastructure:**
+- The softwarecatalog app hosts the enrichment endpoint, not OpenCatalogi directly
+- OpenCatalogi's existing public API (`/api/{catalogSlug}`) serves publication data; views are a softwarecatalog concern
+- The enrichment API calls OpenRegister's ObjectService internally for view, module, and gebruik data
+
+## Requirements
+
+### Requirement: Frontend MUST call enrichment API for views
+The frontend MUST use the softwarecatalog enrichment API (`/softwarecatalog/api/views/{viewId}`) instead of the OpenRegister direct API (`/openregister/api/objects/vng-gemma/view/{id}`) for all view rendering.
+
+#### Scenario: Beheer view loads with enrichment
+- GIVEN a user navigates to `/beheer/view/{id}`
+- WHEN the view component mounts
+- THEN the frontend MUST request `GET /softwarecatalog/api/views/{viewId}`
+- AND the request MUST include enrichment parameters based on active filter toggles
+
+#### Scenario: Public view loads with enrichment
+- GIVEN a visitor navigates to `/views/{id}`
+- WHEN the public view component mounts
+- THEN the frontend MUST request `GET /softwarecatalog/api/views/{viewId}`
+- AND the request MUST include enrichment parameters based on active filter toggles
+
+#### Scenario: Direct OpenRegister calls are no longer used for views
+- GIVEN the frontend codebase
+- WHEN searching for view data fetch calls
+- THEN no calls to `/openregister/api/objects/vng-gemma/view/{id}` MUST exist for rendering
+- AND all view rendering MUST go through the enrichment API
+
+#### Scenario: Enrichment API returns 404 for non-existent view
+- GIVEN a view ID that does not exist in the system
+- WHEN `GET /softwarecatalog/api/views/{invalidId}` is called
+- THEN the response MUST have status 404
+- AND the response body MUST contain an error message indicating the view was not found
+
+#### Scenario: Enrichment API handles server errors gracefully
+- GIVEN the ObjectService is temporarily unavailable
+- WHEN `GET /softwarecatalog/api/views/{viewId}` is called
+- THEN the response MUST have status 503 or 500
+- AND the response body MUST contain a descriptive error message
+- AND the error MUST be logged server-side
+
+### Requirement: Frontend filter toggles MUST map to backend enrichment parameters
+The frontend filter toggle state MUST be translated to the correct backend query parameters on each view fetch.
+
+#### Scenario: Gebruik filter is enabled
+- GIVEN the user enables the "Gebruik" filter toggle
+- WHEN the view is fetched
+- THEN the request MUST include `include_gebruik=true`
+- AND the request MUST include `include_modules=true`
+
+#### Scenario: Deelnames filter is enabled
+- GIVEN the user enables the "Deelnames" filter toggle
+- WHEN the view is fetched
+- THEN the request MUST include `include_deelnames_gebruik=true`
+- AND the request MUST include `include_modules=true`
+
+#### Scenario: Product filter is enabled
+- GIVEN the user enables the "Product" filter toggle
+- WHEN the view is fetched
+- THEN the request MUST include `include_products=true`
+
+#### Scenario: No filters are enabled
+- GIVEN all filter toggles are disabled
+- WHEN the view is fetched
+- THEN the request MUST NOT include any enrichment parameters
+- AND the response MUST contain only the base GEMMA view (viewNodes and viewRelationships from the ArchiMate import)
+
+#### Scenario: Multiple filters enabled simultaneously
+- GIVEN the user enables both "Gebruik" and "Deelnames" toggles
+- WHEN the view is fetched
+- THEN the request MUST include `include_gebruik=true`, `include_deelnames_gebruik=true`, and `include_modules=true`
+- AND the response MUST contain base GEMMA nodes plus both owned and deelnames module overlay nodes
+
+### Requirement: Enrichment API MUST return standard viewNode format
+The enrichment API MUST return module overlay nodes in the same format as base GEMMA viewNodes so the frontend rendering pipeline requires no structural changes.
+
+#### Scenario: Enriched response contains module nodes
+- GIVEN a view is requested with `include_modules=true`
+- WHEN the active organization has modules linked to referentiecomponenten on this view
+- THEN the response `viewNodes` array MUST contain additional entries for each module-referentiecomponent match
+- AND each module node MUST have `viewNodeId`, `modelNodeId`, `name`, `type`, `x`, `y`, `width`, `height`, `parent`, `color`, `borderColor` fields
+- AND each module node MUST have `parent` set to the matching referentiecomponent's `viewNodeId`
+- AND each module node MUST have `_isModuleExpansion` set to `true`
+
+#### Scenario: No matching modules exist
+- GIVEN a view is requested with `include_modules=true`
+- WHEN the active organization has no modules matching referentiecomponenten on this view
+- THEN the response MUST contain only the base viewNodes
+- AND no error MUST be returned
+
+#### Scenario: Module node positioning is calculated server-side
+- GIVEN referentiecomponent R1 at position (100, 200) with size (300, 150)
+- AND 3 modules are mapped to R1
+- WHEN the enrichment API generates module overlay nodes
+- THEN each module node MUST have `x`, `y`, `width`, `height` values that fit within R1's bounds
+- AND the 3 modules MUST be stacked vertically without overlap
+- AND module width MUST match R1's width minus padding
+
+#### Scenario: Deelnames module nodes include type marker
+- GIVEN a view is requested with `include_deelnames_gebruik=true`
+- WHEN deelnames gebruiksobjecten match referentiecomponenten on this view
+- THEN each deelnames module node MUST have `_type: "deelnames"`
+- AND each MUST have `_sourceOrganization` with the owning organization's name
+- AND each MUST have `_sourceOrganizationId` with the owning organization's UUID
+
+#### Scenario: Response includes metadata about enrichment
+- GIVEN a view is requested with enrichment parameters
+- WHEN the response is generated
+- THEN the response MUST include a `_enrichment` metadata object containing:
+  - `modules_count`: number of module overlay nodes added
+  - `deelnames_count`: number of deelnames overlay nodes added
+  - `organization`: the active organization's name and UUID
+  - `timestamp`: ISO 8601 timestamp of when the enrichment was computed
+
+### Requirement: Enrichment API MUST support organization context
+The enrichment API MUST know which organization to enrich for, either from the active organization setting or from a query parameter.
+
+#### Scenario: Active organization is used by default
+- GIVEN the softwarecatalog app has an active organization configured
+- WHEN `GET /softwarecatalog/api/views/{viewId}?include_modules=true` is called without an `organization` parameter
+- THEN the enrichment MUST use the active organization's UUID
+- AND module mappings MUST be fetched for that organization
+
+#### Scenario: Organization parameter overrides active organization
+- GIVEN `GET /softwarecatalog/api/views/{viewId}?include_modules=true&organization={uuid}` is called
+- WHEN the `organization` parameter is provided
+- THEN the enrichment MUST use the specified organization UUID
+- AND the active organization setting MUST be ignored for this request
+
+#### Scenario: No organization available returns base view only
+- GIVEN no active organization is configured AND no `organization` parameter is provided
+- WHEN `GET /softwarecatalog/api/views/{viewId}?include_modules=true` is called
+- THEN the response MUST return the base GEMMA view without any module enrichment
+- AND a warning header `X-Enrichment-Warning: no-organization` MUST be included
+
+### Requirement: Endpoint constants MUST be updated
+The frontend endpoint configuration MUST point to the softwarecatalog enrichment API.
+
+#### Scenario: GEMMA VIEW endpoint is configured
+- GIVEN the frontend endpoints constants file
+- WHEN the GEMMA.VIEW endpoint is resolved
+- THEN it MUST resolve to `/softwarecatalog/api/views/{id}`
+- AND the GEMMA.VIEWS endpoint MUST resolve to `/softwarecatalog/api/views`
+
+#### Scenario: Old OpenRegister view endpoint is removed
+- GIVEN the frontend endpoint constants
+- WHEN searching for view-related endpoint definitions
+- THEN no endpoint MUST reference `/openregister/api/objects/vng-gemma/view/`
+- AND all view-related fetches MUST use the softwarecatalog enrichment API
+
+#### Scenario: Endpoint supports query string parameters
+- GIVEN the enrichment API endpoint
+- WHEN the frontend appends filter parameters
+- THEN the URL MUST support query parameters like `?include_modules=true&include_gebruik=true&include_deelnames_gebruik=true`
+- AND the backend MUST parse all boolean query parameters correctly (accepting `true`, `1`, `yes`)
+
+### Requirement: Enrichment API MUST support caching
+The enrichment API MUST implement caching to avoid recomputing enrichment for unchanged data.
+
+#### Scenario: Repeated request returns cached response
+- GIVEN a view was fetched with the same parameters 30 seconds ago
+- AND no relevant data has changed
+- WHEN the same request is made again
+- THEN the response MUST be served from cache
+- AND the response time MUST be significantly faster than the first request
+
+#### Scenario: Cache is invalidated when module mappings change
+- GIVEN a cached enriched view for organization A
+- WHEN a module mapping is added or removed for organization A
+- THEN the cache for all views of organization A MUST be invalidated
+- AND the next request MUST recompute the enrichment
+
+#### Scenario: Cache key includes all relevant parameters
+- GIVEN enrichment requests with different parameter combinations
+- WHEN caching responses
+- THEN the cache key MUST include: viewId, organization UUID, include_modules, include_gebruik, include_deelnames_gebruik, include_products
+- AND different parameter combinations MUST NOT share cache entries
+
+#### Scenario: Cache respects TTL
+- GIVEN a cached enriched view
+- WHEN the cache TTL (default 5 minutes) expires
+- THEN the next request MUST recompute the enrichment
+- AND the stale cache entry MUST be replaced
+
+### Requirement: Enrichment API MUST return view relationships
+The enrichment API MUST include both base GEMMA relationships and any enrichment-specific relationships (e.g., specialization relationships between modules and referentiecomponenten).
+
+#### Scenario: Base relationships are included unchanged
+- GIVEN a view with 50 base GEMMA relationships
+- WHEN the enrichment API returns the view
+- THEN all 50 relationships MUST be present in the `viewRelationships` array
+- AND their structure MUST be identical to the raw OpenRegister response
+
+#### Scenario: Module enrichment adds specialization relationships
+- GIVEN 5 modules mapped to referentiecomponenten on a view
+- WHEN the enrichment API returns the view with `include_modules=true`
+- THEN the `viewRelationships` array MUST contain 5 additional specialization relationships
+- AND each relationship MUST link a module viewNode to its parent referentiecomponent viewNode
+
+#### Scenario: No enrichment returns only base relationships
+- GIVEN a view requested without enrichment parameters
+- WHEN the enrichment API returns the view
+- THEN the `viewRelationships` array MUST contain only base GEMMA relationships
+- AND no synthetic relationships MUST be added
+
+### Requirement: Enrichment API MUST handle concurrent requests
+The enrichment API MUST handle multiple simultaneous requests without data corruption or excessive resource usage.
+
+#### Scenario: Five users request the same view simultaneously
+- GIVEN 5 users request the same view with the same enrichment parameters at the same time
+- WHEN all requests are processed
+- THEN all 5 responses MUST be identical
+- AND the backend MUST NOT execute 5 separate enrichment computations (cache should serve 4 of 5)
+
+#### Scenario: Different organizations request the same view
+- GIVEN user A (organization Zeist) and user B (organization Utrecht) request the same view
+- WHEN both requests are processed concurrently
+- THEN user A's response MUST contain Zeist's module mappings
+- AND user B's response MUST contain Utrecht's module mappings
+- AND the responses MUST NOT be mixed
+
+### Requirement: Enrichment API response MUST include pagination metadata for large views
+For views with many nodes, the API MUST include metadata to help the frontend manage rendering.
+
+#### Scenario: Large view includes node count metadata
+- GIVEN a view with 500 base nodes and 200 module overlay nodes
+- WHEN the enrichment API returns the view
+- THEN the response MUST include `_meta.totalNodes` with value 700
+- AND `_meta.baseNodes` with value 500
+- AND `_meta.overlayNodes` with value 200
+
+#### Scenario: View response includes timing metadata
+- GIVEN an enrichment request
+- WHEN the response is generated
+- THEN `_meta.processingTimeMs` MUST indicate the server-side processing time in milliseconds
+- AND this value MUST help frontend developers identify slow enrichments
+
+### Requirement: Enrichment API MUST validate input parameters
+The API MUST validate all input parameters and return clear error messages for invalid input.
+
+#### Scenario: Invalid view ID format
+- GIVEN `GET /softwarecatalog/api/views/not-a-uuid?include_modules=true`
+- WHEN the request is processed
+- THEN the response MUST have status 400
+- AND the error message MUST indicate the view ID format is invalid
+
+#### Scenario: Invalid organization UUID
+- GIVEN `GET /softwarecatalog/api/views/{viewId}?organization=invalid`
+- WHEN the request is processed
+- THEN the response MUST have status 400
+- AND the error message MUST indicate the organization UUID is invalid
+
+#### Scenario: Unknown query parameter is ignored
+- GIVEN `GET /softwarecatalog/api/views/{viewId}?include_modules=true&unknown_param=true`
+- WHEN the request is processed
+- THEN the `unknown_param` MUST be silently ignored
+- AND the response MUST be generated normally with module enrichment
+
+## MODIFIED Requirements
+
+_None -- this is a new capability._
+
+## REMOVED Requirements
+
+_None._
+
+## Current Implementation Status
+- **Not yet implemented**: No view enrichment API exists in softwarecatalog or OpenCatalogi.
+- **Building blocks that exist**:
+  - OpenRegister ObjectService for fetching view, module, and gebruik objects
+  - Softwarecatalog app infrastructure (controllers, services, routes)
+  - Frontend endpoint constants configuration
+  - GEMMA view data model (viewNodes, viewRelationships, modelNodes)
+  - Filter toggle UI components in the softwarecatalog frontend
+- **Key gaps**:
+  - No ViewEnrichmentService or ViewEnrichmentController in softwarecatalog
+  - No enrichment API endpoint registered in routes
+  - No cache layer for enriched view data
+  - No module-to-referentiecomponent matching logic
+  - No overlay node position calculation
+  - Frontend still calls OpenRegister directly for view data
+
+## Dependencies
+- OpenRegister ObjectService (data queries for views, modules, gebruik)
+- Softwarecatalog app (hosts the enrichment endpoint)
+- `deelnames-gebruik` spec (deelnames query logic)
+- `module-overlay-rendering` spec (consumes the enriched data)

--- a/openspec/changes/view-enrichment-api/tasks.md
+++ b/openspec/changes/view-enrichment-api/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: view-enrichment-api
+
+## Task 1: Implementation planning
+- **Spec ref**: specs/view-enrichment-api/spec.md
+- **Status**: todo
+- **Acceptance criteria**: Requirements from spec are decomposed into implementable tasks

--- a/openspec/specs/org-archimate-export/spec.md
+++ b/openspec/specs/org-archimate-export/spec.md
@@ -1,0 +1,439 @@
+---
+status: implemented
+---
+
+# Organization-Specific ArchiMate Export Specification
+
+## Purpose
+Defines how the softwarecatalog app exports an organization-enriched ArchiMate (AMEFF) XML file that includes the base GEMMA model plus the organization's applications plotted on referentiecomponenten, with proper folder structure, naming, and metadata. Supports toggling data layers (modules, deelnames, gebruik) via query parameters and organises output into typed folders. The exported file is designed to import cleanly into Archi (the open-source ArchiMate modelling tool) and other AMEFF-compatible tools.
+
+## Context
+Organizations using the softwarecatalog map their applications to GEMMA referentiecomponenten. This export feature lets them download a complete ArchiMate model that includes both the national GEMMA standard and their organization-specific application landscape. The exported XML follows the ArchiMate Model Exchange File Format (AMEFF) specification and can be opened in tools like Archi for further analysis, reporting, and architecture governance.
+
+**Relation to existing specs:**
+- `view-enrichment-api`: Uses similar module-to-referentiecomponent matching logic, but this spec outputs XML instead of JSON
+- `deelnames-gebruik`: Provides deelnames data that can optionally be included in the export
+- `module-overlay-rendering`: The visual equivalent of what this spec produces in XML form
+
+**Technical foundation:**
+- Output format: ArchiMate Model Exchange File Format (AMEFF) XML
+- Base model: VNG GEMMA reference architecture (imported from official AMEFF file)
+- Added elements: ApplicationComponent elements for organization modules
+- Added relationships: SpecializationRelationship linking modules to referentiecomponenten
+- Added views: Copies of qualifying GEMMA views with module nodes plotted
+
+## Requirements
+
+### Requirement: Export MUST produce valid ArchiMate XML with organization applications
+The organization export MUST generate a valid AMEFF XML file that includes all base GEMMA objects plus synthesized application elements, specialization relationships, enriched view copies, and organization folder structure.
+
+#### Scenario: Organization with mapped applications exports successfully
+- GIVEN an organization "Zeist" with 10 modules mapped to referentiecomponenten
+- WHEN the organization export is requested for "Zeist"
+- THEN the response MUST be a valid ArchiMate XML file
+- AND the file MUST contain all base GEMMA elements, relationships, and property definitions
+- AND the file MUST contain 10 additional `<element>` entries for the applications
+- AND the file MUST contain specialization relationships linking each application to its referentiecomponent
+- AND the file MUST import into Archi without errors
+
+#### Scenario: Organization with no mapped applications
+- GIVEN an organization "EmptyOrg" with 0 modules mapped to referentiecomponenten
+- WHEN the organization export is requested for "EmptyOrg"
+- THEN the response MUST be a valid ArchiMate XML file containing only the base GEMMA objects
+- AND no SWC-specific elements, relationships, or view copies MUST be added
+- AND no error MUST be returned
+
+#### Scenario: Export preserves all base GEMMA data
+- GIVEN the base GEMMA model with 2000 elements and 1500 relationships
+- WHEN any organization export is generated
+- THEN all 2000 base elements MUST be present in the output
+- AND all 1500 base relationships MUST be present
+- AND all base views, property definitions, and organization folders MUST be preserved
+- AND no base GEMMA data MUST be modified or omitted
+
+#### Scenario: Export XML is well-formed and schema-valid
+- GIVEN any organization export
+- WHEN the XML output is validated
+- THEN it MUST be well-formed XML (parseable without errors)
+- AND it MUST conform to the ArchiMate 3.x AMEFF XML schema
+- AND the XML declaration MUST specify UTF-8 encoding
+
+#### Scenario: Large organization export completes within timeout
+- GIVEN an organization with 200 modules mapped to referentiecomponenten across 50 views
+- WHEN the export is requested
+- THEN the export MUST complete within 30 seconds
+- AND the response MUST be streamed (not buffered entirely in memory) for files over 10MB
+
+### Requirement: Application elements MUST be ApplicationComponent type with Bron property
+Each organization application MUST be exported as an ArchiMate `<element>` with `xsi:type="ApplicationComponent"`, a unique identifier, and a `Bron=Softwarecatalogus` property.
+
+#### Scenario: Application element has correct structure
+- GIVEN a module "Topdesk" belonging to organization "Zeist"
+- WHEN the organization export is generated
+- THEN the XML MUST contain an element like `<element identifier="id-swc-app-{uuid}" xsi:type="ApplicationComponent">`
+- AND the element MUST have a `<name>` child with value "Topdesk"
+- AND the element MUST have a `<properties>` section with `Bron` property set to "Softwarecatalogus"
+
+#### Scenario: Application element has unique SWC identifier
+- GIVEN two modules "Topdesk" and "Key2Financien"
+- WHEN the organization export is generated
+- THEN each application element MUST have a unique `identifier` attribute prefixed with `id-swc-app-`
+- AND the identifiers MUST NOT collide with any existing GEMMA element identifiers
+
+#### Scenario: Application element identifier is deterministic
+- GIVEN a module "Topdesk" with UUID "abc-123"
+- WHEN the export is generated twice
+- THEN the element identifier MUST be the same both times (e.g., `id-swc-app-abc-123`)
+- AND importing the same export twice into Archi MUST not create duplicate elements
+
+#### Scenario: Application element name handles special XML characters
+- GIVEN a module named "R&D Tool <v2>"
+- WHEN the organization export is generated
+- THEN the `<name>` element MUST properly escape XML special characters
+- AND the output MUST contain `R&amp;D Tool &lt;v2&gt;`
+
+### Requirement: SpecializationRelationship MUST link applications to referentiecomponenten
+Each application-to-referentiecomponent mapping MUST produce a `<relationship>` of type `SpecializationRelationship` in the export.
+
+#### Scenario: Application mapped to one referentiecomponent
+- GIVEN module "Topdesk" is mapped to referentiecomponent "Zaakregistratiecomponent"
+- WHEN the organization export is generated
+- THEN the XML MUST contain a `<relationship xsi:type="SpecializationRelationship">` with `source` pointing to the Topdesk application element and `target` pointing to the Zaakregistratiecomponent element
+- AND the relationship MUST have a unique identifier prefixed with `id-swc-rel-`
+- AND the relationship MUST have the `Bron=Softwarecatalogus` property
+
+#### Scenario: Application mapped to multiple referentiecomponenten
+- GIVEN module "SAP" is mapped to 3 referentiecomponenten
+- WHEN the organization export is generated
+- THEN the XML MUST contain 3 separate SpecializationRelationship elements, one per mapping
+- AND each relationship MUST have a unique identifier
+
+#### Scenario: Relationship identifiers are deterministic
+- GIVEN module "Topdesk" mapped to "Zaakregistratiecomponent"
+- WHEN the export is generated twice
+- THEN the relationship identifier MUST be identical both times
+- AND the relationship MUST NOT create duplicates on re-import
+
+#### Scenario: Relationship source and target reference valid elements
+- GIVEN a module-to-referentiecomponent relationship
+- WHEN the XML is validated
+- THEN the `source` attribute MUST reference an existing `<element>` identifier in the same file
+- AND the `target` attribute MUST reference an existing `<element>` identifier in the same file
+
+### Requirement: Views MUST be copied with applications plotted inside referentiecomponenten
+The export MUST create copies of qualifying GEMMA views and inject application nodes as children of their mapped referentiecomponent nodes.
+
+#### Scenario: View with applications plotted on referentiecomponenten
+- GIVEN a GEMMA view "BBN poster" with referentiecomponent node "Zaakregistratiecomponent"
+- AND module "Topdesk" is mapped to "Zaakregistratiecomponent"
+- WHEN the organization export is generated
+- THEN the export MUST contain a copy of the "BBN poster" view with a new identifier prefixed with `id-swc-view-`
+- AND the copied view MUST contain a child `<node>` inside the "Zaakregistratiecomponent" node with `elementRef` pointing to the "Topdesk" application element
+- AND a `<connection>` element MUST be added for the specialization relationship between "Topdesk" and "Zaakregistratiecomponent"
+
+#### Scenario: Multiple applications stacked inside one referentiecomponent
+- GIVEN referentiecomponent "Zaakregistratiecomponent" has 3 mapped applications
+- WHEN the organization export is generated
+- THEN the referentiecomponent node MUST contain 3 child `<node>` elements
+- AND each child node MUST have positioning attributes (`x`, `y`, `w`, `h`) that fit within the parent node bounds
+- AND the child nodes MUST be stacked vertically without overlapping
+
+#### Scenario: Application appears in multiple referentiecomponenten across views
+- GIVEN module "Topdesk" is mapped to 2 referentiecomponenten that appear on 3 views
+- WHEN the organization export is generated
+- THEN each view copy MUST contain child nodes for "Topdesk" inside each occurrence of its mapped referentiecomponenten
+- AND each child node MUST have a unique identifier
+
+#### Scenario: View without any matching referentiecomponenten
+- GIVEN a view that contains no referentiecomponenten with mapped applications
+- WHEN the organization export is generated
+- THEN the view copy MUST be included unchanged (no child nodes added)
+- AND the view copy MUST still have the new identifier and name
+
+#### Scenario: Original GEMMA views are preserved unchanged
+- GIVEN the base GEMMA model contains view "BBN poster"
+- WHEN the organization export is generated
+- THEN the original "BBN poster" view MUST remain in the export unchanged
+- AND the enriched copy MUST be a separate view with a different identifier
+- AND both views MUST coexist in the XML
+
+### Requirement: View copies MUST use Titel view SWC property for naming
+Copied views MUST be named using the `Titel view SWC` property from the original view combined with the organization name.
+
+#### Scenario: View has Titel view SWC property
+- GIVEN a GEMMA view with property `Titel view SWC` = "Applicatieservices bestuur"
+- AND the organization name is "Zeist"
+- WHEN the organization export is generated
+- THEN the copied view's `<name>` MUST be "Applicatieservices bestuur Zeist"
+
+#### Scenario: View without Titel view SWC property
+- GIVEN a GEMMA view named "BBN poster" without a `Titel view SWC` property
+- AND the organization name is "Zeist"
+- WHEN the organization export is generated
+- THEN the copied view's `<name>` MUST fall back to the original view name plus organization name: "BBN poster Zeist"
+
+#### Scenario: View name handles long organization names
+- GIVEN a GEMMA view with property `Titel view SWC` = "Applicatieservices bestuur"
+- AND the organization name is "Samenwerkingsverband Regio Eindhoven"
+- WHEN the organization export is generated
+- THEN the full name "Applicatieservices bestuur Samenwerkingsverband Regio Eindhoven" MUST be used
+- AND the name MUST NOT be truncated
+
+### Requirement: SWC objects MUST be organized in typed folders
+All SWC-added elements MUST be placed in organisation folders within the `<organizations>` section, separated by relationship type.
+
+#### Scenario: Organisation folders created with typed subfolders
+- GIVEN an organization export for "Zeist" with modules, deelnames, and gebruik enabled
+- AND Zeist has own modules, deelname modules, and relationships/views
+- WHEN the XML is generated
+- THEN the `<organizations>` section MUST contain a top-level item with label "Zeist"
+- AND under it, a subfolder with label `Gebruikt (Softwarecatalogus)` referencing the org's own application elements
+- AND a subfolder with label `Aangeboden (Softwarecatalogus)` referencing applications the org provides
+- AND a subfolder with label `Deelnames (Softwarecatalogus)` referencing deelname application elements
+- AND a subfolder with label `Relaties (Softwarecatalogus)` referencing all SWC relationship elements
+- AND a subfolder with label `Views (Softwarecatalogus)` referencing all SWC view copies
+
+#### Scenario: Empty folders are omitted
+- GIVEN organisation "Zeist" has modules but no deelnames and no aangeboden
+- WHEN the export is generated with all parameters enabled
+- THEN the `Gebruikt (Softwarecatalogus)` folder MUST be present with application references
+- AND the `Deelnames (Softwarecatalogus)` folder MUST NOT appear
+- AND the `Aangeboden (Softwarecatalogus)` folder MUST NOT appear
+
+#### Scenario: Only deelnames enabled produces only deelnames folder
+- GIVEN organisation "Zeist" has deelname gebruik
+- WHEN the export is generated with only `?deelnames=true`
+- THEN only the `Deelnames (Softwarecatalogus)` folder MUST appear under the org
+- AND the `Gebruikt (Softwarecatalogus)` folder MUST NOT appear
+
+#### Scenario: Folder item references are valid
+- GIVEN the `Gebruikt (Softwarecatalogus)` folder contains 10 application references
+- WHEN the XML is validated
+- THEN each `<item>` in the folder MUST have an `identifierRef` pointing to a valid `<element>` identifier
+- AND no orphaned references MUST exist
+
+### Requirement: File and model MUST follow naming convention
+The export file name and ArchiMate model name MUST include the organization name and export date.
+
+#### Scenario: File name includes date and organization
+- GIVEN the organization name is "Zeist"
+- AND the current date is 17-02-2026
+- WHEN the organization export is generated
+- THEN the Content-Disposition header MUST set the filename to `17-02-2026_Softwarecatalogus_AMEFF_export_Zeist.xml`
+
+#### Scenario: Model name includes organization
+- GIVEN the organization name is "Zeist"
+- WHEN the organization export is generated
+- THEN the root `<model>` element's `<name>` MUST be "Softwarecatalogus Zeist"
+
+#### Scenario: File name sanitizes special characters in organization name
+- GIVEN an organization name "Gemeente 's-Hertogenbosch"
+- WHEN the organization export is generated
+- THEN the filename MUST sanitize special characters: `17-02-2026_Softwarecatalogus_AMEFF_export_Gemeente_s-Hertogenbosch.xml`
+- AND the model `<name>` MUST preserve the original name: "Softwarecatalogus Gemeente 's-Hertogenbosch"
+
+### Requirement: API endpoint MUST accept organization UUID and return XML download
+The export MUST be triggered via `GET /api/archimate/export/organization/{organizationUuid}` with the organization UUID as a path parameter and optional boolean query parameters.
+
+#### Scenario: Valid organization UUID provided
+- GIVEN a valid organization UUID "uuid-123"
+- WHEN `GET /api/archimate/export/organization/uuid-123` is called
+- THEN the response MUST have status 200
+- AND Content-Type MUST be `application/xml`
+- AND Content-Disposition MUST include `attachment; filename="..."`
+- AND the body MUST contain valid ArchiMate XML
+
+#### Scenario: Valid organization UUID with query parameters
+- GIVEN a valid organization UUID "uuid-123"
+- WHEN `GET /api/archimate/export/organization/uuid-123?modules=true&deelnames=true` is called
+- THEN the response MUST have status 200
+- AND the XML MUST include both module and deelname data
+
+#### Scenario: Non-existent organization UUID
+- GIVEN a UUID that does not match any organization
+- WHEN `GET /api/archimate/export/organization/uuid-invalid` is called
+- THEN the response MUST have status 404
+- AND the response MUST contain error message "Organization not found"
+
+#### Scenario: Unauthenticated request is rejected
+- GIVEN no authentication credentials
+- WHEN `GET /api/archimate/export/organization/uuid-123` is called
+- THEN the response MUST have status 401
+- AND no XML data MUST be returned
+
+#### Scenario: Non-admin user is rejected
+- GIVEN a non-admin authenticated user
+- WHEN `GET /api/archimate/export/organization/uuid-123` is called
+- THEN the response MUST have status 403
+- AND the response MUST indicate insufficient permissions
+
+### Requirement: Bron property definition MUST be added to the model
+The export MUST include a `<propertyDefinition>` for "Bron" so that the `Bron=Softwarecatalogus` property on SWC objects references a valid definition.
+
+#### Scenario: Bron property definition does not already exist
+- GIVEN the base GEMMA model does not have a "Bron" property definition
+- WHEN the organization export is generated
+- THEN the XML MUST contain a `<propertyDefinition identifier="id-swc-propdef-bron">` with name "Bron" in the `<propertyDefinitions>` section
+
+#### Scenario: Bron property definition already exists
+- GIVEN the base GEMMA model already has a "Bron" property definition
+- WHEN the organization export is generated
+- THEN the existing property definition MUST be reused
+- AND a duplicate MUST NOT be created
+
+#### Scenario: Bron property references are valid
+- GIVEN SWC elements and relationships with `Bron=Softwarecatalogus` properties
+- WHEN the XML is validated
+- THEN each `<property>` element's `propertyDefinitionRef` MUST point to a valid `<propertyDefinition>` identifier
+
+### Requirement: Connection elements MUST be created for plotted applications
+Each application node plotted inside a referentiecomponent MUST have a corresponding `<connection>` element in the view linking it via the specialization relationship.
+
+#### Scenario: Connection links application node to referentiecomponent node
+- GIVEN application node "Topdesk" plotted inside referentiecomponent node "Zaakregistratiecomponent"
+- AND a SpecializationRelationship exists between them
+- WHEN the view copy is generated
+- THEN a `<connection>` element MUST be added to the view with `relationshipRef` pointing to the SpecializationRelationship identifier
+- AND `source` pointing to the application node identifier
+- AND `target` pointing to the referentiecomponent node identifier
+
+#### Scenario: Connection identifiers are unique
+- GIVEN 10 application nodes plotted across 3 views
+- WHEN the export is generated
+- THEN each `<connection>` element MUST have a unique `identifier` attribute
+- AND identifiers MUST be deterministic (same on repeated exports)
+
+#### Scenario: Connection without matching relationship is not created
+- GIVEN an application node that has no SpecializationRelationship in the model
+- WHEN the view copy is generated
+- THEN no `<connection>` element MUST be created for this node
+- AND a warning MUST be logged about the missing relationship
+
+### Requirement: Export MUST include deelname data when deelnames parameter is enabled
+When the `deelnames` query parameter is `true`, the export MUST query gebruik objects where the current organisation's UUID appears in the `deelnemers` field (with RBAC disabled) and include those applications in the output.
+
+#### Scenario: Organisation has deelname gebruik
+- GIVEN organisation "Zeist" appears in the `deelnemers` field of 5 gebruik objects owned by other organisations
+- WHEN the export is requested with `?deelnames=true`
+- THEN the XML MUST contain application elements for the 5 deelname modules
+- AND specialization relationships MUST link each deelname application to its referentiecomponent
+- AND the deelname applications MUST be placed in the `Deelnames (Softwarecatalogus)` folder
+
+#### Scenario: Organisation has no deelname gebruik
+- GIVEN organisation "EmptyDeelnames" does not appear in any other organisation's `deelnemers` field
+- WHEN the export is requested with `?deelnames=true`
+- THEN the XML MUST still be valid
+- AND the `Deelnames (Softwarecatalogus)` folder MUST NOT appear in the output
+- AND no error MUST be returned
+
+#### Scenario: Deelnames parameter is not set
+- GIVEN organisation "Zeist" has deelname gebruik
+- WHEN the export is requested without the `deelnames` parameter (or `deelnames=false`)
+- THEN the XML MUST NOT contain any deelname application elements
+- AND no deelname query MUST be executed
+
+#### Scenario: Deelname applications have distinct identifiers
+- GIVEN organisation "Zeist" has both owned and deelname modules with the same name "Topdesk"
+- WHEN the export is generated with `?modules=true&deelnames=true`
+- THEN the owned "Topdesk" element MUST have identifier `id-swc-app-{owned-uuid}`
+- AND the deelname "Topdesk" element MUST have identifier `id-swc-app-{deelname-uuid}`
+- AND both MUST be distinct elements in the XML
+
+### Requirement: Deelname query MUST use RBAC-disabled ObjectService search
+Deelname gebruik objects are owned by other organisations. The query MUST bypass RBAC to find records where the current organisation appears in the `deelnemers` array.
+
+#### Scenario: Deelname query filters on deelnemers field
+- GIVEN organisation "Zeist" with UUID "uuid-zeist"
+- WHEN the deelname query is executed
+- THEN ObjectService.searchObjects MUST be called with `_rbac: false` and `_multitenancy: false`
+- AND the query MUST contain `'deelnemers' => 'uuid-zeist'`
+- AND the query MUST target the gebruik schema in the voorzieningen register
+
+#### Scenario: Deelname query handles no results gracefully
+- GIVEN an organisation with no deelname usage
+- WHEN the deelname query returns empty results
+- THEN the export MUST continue without deelname data
+- AND no error MUST be logged for empty results
+
+### Requirement: Export MUST support query parameters for toggling data layers
+The GET endpoint MUST accept boolean query parameters that control which data is included in the export.
+
+#### Scenario: All parameters enabled
+- GIVEN a valid organisation UUID
+- WHEN the export is requested with `?modules=true&deelnames=true&gebruik=true`
+- THEN the XML MUST contain module application elements in `Gebruikt (Softwarecatalogus)` folder
+- AND deelname application elements in `Deelnames (Softwarecatalogus)` folder
+- AND gebruik data MUST be included
+- AND all corresponding relationships and view enrichments MUST be present
+
+#### Scenario: No parameters provided (default behavior)
+- GIVEN a valid organisation UUID
+- WHEN the export is requested without any query parameters
+- THEN the export MUST behave as if `modules=true` (current default behavior)
+- AND deelnames and gebruik data MUST NOT be included
+
+#### Scenario: Only deelnames enabled
+- GIVEN a valid organisation UUID
+- WHEN the export is requested with `?deelnames=true`
+- THEN the XML MUST contain only deelname application elements
+- AND module elements from the organisation's own gebruik MUST NOT be included
+
+#### Scenario: Boolean parameters accept various truthy values
+- GIVEN a valid organisation UUID
+- WHEN the export is requested with `?modules=1&deelnames=yes&gebruik=TRUE`
+- THEN all three data layers MUST be included
+- AND the API MUST treat `1`, `yes`, `true`, `TRUE` as truthy values
+
+### Requirement: Frontend MUST provide organization export with data layer toggles
+The ArchiMate settings section MUST include checkboxes for selecting which data layers to include, and trigger the export via the GET endpoint.
+
+#### Scenario: User triggers organization export with toggles
+- GIVEN the user is on the ArchiMate settings page
+- AND an organization is selected in the organization dropdown
+- AND the "Modules" checkbox is checked
+- AND the "Deelnames" checkbox is checked
+- WHEN the user clicks the "Organization Export" button
+- THEN the frontend MUST call `GET /api/archimate/export/organization/{uuid}?modules=true&deelnames=true`
+- AND the browser MUST download the resulting XML file
+
+#### Scenario: No organization selected
+- GIVEN the user is on the ArchiMate settings page
+- AND no organization is selected in the dropdown
+- WHEN the user attempts to click the export button
+- THEN the button MUST be disabled or show a message requiring organization selection
+
+#### Scenario: Default checkbox state
+- GIVEN the user navigates to the ArchiMate settings page
+- THEN the "Modules" checkbox MUST be checked by default
+- AND the "Deelnames" checkbox MUST be unchecked by default
+- AND the "Gebruik" checkbox MUST be unchecked by default
+
+#### Scenario: Export button shows loading state during download
+- GIVEN the user clicks the export button
+- WHEN the download request is in progress
+- THEN the export button MUST show a loading indicator (spinner or disabled state)
+- AND the button MUST return to normal state when the download completes or fails
+
+## MODIFIED Requirements
+
+_None._
+
+## REMOVED Requirements
+
+_None._
+
+## Current Implementation Status
+- **Partially implemented**: The softwarecatalog app has an ArchiMate export controller, but deelnames and data layer toggles are not yet implemented.
+- **Key gaps**:
+  - No deelnames data layer in the export
+  - No typed organization folders (Gebruikt, Aangeboden, Deelnames)
+  - No frontend data layer toggle checkboxes
+  - No boolean parameter parsing for truthy values
+  - No file name sanitization for special characters
+
+## Dependencies
+- VNG GEMMA ArchiMate model (base AMEFF XML)
+- OpenRegister ObjectService (module and gebruik data)
+- `deelnames-gebruik` spec (deelnames query logic)
+- Softwarecatalog app (hosts the export endpoint)
+- ArchiMate 3.x AMEFF XML schema (validation target)


### PR DESCRIPTION
## Summary

Receive 1 spec + 3 in-flight changes from `ConductionNL/opencatalogi` that the 2026-05-24 fleet coverage scan identified as misfiled — they explicitly describe softwarecatalog features but were carried under opencatalogi/openspec/.

**Moving in:**
- `openspec/specs/org-archimate-export/` — 14 REQs. Spec Purpose literally reads "Defines how the softwarecatalog app exports an organization-enriched ArchiMate (AMEFF) XML file…"
- `openspec/changes/deelnames-gebruik/` — GEMMA participations visualization
- `openspec/changes/module-overlay-rendering/` — JointJS module overlay on GEMMA views
- `openspec/changes/view-enrichment-api/` — backend API enriching GEMMA view data with module/gebruik/org info

## Evidence the moves are correct

- `grep -r archimate softwarecatalog/lib/` returns 10 hits including `ArchiMateService.php`, `ArchiMateExportService.php`, `ViewController.php`, `ViewService.php`, 3 GEMMA XML reference files in `Settings/`
- `grep -r deelnames|moduleoverlay|viewenrichment opencatalogi/lib/` returns **zero** hits — opencatalogi has no implementation of any of these
- `git log --all` on the moved dirs traces back to a 2026-04 \"Restructure specs\" commit on opencatalogi; the GEMMA work was inadvertently parked there

## Coordinated PR

Paired with: https://github.com/ConductionNL/opencatalogi/pull/666

When both PRs land, run \`/opsx-coverage-scan softwarecatalog\` to verify the spec set wires up cleanly against existing softwarecatalog/lib/ code.

## Test plan

- [ ] Verify softwarecatalog/openspec/specs/org-archimate-export/spec.md is readable
- [ ] Verify each of the 3 changes has design.md + proposal.md + tasks.md + specs/<cap>/spec.md (where applicable)
- [ ] If `npx openspec validate --strict` is wired locally, run it
- [ ] After merge, re-run `/opsx-coverage-scan softwarecatalog` and confirm org-archimate-export REQs land in Bucket 1 (matched against ArchiMateService methods)

Refs #285