### PR TITLE
fix: gate 7 auth-critical endpoints + remove dormant plaintext-password email code

### DIFF
--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -264,7 +264,6 @@ class ContactpersonenController extends Controller
      *
      * @return JSONResponse Result of user creation.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -274,21 +273,30 @@ class ContactpersonenController extends Controller
      */
     public function convertToUser(string $contactpersoonId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Only admins and org-admins may create user accounts.
+        $isAdmin    = $this->groupManager->isAdmin($currentUser->getUID());
+        $isOrgAdmin = $this->groupManager->isInGroup($currentUser->getUID(), 'gebruik-beheerder')
+            || $this->groupManager->isInGroup($currentUser->getUID(), 'aanbod-beheerder');
+        if ($isAdmin === false && $isOrgAdmin === false) {
+            return new JSONResponse(['message' => 'Insufficient permissions'], Http::STATUS_FORBIDDEN);
         }
 
         try {
             // Get object service.
             $objectService = \OC::$server->get('OCA\OpenRegister\Service\ObjectService');
 
-            // Find the contactpersoon object.
+            // Find the contactpersoon object — bind to current tenant.
             $contactpersoonObject = $objectService->find(
                 id: $contactpersoonId,
                 register: 'voorzieningen',
                 schema: 'contactpersoon',
-                _rbac: false,
-                _multitenancy: false
+                _rbac: true,
+                _multitenancy: true
             );
 
             if ($contactpersoonObject === null) {
@@ -493,8 +501,12 @@ class ContactpersonenController extends Controller
     /**
      * Change user password.
      *
-     * @param string $username    The username.
-     * @param string $newPassword The new password.
+     * Admins may change any user's password. Regular users may only change their
+     * own password, and must supply the current password for confirmation.
+     *
+     * @param string $username        The username.
+     * @param string $newPassword     The new password.
+     * @param string $currentPassword The current password (required for self-service resets).
      *
      * @return JSONResponse Result of password change.
      *
@@ -502,11 +514,45 @@ class ContactpersonenController extends Controller
      * @NoCSRFRequired
      * @spec            openspec/changes/retrofit-2026-05-26-contactpersonen-api/tasks.md#task-3
      */
-    public function changePassword(string $username, string $newPassword): JSONResponse
+    public function changePassword(string $username, string $newPassword, string $currentPassword=''): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
+
+        $isAdmin     = $this->groupManager->isAdmin($currentUser->getUID());
+        $isSelfReset = $currentUser->getUID() === $username;
+
+        // Non-admins may only change their own password.
+        if ($isAdmin === false && $isSelfReset === false) {
+            return new JSONResponse(['message' => 'Insufficient permissions'], Http::STATUS_FORBIDDEN);
+        }
+
+        // Self-service resets require current-password confirmation.
+        if ($isSelfReset === true && $isAdmin === false) {
+            if (empty($currentPassword) === true) {
+                return new JSONResponse(
+                        [
+                            'success' => false,
+                            'message' => 'Current password is required for self-service password reset',
+                        ],
+                        400
+                        );
+            }
+
+            // Verify current password by checking the user's backend.
+            $authUser = $this->userManager->checkPassword($username, $currentPassword);
+            if ($authUser === false) {
+                return new JSONResponse(
+                        [
+                            'success' => false,
+                            'message' => 'Current password is incorrect',
+                        ],
+                        403
+                        );
+            }
+        }//end if
 
         try {
             $user = $this->userManager->get($username);
@@ -1011,18 +1057,27 @@ class ContactpersonenController extends Controller
     /**
      * Disable a user account.
      *
+     * Requires admin or organisation-admin (gebruik-beheerder / aanbod-beheerder) role.
+     *
      * @param string $contactpersoonId The contactpersoon ID.
      *
      * @return JSONResponse Result of the disable operation.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
-     * @spec            openspec/changes/retrofit-2026-05-26-contactpersonen-api/tasks.md#task-3
+     * @spec           openspec/changes/retrofit-2026-05-26-contactpersonen-api/tasks.md#task-3
      */
     public function disableUser(string $contactpersoonId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $isAdmin    = $this->groupManager->isAdmin($currentUser->getUID());
+        $isOrgAdmin = $this->groupManager->isInGroup($currentUser->getUID(), 'gebruik-beheerder')
+            || $this->groupManager->isInGroup($currentUser->getUID(), 'aanbod-beheerder');
+        if ($isAdmin === false && $isOrgAdmin === false) {
+            return new JSONResponse(['message' => 'Insufficient permissions'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -1063,18 +1118,27 @@ class ContactpersonenController extends Controller
     /**
      * Enable a user account.
      *
+     * Requires admin or organisation-admin (gebruik-beheerder / aanbod-beheerder) role.
+     *
      * @param string $contactpersoonId The contactpersoon ID.
      *
      * @return JSONResponse Result of the enable operation.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
-     * @spec            openspec/changes/retrofit-2026-05-26-contactpersonen-api/tasks.md#task-3
+     * @spec           openspec/changes/retrofit-2026-05-26-contactpersonen-api/tasks.md#task-3
      */
     public function enableUser(string $contactpersoonId): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $isAdmin    = $this->groupManager->isAdmin($currentUser->getUID());
+        $isOrgAdmin = $this->groupManager->isInGroup($currentUser->getUID(), 'gebruik-beheerder')
+            || $this->groupManager->isInGroup($currentUser->getUID(), 'aanbod-beheerder');
+        if ($isAdmin === false && $isOrgAdmin === false) {
+            return new JSONResponse(['message' => 'Insufficient permissions'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -1344,9 +1344,13 @@ class SettingsController extends Controller
     /**
      * Import ArchiMate file.
      *
+     * Only accepts multipart file uploads — the `file_path` JSON body parameter is
+     * rejected to prevent local filesystem read (path traversal / SSRF).
+     * The `ini_set('memory_limit')` call has been removed; configure PHP memory via
+     * php.ini / pool config instead.
+     *
      * @return JSONResponse Result of the import operation with progress tracking.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -1356,20 +1360,16 @@ class SettingsController extends Controller
      */
     public function importArchiMate(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
+        }
+
         try {
-            // Increase memory limit for large imports.
-            ini_set('memory_limit', '4096M');
-            $this->logger->info(
-                    'Memory limit increased for import',
-                    [
-                        'old_limit' => ini_get('memory_limit'),
-                        'new_limit' => '4096M',
-                    ]
-                    );
             // Get JSON data from request body.
             $rawInput = file_get_contents('php://input');
             $data     = json_decode($rawInput, true);
@@ -1377,13 +1377,21 @@ class SettingsController extends Controller
             $contentType = $this->request->getHeader('Content-Type');
             $isMultipart = strpos(haystack: $contentType, needle: 'multipart/form-data') !== false;
 
-            // Enhanced debug logging.
+            // Reject file_path from JSON body — only uploaded files are accepted.
+            if ($data !== null && isset($data['file_path']) === true) {
+                return new JSONResponse(
+                        [
+                            'success' => false,
+                            'message' => 'The file_path parameter is not accepted. Please upload a file via multipart/form-data.',
+                            'error'   => 'FILE_PATH_NOT_ALLOWED',
+                        ],
+                        400
+                        );
+            }
+
             $this->logger->info(
                     'ArchiMate import request received',
                     [
-                        'rawInput'       => $rawInput,
-                        'decodedData'    => $data,
-                        'jsonError'      => json_last_error_msg(),
                         'contentType'    => $contentType,
                         'isMultipart'    => $isMultipart,
                         'requestMethod'  => $this->request->getMethod(),
@@ -1407,8 +1415,6 @@ class SettingsController extends Controller
             $this->logger->info(
                     'File upload detection detailed',
                     [
-                        'uploadedFiles'     => $uploadedFiles,
-                        'filesArray'        => $filesArray,
                         'requestMethod'     => $this->request->getMethod(),
                         'contentType'       => $contentType,
                         'hasUploadedFiles'  => $hasUploadedFiles,
@@ -1438,42 +1444,15 @@ class SettingsController extends Controller
                 ];
 
                 $this->logger->info('File upload detected.', ['options' => $options]);
-            } else if ($data !== null && isset($data['file_path']) === true) {
-                // Handle file path from JSON payload.
-                    $fileSize = 0;
-                if (file_exists($data['file_path']) === true) {
-                }
-
-                $options = [
-                    'updateExisting' => $data['updateExisting'] ?? true,
-                    'deleteOrphaned' => $data['deleteOrphaned'] ?? false,
-                    'preserveIds'    => $data['preserveIds'] ?? true,
-                    'processingMode' => $data['processingMode'] ?? 'speed',
-                    'filePath'       => $data['file_path'],
-                    'fileName'       => $data['fileName'] ?? basename($data['file_path']),
-                    'fileSize'       => $data['fileSize'] ?? $fileSize,
-                    'mimeType'       => $data['mimeType'] ?? 'text/xml',
-                ];
-
-                $this->logger->info('JSON payload detected.', ['options' => $options]);
             }//end if
 
             if (isset($options) === false) {
                 $this->logger->error(
-                        'No file uploaded or file path provided — DETAILED DEBUG',
+                        'No ArchiMate file uploaded',
                         [
-                            'uploadedFiles'  => $uploadedFiles,
-                            'filesArray'     => $filesArray,
-                            'data'           => $data,
-                            'rawInput'       => $rawInput,
-                            'contentType'    => $contentType,
-                            'isMultipart'    => $isMultipart,
-                            'requestMethod'  => $this->request->getMethod(),
-                            '_FILES_DEBUG'   => $_FILES,
-                            '_POST_DEBUG'    => $_POST,
-                            'requestParams'  => $this->request->getParams(),
-                            'userAgent'      => $this->request->getHeader('User-Agent'),
-                            'xRequestedWith' => $this->request->getHeader('X-Requested-With'),
+                            'contentType'   => $contentType,
+                            'isMultipart'   => $isMultipart,
+                            'requestMethod' => $this->request->getMethod(),
                         ]
                         );
 
@@ -1928,20 +1907,37 @@ class SettingsController extends Controller
     /**
      * Get email settings
      *
-     * @NoAdminRequired
+     * Secret fields (passwords / API keys) are redacted in the response; only
+     * a boolean presence indicator is returned for each secret.
+     *
      * @NoCSRFRequired
      *
-     * @return JSONResponse Current email settings
+     * @return JSONResponse Current email settings (secrets redacted)
      * @spec   openspec/changes/retrofit-2026-05-26-settings-admin-controller/tasks.md#task-4
      */
     public function getEmailSettings(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
         }
 
         try {
             $emailSettings = $this->settingsService->getEmailSettings();
+
+            // Redact secret values — return only a masked placeholder when set.
+            $secretFields = ['smtpPassword', 'sendgridApiKey', 'mailgunApiKey', 'postmarkApiKey', 'sesSecretKey', 'mailjetSecretKey'];
+            foreach ($secretFields as $field) {
+                if (empty($emailSettings[$field]) === false) {
+                    $emailSettings[$field] = '••••••••';
+                } else {
+                    $emailSettings[$field] = '';
+                }//end if
+            }
 
             return new JSONResponse(
                     [
@@ -1969,7 +1965,6 @@ class SettingsController extends Controller
     /**
      * Update email settings
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse Update result
@@ -1977,8 +1972,13 @@ class SettingsController extends Controller
      */
     public function updateEmailSettings(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -2302,7 +2302,6 @@ class SettingsController extends Controller
     /**
      * Set generic user groups
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse Update result
@@ -2310,8 +2309,13 @@ class SettingsController extends Controller
      */
     public function setGenericUserGroups(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -2390,7 +2394,6 @@ class SettingsController extends Controller
     /**
      * Set organization admin groups
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse Update result
@@ -2398,8 +2401,13 @@ class SettingsController extends Controller
      */
     public function setOrganizationAdminGroups(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
         }
 
         try {
@@ -2478,7 +2486,6 @@ class SettingsController extends Controller
     /**
      * Set super user groups
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse Update result
@@ -2486,8 +2493,13 @@ class SettingsController extends Controller
      */
     public function setSuperUserGroups(): JSONResponse
     {
-        if ($this->userSession->getUser() === null) {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
             return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isAdmin($currentUser->getUID()) === false) {
+            return new JSONResponse(['message' => 'Admin privileges required'], Http::STATUS_FORBIDDEN);
         }
 
         try {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1916,11 +1916,6 @@ class SettingsService
                     'email_user_creation_enabled',
                     'true'
             ) === 'true',
-            'userPasswordEnabled'             => $this->config->getValueString(
-                $app,
-                    'email_user_password_enabled',
-                    'true'
-            ) === 'true',
             'userOrganisationEnabled'         => $this->config->getValueString(
                 $app,
                     'email_user_organisation_enabled',
@@ -2021,7 +2016,6 @@ class SettingsService
                 'organization_registration' => $this->getEmailTemplate(templateName: 'organization_registration'),
                 'organization_activation'   => $this->getEmailTemplate(templateName: 'organization_activation'),
                 'user_creation'             => $this->getEmailTemplate(templateName: 'user_creation'),
-                'user_password'             => $this->getEmailTemplate(templateName: 'user_password'),
             ],
         ];
 
@@ -2060,7 +2054,6 @@ class SettingsService
             'organizationRegistrationEnabled' => 'email_org_registration_enabled',
             'organizationActivationEnabled'   => 'email_org_activation_enabled',
             'userCreationEnabled'             => 'email_user_creation_enabled',
-            'userPasswordEnabled'             => 'email_user_password_enabled',
             'userOrganisationEnabled'         => 'email_user_organisation_enabled',
 
             // Symfony Mailer transport configuration.
@@ -2223,20 +2216,6 @@ class SettingsService
 <p>Heeft u vragen over uw account? Neem dan contact met ons op.</p>
 <p>Met vriendelijke groet,<br>Het Software Catalogus Team</p>
             ',
-            'user_password'             => '
-<h1>Uw wachtwoord voor de Software Catalogus</h1>
-<p>Beste {{ user.name }},</p>
-<p>Uw wachtwoord voor de Software Catalogus is aangepast.</p>
-<p>Uw logingegevens:</p>
-<ul>
-    <li>E-mailadres: {{ user.email }}</li>
-    <li>Gebruikersnaam: {{ user.username }}</li>
-    <li>Nieuw wachtwoord: {{ user.password }}</li>
-</ul>
-<p>U kunt nu inloggen met uw nieuwe wachtwoord.</p>
-<p>We raden u aan om uw wachtwoord te wijzigen na het eerste inloggen.</p>
-<p>Met vriendelijke groet,<br>Het Software Catalogus Team</p>
-            ',
         ];
 
         return $templates[$templateName] ?? '';
@@ -2269,13 +2248,6 @@ class SettingsService
                 'user.name'              => 'User display name',
                 'user.email'             => 'User email address',
                 'user.username'          => 'Username',
-                'user.organization.name' => 'Organization name (if applicable)',
-            ],
-            'user_password'             => [
-                'user.name'              => 'User display name',
-                'user.email'             => 'User email address',
-                'user.username'          => 'Username',
-                'user.password'          => 'Auto-generated password',
                 'user.organization.name' => 'Organization name (if applicable)',
             ],
         ];
@@ -3926,7 +3898,6 @@ class SettingsService
             'organization_registration' => $this->getEmailTemplate(templateName: 'organization_registration'),
             'organization_activation'   => $this->getEmailTemplate(templateName: 'organization_activation'),
             'user_creation'             => $this->getEmailTemplate(templateName: 'user_creation'),
-            'user_password'             => $this->getEmailTemplate(templateName: 'user_password'),
         ];
 
         // Get Voorzieningen and AMEF configs (without object counts for performance).
@@ -4888,11 +4859,6 @@ class SettingsService
                         'email_user_creation_enabled',
                         'true'
                 ) === 'true',
-                'user_password_enabled'    => $this->config->getValueString(
-                    $an,
-                        'email_user_password_enabled',
-                        'true'
-                ) === 'true',
                 'test_receiver_override'   => $this->config->getValueString(
                     $an,
                         'test_receiver_override',
@@ -5015,7 +4981,6 @@ class SettingsService
                 'email_org_registration_enabled',
                 'email_org_activation_enabled',
                 'email_user_creation_enabled',
-                'email_user_password_enabled',
                 'test_receiver_override',
             ];
 
@@ -5218,7 +5183,6 @@ class SettingsService
             'organization_registration',
             'organization_activation',
             'user_creation',
-            'user_password',
             'user_organisation',
         ];
         $templates     = [];

--- a/lib/Service/SymfonyEmailService.php
+++ b/lib/Service/SymfonyEmailService.php
@@ -152,35 +152,6 @@ class SymfonyEmailService
     ';
 
     /**
-     * Email template for user password emails
-     *
-     * @var string User password email template
-     */
-    private const USER_PASSWORD_TEMPLATE = '
-        <html>
-        <head>
-            <title>Inloggegevens - Software Catalogus</title>
-            <meta charset="UTF-8">
-        </head>
-        <body>
-            <h1>Uw inloggegevens voor de Software Catalogus</h1>
-            <p>Beste {{ user.name }},</p>
-            <p>Hierbij ontvangt u uw inloggegevens voor de Software Catalogus.</p>
-            <p><strong>Login gegevens:</strong></p>
-            <ul>
-                <li>E-mailadres: {{ user.email }}</li>
-                <li>Tijdelijk wachtwoord: <code>{{ user.password }}</code></li>
-            </ul>
-            <p><strong>Belangrijk:</strong> We raden u aan om dit tijdelijke wachtwoord te wijzigen na uw eerste inlog.</p>
-            <p>U kunt inloggen op het platform en direct aan de slag met het beheren
-            van software voor {{ organization.name }}.</p>
-            <p>Heeft u vragen? Neem dan contact met ons op via info@conduction.nl</p>
-            <p>Met vriendelijke groet,<br>Het Software Catalogus Team</p>
-        </body>
-        </html>
-    ';
-
-    /**
      * Email template for contact welcome emails (backward compatibility)
      *
      * @var string Contact welcome email template
@@ -929,123 +900,6 @@ class SymfonyEmailService
     }//end sendUserUpdateEmail()
 
     /**
-     * Sends a user password email.
-     *
-     * @param array  $user         The user data.
-     * @param string $password     The generated password.
-     * @param array  $organization The organization data (optional).
-     *
-     * @return bool True if email was sent successfully, false otherwise.
-     *
-     * @throws \Exception If email sending fails.
-     * @spec   openspec/changes/retrofit-2026-05-26-email-delivery/tasks.md#task-1
-     */
-    public function sendUserPasswordEmail(array $user, string $password, array $organization=[]): bool
-    {
-        // Check if email system is fully configured.
-        $configStatus = $this->isEmailSystemConfigured();
-        if ($configStatus['configured'] === false) {
-            $this->logger->info(
-                    'UserPasswordEmail: Email system not configured, skipping',
-                    [
-                        'reason'         => $configStatus['reason'],
-                        'hasCredentials' => $configStatus['hasCredentials'],
-                        'hasTemplates'   => $configStatus['hasTemplates'],
-                        'userEmail'      => $user['email'] ?? 'Unknown',
-                    ]
-                    );
-            return false;
-        }
-
-        $emailSettings = $this->settingsService->getEmailSettings();
-
-        // Check if user password emails are enabled.
-        if ($emailSettings['userPasswordEnabled'] === false) {
-            $this->logger->info(
-                    'UserPasswordEmail: User password emails disabled',
-                    [
-                        'userEmail' => $user['email'] ?? 'Unknown',
-                    ]
-                    );
-            return false;
-        }
-
-        $userEmail = $user['email'] ?? '';
-        $userName  = $user['naam'] ?? $user['name'] ?? ($user['voornaam'] ?? '').' '.($user['achternaam'] ?? '');
-        $userName  = trim($userName);
-
-        if (empty($userEmail) === true) {
-            $this->logger->warning(
-                    'UserPasswordEmail: Cannot send without email address',
-                    [
-                        'user'     => $user,
-                        'userName' => $userName,
-                    ]
-                    );
-            return false;
-        }
-
-        $this->logger->info(
-                'UserPasswordEmail: Sending user password email',
-                [
-                    'userName'         => $userName,
-                    'userEmail'        => $userEmail,
-                    'organizationName' => $organization['naam'] ?? $organization['name'] ?? 'Software Catalogus',
-                    'transportType'    => $configStatus['transportType'],
-                ]
-                );
-
-        // Prepare template data.
-            $displayName = 'Gebruiker';
-        if (empty($userName) === false) {
-        }
-
-        $templateData = [
-            'user'         => [
-                'name'     => $displayName,
-                'email'    => $userEmail,
-                'password' => $password,
-                'functie'  => ($user['functie'] ?? ''),
-            ],
-            'organization' => [
-                'name' => ($organization['naam'] ?? $organization['name'] ?? 'Software Catalogus'),
-            ],
-        ];
-
-        try {
-            $success = $this->sendTemplatedEmail(
-                recipientEmail: $userEmail,
-                recipientName: $displayName,
-                subject: 'Software Catalogus - Inloggegevens',
-                templateName: 'user_password',
-                templateData: $templateData
-            );
-
-            if ($success === true) {
-                $this->logger->info(
-                        'UserPasswordEmail: Successfully sent user password email',
-                        [
-                            'userName'  => $userName,
-                            'userEmail' => $userEmail,
-                        ]
-                        );
-            }
-
-            return $success;
-        } catch (\Exception $e) {
-            $this->logger->error(
-                    'UserPasswordEmail: Failed to send user password email',
-                    [
-                        'userName'  => $userName,
-                        'userEmail' => $userEmail,
-                        'error'     => $e->getMessage(),
-                    ]
-                    );
-            return false;
-        }//end try
-    }//end sendUserPasswordEmail()
-
-    /**
      * Sends a templated email using the configured templates.
      *
      * @param string $recipientEmail The recipient email address.
@@ -1112,7 +966,6 @@ class SymfonyEmailService
             'organization_registration' => self::ORGANIZATION_WELCOME_TEMPLATE,
             'organization_activation' => self::ORGANIZATION_ACTIVATION_TEMPLATE,
             'user_creation' => self::GEBRUIKER_WELCOME_TEMPLATE,
-            'user_password' => self::USER_PASSWORD_TEMPLATE,
             'user_organisation' => self::CONTACT_ADDED_TEMPLATE,
             default => self::ORGANIZATION_WELCOME_TEMPLATE,
         };
@@ -1530,18 +1383,6 @@ class SymfonyEmailService
     }//end setUserCreationEnabled()
 
     /**
-     * Sets whether user password emails are enabled.
-     *
-     * @param bool $enabled True to enable user password emails, false to disable.
-     *
-     * @return void
-     */
-    public function setUserPasswordEnabled(bool $enabled): void
-    {
-        $this->settingsService->updateEmailSettings(['userPasswordEnabled' => $enabled]);
-    }//end setUserPasswordEnabled()
-
-    /**
      * Checks if the email system is fully configured with credentials and templates.
      *
      * @return array Configuration status with details.
@@ -1631,7 +1472,7 @@ class SymfonyEmailService
     private function hasValidTemplates(array $emailSettings): bool
     {
         $templates         = ($emailSettings['templates'] ?? []);
-        $requiredTemplates = ['organization_registration', 'organization_activation', 'user_creation', 'user_password'];
+        $requiredTemplates = ['organization_registration', 'organization_activation', 'user_creation'];
 
         foreach ($requiredTemplates as $templateName) {
             $template = ($templates[$templateName] ?? '');


### PR DESCRIPTION
## Summary

Fixes 6 CRITICAL security issues (#326–#331) and removes dormant code (#332) in a single PR.

- **C1 #326** `changePassword`: non-admins may only reset their own password; self-service resets require current-password confirmation.
- **C2 #327** `setGenericUserGroups` / `setOrganizationAdminGroups` / `setSuperUserGroups`: drop `@NoAdminRequired`, add `isAdmin()` guard — only NC admins may assign groups to privileged roles.
- **C3 #328** `convertToUser`: drop `@NoAdminRequired`, gate on admin+org-admin, switch `ObjectService::find` to `_rbac:true` / `_multitenancy:true` to prevent cross-tenant identity hijack.
- **C4 #329** `disableUser` + `enableUser`: drop `@NoAdminRequired`, add admin+org-admin guard.
- **C5 #330** `getEmailSettings` + `updateEmailSettings`: drop `@NoAdminRequired`, add `isAdmin()` guard; GET response redacts all secret fields to masked placeholder.
- **C6 #331** `importArchiMate`: drop `@NoAdminRequired`, add `isAdmin()` guard; reject `file_path` JSON body parameter; remove `ini_set('memory_limit','4096M')`; strip raw body from error logs.
- **C7 #332** Dormant code removal: `sendUserPasswordEmail()`, `USER_PASSWORD_TEMPLATE`, `setUserPasswordEnabled()`, all `userPasswordEnabled` config keys deleted — zero callers in `lib/`; template contained `{{ user.password }}` plaintext credential.

## Quality checks

- `php -l`: passes all 4 changed files
- `phpcs --standard=phpcs.xml`: 0 new errors
- `phpstan analyse`: 0 errors

## Test plan

- [ ] As non-admin: `POST /api/contactpersonen/change-password` with another user's username → 403
- [ ] As non-admin: self password reset without `currentPassword` → 400
- [ ] As non-admin: `POST /api/settings/user-groups/super-user` → 403
- [ ] As non-admin: `GET /api/settings/email` → 403
- [ ] As non-admin: `POST /api/archimate/import` → 403
- [ ] As admin: `POST /api/archimate/import` with `{"file_path":"/etc/passwd"}` → 400 (rejected)
- [ ] As admin: `GET /api/settings/email` returns `••••••••` for secret fields

Closes #326, #327, #328, #329, #330, closes #332