### PR TITLE
chore(spec): restore gate-16 coverage on BulkSyncDialog

### DIFF
--- a/src/modals/BulkSyncDialog.vue
+++ b/src/modals/BulkSyncDialog.vue
@@ -199,6 +199,11 @@ export default defineComponent({
 	},
 
 	watch: {
+		/**
+		 * Watch the open prop to reset sync state when dialog opens
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-fe-settings-ui/tasks.md#task-8
+		 */
 		open(value) {
 			if (value === true) {
 				this.syncCompleted = false
@@ -210,6 +215,8 @@ export default defineComponent({
 	methods: {
 		/**
 		 * Close the bulk sync dialog
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-fe-settings-ui/tasks.md#task-8
 		 */
 		closeBulkSyncDialog() {
 			this.syncCompleted = false
@@ -221,6 +228,8 @@ export default defineComponent({
 
 		/**
 		 * Reset sync state
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-fe-settings-ui/tasks.md#task-8
 		 */
 		resetSyncState() {
 			this.syncProgress = {
@@ -239,6 +248,8 @@ export default defineComponent({
 
 		/**
 		 * Start the bulk sync process
+		 *
+		 * @spec openspec/changes/retrofit-2026-05-26-fe-settings-ui/tasks.md#task-8
 		 */
 		async startBulkSync() {
 			this.bulkSyncLoading = true
@@ -268,7 +279,9 @@ export default defineComponent({
 
 		/**
 		 * Perform the bulk sync API call
+		 *
 		 * @return {Promise} API response
+		 * @spec openspec/changes/retrofit-2026-05-26-fe-settings-ui/tasks.md#task-8
 		 */
 		async performBulkSync() {
 			const response = await fetch('/index.php/apps/softwarecatalog/api/bulk-sync-standards', {


### PR DESCRIPTION
Adds @spec to the 5 BulkSyncDialog methods extracted from StatisticsOverview during the modal-isolation fix. gate-16 scoped=0.