### PR TITLE
fix: patch CVE-2026-46644 and OrganizationContactSyncJob missing constructor args

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1305,16 +1305,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -1368,7 +1368,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -1388,7 +1388,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -1477,16 +1477,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd"
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
-                "reference": "6b177d03d2eb04a6c9d01bab9818fb93a30ce7fd",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
                 "shasum": ""
             },
             "require": {
@@ -1538,7 +1538,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -1558,7 +1558,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-25T14:08:27+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php83",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -410,7 +410,9 @@ class Application extends App implements IBootstrap
                 function ($container) {
                     return new OrganizationContactSyncJob(
                     timeFactory: $container->get('OCP\AppFramework\Utility\ITimeFactory'),
-                    orgSyncService: $container->get(OrganizationSyncService::class)
+                    orgSyncService: $container->get(OrganizationSyncService::class),
+                    appManager: $container->get(IAppManager::class),
+                    logger: $container->get(LoggerInterface::class)
                     );
                 }
                 );

--- a/lib/Controller/AangebodenGebruikController.php
+++ b/lib/Controller/AangebodenGebruikController.php
@@ -86,7 +86,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
      */
     public function getGebruiksWhereAfnemer(): JSONResponse
     {
@@ -161,7 +161,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
      */
     public function getKoppelingenGebruikByUuid(string $uuid): JSONResponse
     {
@@ -251,7 +251,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
      */
     public function getAllGebruiksForAmbtenaar(): JSONResponse
     {
@@ -527,7 +527,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-1
      */
     public function getGebruiksWhereDeelnemers(): JSONResponse
     {
@@ -604,7 +604,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
      */
     public function setGebruikSelfToActiveOrg(string $gebruikId): JSONResponse
     {
@@ -710,7 +710,7 @@ class AangebodenGebruikController extends Controller
      *
      * @NoCSRFRequired
      * @PublicPage
-     * @spec            openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
+     * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
      */
     public function deleteGebruikAsAfnemer(string $gebruikId): JSONResponse
     {


### PR DESCRIPTION
## Summary

- **CVE-2026-46644**: Bumps `symfony/polyfill-intl-idn` from v1.37.0 → v1.38.1. The CVE (reported 2026-05-26) allowed `idn_to_ascii`/`idn_to_utf8` to accept `xn--` labels whose Punycode payload decodes to ASCII-only strings, enabling insecure host equivalence attacks. Affected versions: >=1.17.1,<1.38.1.
- **Constructor crash fix**: `Application.php` line 411 instantiated `OrganizationContactSyncJob` with only 2 of its 4 required constructor args — `IAppManager` and `LoggerInterface` were missing. Any background job invocation would throw a fatal `ArgumentCountError`. Both args are now fetched from the DI container.
- **Pre-existing PHPCS fix**: Auto-fixed 6 `@spec` tag indentation errors in `AangebodenGebruikController.php` (unrelated to this change's scope but encountered during the check).

## Quality checks

- `composer audit`: No vulnerabilities found (was: CVE-2026-46644)
- `phpstan analyse`: 0 errors
- `phpcs`: 0 errors on changed files