### PR TITLE
fix(security+nc34): symfony CVEs, \OC::$server accessors, array-shape bug

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -632,16 +632,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v6.4.32",
+            "version": "v6.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "99d7e101826e6610606b9433248f80c1997cd20b"
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/99d7e101826e6610606b9433248f80c1997cd20b",
-                "reference": "99d7e101826e6610606b9433248f80c1997cd20b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/2e3bf817ba9347341ab15926700fb6320367c0e1",
+                "reference": "2e3bf817ba9347341ab15926700fb6320367c0e1",
                 "shasum": ""
             },
             "require": {
@@ -692,7 +692,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.32"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v6.4.37"
             },
             "funding": [
                 {
@@ -712,20 +712,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:13:48+00:00"
+            "time": "2026-04-13T14:11:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -739,7 +739,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -772,7 +772,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -784,11 +784,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/http-client",
@@ -890,16 +894,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
-                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
                 "shasum": ""
             },
             "require": {
@@ -912,7 +916,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -948,7 +952,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -960,24 +964,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T11:18:49+00:00"
+            "time": "2026-03-06T13:17:50+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "01b846f48e53ee4096692a383637a1fa4d577301"
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/01b846f48e53ee4096692a383637a1fa4d577301",
-                "reference": "01b846f48e53ee4096692a383637a1fa4d577301",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/94fd44f3052e02340b0dd4447a7d7a5856e32da2",
+                "reference": "94fd44f3052e02340b0dd4447a7d7a5856e32da2",
                 "shasum": ""
             },
             "require": {
@@ -1028,7 +1036,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.4.34"
+                "source": "https://github.com/symfony/mailer/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -1048,25 +1056,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-24T09:34:36+00:00"
+            "time": "2026-05-19T20:33:22+00:00"
         },
         {
             "name": "symfony/mailjet-mailer",
-            "version": "v6.4.34",
+            "version": "v6.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailjet-mailer.git",
-                "reference": "1e9916fccea1c1c5dc57e938b0fcc9d292d44193"
+                "reference": "1b8100c96db52d48567d84b617afd90d87b9c760"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailjet-mailer/zipball/1e9916fccea1c1c5dc57e938b0fcc9d292d44193",
-                "reference": "1e9916fccea1c1c5dc57e938b0fcc9d292d44193",
+                "url": "https://api.github.com/repos/symfony/mailjet-mailer/zipball/1b8100c96db52d48567d84b617afd90d87b9c760",
+                "reference": "1b8100c96db52d48567d84b617afd90d87b9c760",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/mailer": "^5.4.21|^6.2.7|^7.0"
+            },
+            "conflict": {
+                "symfony/mime": "<6.2"
             },
             "require-dev": {
                 "symfony/http-client": "^5.4|^6.0|^7.0",
@@ -1098,7 +1109,7 @@
             "description": "Symfony Mailjet Mailer Bridge",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailjet-mailer/tree/v6.4.34"
+                "source": "https://github.com/symfony/mailjet-mailer/tree/v6.4.40"
             },
             "funding": [
                 {
@@ -1118,44 +1129,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-05T07:56:34+00:00"
+            "time": "2026-05-13T14:04:06+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.4.34",
+            "version": "v7.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2b32fbbe10b36a8379efab6e702ad8b917151839"
+                "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2b32fbbe10b36a8379efab6e702ad8b917151839",
-                "reference": "2b32fbbe10b36a8379efab6e702ad8b917151839",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/b198dd66c211c97119bcaaff7c13431dbbb5e470",
+                "reference": "b198dd66c211c97119bcaaff7c13431dbbb5e470",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-intl-idn": "^1.10",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "egulias/email-validator": "~3.0.0",
-                "phpdocumentor/reflection-docblock": "<3.2.2",
-                "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/mailer": "<5.4",
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/mailer": "<6.4",
                 "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1|^4",
                 "league/html-to-markdown": "^5.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.4|^7.0",
-                "symfony/property-access": "^5.4|^6.0|^7.0",
-                "symfony/property-info": "^5.4|^6.0|^7.0",
-                "symfony/serializer": "^6.4.3|^7.0.3"
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1187,7 +1198,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.4.34"
+                "source": "https://github.com/symfony/mime/tree/v7.4.12"
             },
             "funding": [
                 {
@@ -1207,7 +1218,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T17:01:23+00:00"
+            "time": "2026-05-20T07:20:23+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1294,7 +1305,7 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
@@ -1357,7 +1368,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1381,16 +1392,16 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -1442,7 +1453,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -1462,7 +1473,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1631,16 +1642,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
                 "shasum": ""
             },
             "require": {
@@ -1658,7 +1669,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -1694,7 +1705,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -1714,7 +1725,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-03-28T09:44:51+00:00"
         },
         {
             "name": "twig/twig",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -168,7 +168,9 @@ class Application extends App implements IBootstrap
                     return new HierarchyHandler(
                     _organizationHandler: $c->get('OCA\SoftwareCatalog\Service\SoftwareCatalogue\OrganizationHandler'),
                     _contactPersonHandler: $c->get('OCA\SoftwareCatalog\Service\SoftwareCatalogue\ContactPersonHandler'),
-                    _logger: $c->get(LoggerInterface::class)
+                    _logger: $c->get(LoggerInterface::class),
+                    _userManager: $c->get(IUserManager::class),
+                    _groupManager: $c->get(IGroupManager::class)
                     );
                 }
                 );
@@ -258,7 +260,8 @@ class Application extends App implements IBootstrap
                     request: $container->get('OCP\IRequest'),
                     container: $container,
                     appManager: $container->get('OCP\App\IAppManager'),
-                    logger: $container->get('Psr\Log\LoggerInterface')
+                    logger: $container->get('Psr\Log\LoggerInterface'),
+                    groupManager: $container->get(IGroupManager::class)
                     );
                 }
                 );
