### PR TITLE
retrofit: reverse-spec concept-organizations-widget (1 REQ / 1 method)

### DIFF
--- a/lib/Dashboard/ConceptOrganisatiesWidget.php
+++ b/lib/Dashboard/ConceptOrganisatiesWidget.php
@@ -90,6 +90,8 @@ class ConceptOrganisatiesWidget implements IWidget
      * @return void
      *
      * @SuppressWarnings(PHPMD.StaticAccess)
+     *
+     * @spec openspec/changes/retrofit-2026-05-24-concept-organizations-widget/tasks.md#task-1
      */
     public function load(): void
     {

--- a/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/design.md
+++ b/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/design.md
@@ -1,0 +1,24 @@
+# Design — Retrofit Concept Organizations Widget
+
+Retrofit change. Tasks describe retroactive annotation, not new implementation work.
+
+## Context
+
+The dashboard widget already exists and is registered via `Application::register()`. Coverage scan bucketed `load()` as 2b and the metadata getters as `plumbing`. This change retro-specifies `load()` so the cluster moves to Bucket 1.
+
+## Decisions
+
+- **Cluster mode** — no existing capability covers dashboard widgets in softwarecatalog.
+- **1 REQ / 1 method** — the metadata getters are plumbing. Only `load()` carries an enforceable contract.
+- **Spec dependency order explicitly.** webpack's splitChunks produces these chunk names; the load order is what makes the widget work, not the chunk names. The REQ captures both.
+
+## Out of scope
+
+- Refactoring the widget to a single-bundle / dynamic-import shape — open a separate issue.
+- Removing the `softwarecatalog-` prefix or aligning with the openbuilt widget naming — out of scope.
+
+## References
+
+- Umbrella: ConductionNL/softwarecatalog#285
+- Coverage report: openspec/coverage-report.md (2026-05-24)
+- Source: lib/Dashboard/ConceptOrganisatiesWidget.php

--- a/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/proposal.md
+++ b/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/proposal.md
@@ -1,0 +1,14 @@
+# Retrofit — concept-organizations-widget
+
+Describes observed behavior of `ConceptOrganisatiesWidget::load()` as 1 new REQ under a new `concept-organizations-widget` capability. Code already exists — this change retroactively specifies it. The widget's IWidget metadata getters (`getId`, `getTitle`, `getOrder`, `getIconClass`, `getUrl`) are framework plumbing already bucketed as `plumbing`; only `load()` carries the actual loading contract.
+
+## Affected code units
+
+- lib/Dashboard/ConceptOrganisatiesWidget.php::load
+
+## Approach
+
+- Describe the bundle-loading order (runtime → vendor → nc-vue → widget) that the widget enforces via `Util::addScript` calls.
+- Note the dependency on webpack `splitChunks` + `runtimeChunk` config — the script names are not arbitrary.
+
+Source: openspec/coverage-report.md generated 2026-05-24. Umbrella: ConductionNL/softwarecatalog#285.

--- a/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/specs/concept-organizations-widget/spec.md
+++ b/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/specs/concept-organizations-widget/spec.md
@@ -1,0 +1,33 @@
+---
+status: draft
+retrofit: true
+---
+
+# Concept Organizations Widget Specification
+
+## Purpose
+
+Captures the asset-loading contract for the Concept Organisaties dashboard widget. The widget is mounted via Nextcloud's `IWidget` interface and contributes a Vue bundle to the dashboard page; its `load()` method MUST add the four split-chunk scripts in dependency order plus the shared widget stylesheet. Reverse-spec'd from existing code 2026-05-24.
+
+## ADDED Requirements
+
+### REQ-001: The widget SHALL load runtime, vendor, nc-vue, widget, and stylesheet assets in dependency order
+
+`ConceptOrganisatiesWidget::load()` MUST register, in this order: (1) the webpack runtime chunk `softwarecatalog-runtime`, (2) the shared vendor chunk `softwarecatalog-shared-vendor`, (3) the shared nc-vue chunk `softwarecatalog-shared-nc-vue`, (4) the widget entry chunk `softwarecatalog-conceptOrganisatiesWidget`. It MUST also register the `dashboardWidgets` stylesheet. All registrations MUST go through `OCP\Util::addScript` / `OCP\Util::addStyle` using `Application::APP_ID` as the application namespace.
+
+#### Scenario: All four scripts are registered in order
+- GIVEN the widget is invoked by the dashboard framework
+- WHEN `load()` executes
+- THEN `Util::addScript` MUST be called four times with file arguments `"<APP_ID>-runtime"`, `"<APP_ID>-shared-vendor"`, `"<APP_ID>-shared-nc-vue"`, `"<APP_ID>-conceptOrganisatiesWidget"` in that order
+- AND `Util::addStyle` MUST be called once with file argument `"dashboardWidgets"`
+
+#### Scenario: Application namespace is used
+- GIVEN `Application::APP_ID = "softwarecatalog"`
+- WHEN `load()` executes
+- THEN every `Util::addScript` / `Util::addStyle` call MUST use `"softwarecatalog"` as the `application` argument
+
+## Notes
+
+- **Dependency-order is load-bearing.** Runtime must come before vendor, vendor before nc-vue, nc-vue before the widget entry — this matches webpack's `splitChunks` + `runtimeChunk` output and the page would error on any other order.
+- **IWidget metadata getters** (`getId`, `getTitle`, `getOrder`, `getIconClass`, `getUrl`) are framework getters and are bucketed as `plumbing` in the coverage report. They are not part of this REQ.
+- **Acceptance Criteria:** Verified by loading the dashboard in a browser and confirming the widget renders (no JS errors in console). No unit coverage at retrofit time.

--- a/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/tasks.md
+++ b/openspec/changes/retrofit-2026-05-24-concept-organizations-widget/tasks.md
@@ -1,0 +1,3 @@
+# Tasks
+
+- [x] task-1: concept-organizations-widget#REQ-001 — Widget SHALL load runtime, vendor, nc-vue, widget, and stylesheet assets in dependency order (retroactive annotation)


### PR DESCRIPTION
## Retrofit — Reverse-Spec

Describes the asset-loading contract of `ConceptOrganisatiesWidget::load()` as 1 REQ under a new `concept-organizations-widget` capability.

Ghost change: `retrofit-2026-05-24-concept-organizations-widget`.

### What this PR does
- Drafts 1 REQ: load runtime, vendor, nc-vue, widget, stylesheet in dependency order
- Annotates `load()` with `@spec` tag
- Metadata getters (getId, getTitle, getOrder, getIconClass, getUrl) stay bucketed as plumbing

### What this PR does NOT do
- No code behavior changes — annotations only
- Does not refactor widget bundling (open issue if needed)

Source: \`openspec/coverage-report.md\` generated 2026-05-24 | Cluster: \`concept-organizations-widget\` (Bucket 2b)

Umbrella: #285