@@ -340,7 +343,8 @@ class Application extends App implements IBootstrap
                     container: $container,
                     logger: $container->get('Psr\Log\LoggerInterface'),
                     settingsService: $container->get(SettingsService::class),
-                    organisationService: $container->get(OpenRegisterOrganisationService::class)
+                    organisationService: $container->get(OpenRegisterOrganisationService::class),
+                    dbConnection: $container->get(IDBConnection::class)
                     );
                 }
                 );

--- a/lib/Service/ArchiMateImportService.php
+++ b/lib/Service/ArchiMateImportService.php
@@ -23,6 +23,7 @@ namespace OCA\SoftwareCatalog\Service;
 use OCA\OpenRegister\Service\ObjectService;
 use OCA\OpenRegister\Service\OrganisationService;
 use OCP\App\IAppManager;
+use OCP\IDBConnection;
 use OCP\IAppConfig;
 use OCP\IUserSession;
 use OCP\Files\IRootFolder;
@@ -165,6 +166,7 @@ class ArchiMateImportService
      * @param LoggerInterface     $logger              Logger service
      * @param SettingsService     $settingsService     Settings service for AMEF configuration.
      * @param OrganisationService $organisationService Organisation service.
+     * @param IDBConnection       $dbConnection        Database connection interface.
      */
     public function __construct(
         private readonly IAppConfig $config,
@@ -174,7 +176,8 @@ class ArchiMateImportService
         private readonly ContainerInterface $container,
         private readonly LoggerInterface $logger,
         private readonly SettingsService $settingsService,
-        private readonly OrganisationService $organisationService
+        private readonly OrganisationService $organisationService,
+        private readonly IDBConnection $dbConnection
     ) {
     }//end __construct()
 
@@ -1462,7 +1465,7 @@ class ArchiMateImportService
             }
 
             // Get database connection.
-            $connection = \OC::$server->getDatabaseConnection();
+            $connection = $this->dbConnection;
             $tableName  = 'oc_openregister_table_'.$registerId.'_'.$elementSchemaId;
 
             // Step 1: Build a mapping from ArchiMate identifier to database UUID for Standaarden.

--- a/lib/Service/OrganizationSyncService.php
+++ b/lib/Service/OrganizationSyncService.php
@@ -2494,6 +2494,7 @@ class OrganizationSyncService
                 ]
             );
 
+            /** @var array<string, mixed> $contactEntityObject */
             $contactEntityObject = $contactObject->getObject();
 
             // Skip if no organization reference.

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace OCA\SoftwareCatalog\Service;
 
 use OCP\IAppConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\App\IAppManager;
 use Psr\Container\ContainerInterface;
@@ -104,18 +105,20 @@ class SettingsService
     /**
      * SettingsService constructor
      *
-     * @param IAppConfig         $config     App configuration interface
-     * @param IRequest           $request    Request interface
-     * @param ContainerInterface $container  Container for dependency injection
-     * @param IAppManager        $appManager App manager interface
-     * @param LoggerInterface    $logger     Logger interface
+     * @param IAppConfig         $config       App configuration interface
+     * @param IRequest           $request      Request interface
+     * @param ContainerInterface $container    Container for dependency injection
+     * @param IAppManager        $appManager   App manager interface
+     * @param LoggerInterface    $logger       Logger interface
+     * @param IGroupManager      $groupManager Group manager interface
      */
     public function __construct(
         private readonly IAppConfig $config,
         private readonly IRequest $request,
         private readonly ContainerInterface $container,
         private readonly IAppManager $appManager,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly IGroupManager $groupManager
     ) {
         $this->appName = 'softwarecatalog';
     }//end __construct()
@@ -1629,7 +1632,7 @@ class SettingsService
             ];
 
             // Get the group manager.
-            $groupManager = \OC::$server->getGroupManager();
+            $groupManager = $this->groupManager;
 
             // Define the required groups (matching role-based system).
             $requiredGroups = [
@@ -1664,7 +1667,7 @@ class SettingsService
 
                 // Create the group.
                 $group = $groupManager->createGroup($groupId);
-                if ($group !== false) {
+                if ($group !== null) {
                     $result['created'][] = $groupId;
                     $this->logger->info("SettingsService: Created user group: {$groupId}");
                 } else {
@@ -1750,7 +1753,7 @@ class SettingsService
             $this->logger->info('Starting creation of required user groups');
 
             // Get the group manager.
-            $groupManager = \OC::$server->getGroupManager();
+            $groupManager = $this->groupManager;
 
             // Define the required groups (matching role-based system).
             $requiredGroups = [
@@ -1788,7 +1791,7 @@ class SettingsService
 
                 // Create the group.
                 $group = $groupManager->createGroup($groupId);
-                if ($group !== false) {
+                if ($group !== null) {
                     $createdGroups[] = $groupId;
                     $this->logger->info("Created user group: {$groupId}");
                 } else {
@@ -1847,7 +1850,7 @@ class SettingsService
         // Get group manager if possible.
         if ($this->appManager->isInstalled('user_management') === true) {
             try {
-                $groupManager = \OC::$server->getGroupManager();
+                $groupManager = $this->groupManager;
                 $allGroups    = $groupManager->search('');
 
                 foreach ($allGroups as $group) {

--- a/lib/Service/SoftwareCatalogue/ContactPersonHandler.php
+++ b/lib/Service/SoftwareCatalogue/ContactPersonHandler.php
@@ -1593,7 +1593,7 @@ class ContactPersonHandler
 
             // In Nextcloud, we can set this as a user preference or custom attribute.
             // Since there's no built-in manager field, we'll use preferences.
-            \OC::$server->getConfig()->setUserValue(
+            $this->config->setUserValue(
                 $username,
                 'softwarecatalog',
                 'manager',
@@ -1630,7 +1630,7 @@ class ContactPersonHandler
     public function getUserManager(string $username): ?string
     {
         try {
-            $manager = \OC::$server->getConfig()->getUserValue(
+            $manager = $this->config->getUserValue(
                 $username,
                 'softwarecatalog',
                 'manager',

--- a/lib/Service/SoftwareCatalogue/HierarchyHandler.php
+++ b/lib/Service/SoftwareCatalogue/HierarchyHandler.php
@@ -23,6 +23,8 @@ namespace OCA\SoftwareCatalog\Service\SoftwareCatalogue;
 
 use OCA\SoftwareCatalog\Service\SoftwareCatalogue\OrganizationHandler;
 use OCA\SoftwareCatalog\Service\SoftwareCatalogue\ContactPersonHandler;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -56,11 +58,15 @@ class HierarchyHandler
      * @param OrganizationHandler  $_organizationHandler  Organization handler
      * @param ContactPersonHandler $_contactPersonHandler Contact person handler
      * @param LoggerInterface      $_logger               Logger interface
+     * @param IUserManager         $_userManager          User manager interface
+     * @param IGroupManager        $_groupManager         Group manager interface
      */
     public function __construct(
         private readonly OrganizationHandler $_organizationHandler,
         private readonly ContactPersonHandler $_contactPersonHandler,
         private readonly LoggerInterface $_logger,
+        private readonly IUserManager $_userManager,
+        private readonly IGroupManager $_groupManager,
     ) {
     }//end __construct()
 
@@ -237,7 +243,7 @@ class HierarchyHandler
 
         try {
             // Get all users and check their managers.
-            $userManager = \OC::$server->getUserManager();
+            $userManager = $this->_userManager;
             $users       = $userManager->search('');
 
             foreach ($users as $user) {
@@ -271,14 +277,14 @@ class HierarchyHandler
     private function isUserBeheerder(string $username): bool
     {
         try {
-            $groupManager   = \OC::$server->getGroupManager();
+            $groupManager   = $this->_groupManager;
             $beheerderGroup = $groupManager->get('beheerder');
 
             if ($beheerderGroup === null) {
                 return false;
             }
 
-            $userManager = \OC::$server->getUserManager();
+            $userManager = $this->_userManager;
             $user        = $userManager->get($username);
 
             if ($user === null) {

--- a/lib/Service/SoftwareCatalogueService.php
+++ b/lib/Service/SoftwareCatalogueService.php
@@ -28,6 +28,9 @@ use OCA\SoftwareCatalog\Service\SymfonyEmailService;
 use Psr\Log\LoggerInterface;
 use Psr\Container\ContainerInterface;
 use OCP\App\IAppManager;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
 
 /**
  * Service for handling software catalog operations.
@@ -83,6 +86,9 @@ class SoftwareCatalogueService
      * @param LoggerInterface      $_logger               Logger interface.
      * @param ContainerInterface   $_container            Container interface.
      * @param IAppManager          $_appManager           App manager interface.
+     * @param IUserSession         $_userSession          User session interface.
+     * @param IUserManager         $_userManager          User manager interface.
+     * @param IGroupManager        $_groupManager         Group manager interface.
      */
     public function __construct(
         private readonly OrganizationHandler $_organizationHandler,
@@ -93,6 +99,9 @@ class SoftwareCatalogueService
         private readonly LoggerInterface $_logger,
         private readonly ContainerInterface $_container,
         private readonly IAppManager $_appManager,
+        private readonly IUserSession $_userSession,
+        private readonly IUserManager $_userManager,
+        private readonly IGroupManager $_groupManager,
     ) {
         $this->appName = 'softwarecatalog';
     }//end __construct()
@@ -1538,7 +1547,7 @@ class SoftwareCatalogueService
                 );
 
         // Check if we're in an anonymous context (no logged-in user).
-        $userSession = \OC::$server->getUserSession();
+        $userSession = $this->_userSession;
         $currentUser = $userSession->getUser();
 
             $currentUserValue = 'null';
@@ -2253,7 +2262,7 @@ class SoftwareCatalogueService
                     );
 
             // Get the user manager.
-            $userManager    = \OC::$server->getUserManager();
+            $userManager    = $this->_userManager;
             $activatedUsers = [];
             $failedUsers    = [];
 
@@ -2362,7 +2371,7 @@ class SoftwareCatalogueService
                     );
 
             // Get the user manager.
-            $userManager      = \OC::$server->getUserManager();
+            $userManager      = $this->_userManager;
             $deactivatedUsers = [];
             $failedUsers      = [];
 
@@ -2526,7 +2535,7 @@ class SoftwareCatalogueService
     private function getAdminGroupUsernames(): array
     {
         try {
-            $groupManager = \OC::$server->getGroupManager();
+            $groupManager = $this->_groupManager;
             $adminGroup   = $groupManager->get('admin');
 
             if ($adminGroup === null) {
@@ -2579,7 +2588,7 @@ class SoftwareCatalogueService
                     );
 
             // Get the group manager to access admin group users.
-            $groupManager = \OC::$server->getGroupManager();
+            $groupManager = $this->_groupManager;
             $adminGroup   = $groupManager->get('admin');
 
             if ($adminGroup === null) {


### PR DESCRIPTION
## Summary

This PR resolves three categories of code-quality and security findings from the fleet quality sweep:

**1. Symfony CVEs (security) — 4 advisories fixed**
- CVE-2026-45068 (symfony/mailer): Argument Injection via Sendmail dash-prefixed recipient
- CVE-2026-45754 (symfony/mailjet-mailer): Unauthenticated webhook event injection
- CVE-2026-45070 (symfony/mime): Email header injection via non-token characters
- CVE-2026-45067 (symfony/mime): CRLF injection via `Symfony\Component\Mime\Address`
- Bumped symfony/mailer → 6.4.40, symfony/mime → 7.4.12, symfony/mailjet-mailer → 6.4.40 via `composer update --with-all-dependencies`. `composer audit` returns clean.

**2. NC34 legacy `\OC::$server->get*()` accessors replaced (15 calls → constructor-injected interfaces)**
- `SoftwareCatalogueService`: injected `IUserSession`, `IUserManager`, `IGroupManager` (replaced `getUserSession()` ×1, `getUserManager()` ×2, `getGroupManager()` ×2)
- `SettingsService`: injected `IGroupManager` (replaced `getGroupManager()` ×3); also fixed two `$group !== false` checks that should be `!== null` (now that `IGroupManager::createGroup()` is properly typed)
- `HierarchyHandler`: injected `IUserManager`, `IGroupManager` (replaced `getUserManager()` ×2, `getGroupManager()` ×1)
- `ContactPersonHandler`: replaced `\OC::$server->getConfig()->setUserValue()` and `getUserValue()` with the already-injected `IConfig $config` (×2)
- `ArchiMateImportService`: injected `IDBConnection` (replaced `getDatabaseConnection()` ×1)
- `Application.php`: updated all explicit DI registrations to pass the new constructor params

**3. PHPStan array-shape bug in OrganizationSyncService**
- `lib/Service/OrganizationSyncService.php:2585-2586`: added `/** @var array<string, mixed> */` annotation on `$contactEntityObject` so PHPStan no longer narrows the type to `array{username: string}` after the `['username']` assignment, fixing the two "offset 'organisatie' does not exist" errors.

## Test plan

- [ ] `composer audit` returns no advisories
- [ ] `php -l` on all edited files — no syntax errors
- [ ] `vendor/bin/phpstan analyse` — the 2 OrganizationSyncService errors gone; no new errors introduced (SoftwareCatalogAdmin unused-property pre-exists)
- [ ] Deploy to test environment and run a contactpersoon create/update flow to verify DI wiring is correct