### PR TITLE
fix(auth): drop @PublicPage from mutating endpoints, fix isUserInGroup (H2-H5)

### DIFF
--- a/lib/Controller/AanbodController.php
+++ b/lib/Controller/AanbodController.php
@@ -155,8 +155,8 @@ class AanbodController extends Controller
      *
      * @return JSONResponse JSON response with success status and updated object
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      *
      * @spec openspec/changes/retrofit-2026-05-24-aanbod-listings/tasks.md#task-2
      */
@@ -255,8 +255,8 @@ class AanbodController extends Controller
      *
      * @return JSONResponse JSON response with success status and deletion details
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      *
      * @spec openspec/changes/retrofit-2026-05-24-aanbod-listings/tasks.md#task-3
      */

--- a/lib/Controller/AangebodenGebruikController.php
+++ b/lib/Controller/AangebodenGebruikController.php
@@ -480,7 +480,7 @@ class AangebodenGebruikController extends Controller
 
             $userId = $user->getUID();
 
-            $group = $groupManager->get($groupName);
+            $group = $this->groupManager->get($groupName);
             if ($group === null) {
                 $this->logger->warning('Group does not exist', ['group' => $groupName]);
                 return false;
@@ -602,8 +602,8 @@ class AangebodenGebruikController extends Controller
      *
      * @return JSONResponse JSON response with success status and updated object
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
      */
     public function setGebruikSelfToActiveOrg(string $gebruikId): JSONResponse
@@ -708,8 +708,8 @@ class AangebodenGebruikController extends Controller
      *
      * @return JSONResponse JSON response with success status and deletion details
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      * @spec           openspec/changes/retrofit-2026-05-26-aangeboden-gebruik-api/tasks.md#task-2
      */
     public function deleteGebruikAsAfnemer(string $gebruikId): JSONResponse

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -1236,6 +1236,10 @@ class SettingsController extends Controller
      */
     public function streamProgress(string $operationId): Response
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Set headers for Server-Sent Events.
         $response = new class($operationId, $this->progressTracker, $this->logger) extends Response {
             /**
@@ -1254,7 +1258,6 @@ class SettingsController extends Controller
                 $this->addHeader(name: 'Content-Type', value: 'text/event-stream');
                 $this->addHeader(name: 'Cache-Control', value: 'no-cache');
                 $this->addHeader(name: 'Connection', value: 'keep-alive');
-                $this->addHeader(name: 'Access-Control-Allow-Origin', value: '*');
                 $this->addHeader(name: 'Access-Control-Allow-Headers', value: 'Cache-Control');
             }//end __construct()
 

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -69,8 +69,8 @@ class ViewController extends Controller
      * - include_gebruik (bool): Include usage data in view nodes
      * - include_deelnames_gebruik (bool): Include participation usage data in view nodes
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      *
      * @return JSONResponse JSON response with views array
      *
@@ -144,8 +144,8 @@ class ViewController extends Controller
      *
      * @param string $viewId The view identifier
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      *
      * @return JSONResponse JSON response with view object
      *
@@ -303,8 +303,8 @@ class ViewController extends Controller
      *
      * API Endpoint: GET /api/views/docs
      *
+     * @NoAdminRequired
      * @NoCSRFRequired
-     * @PublicPage
      *
      * @return JSONResponse JSON response with API documentation
      *


### PR DESCRIPTION
## Summary

Fixes four HIGH-severity auth issues identified in the 2026-05-27 deep review pass.

- **H2 #334**: `ViewController` `getAllViews`/`getView`/`getApiDocumentation` were `@PublicPage`, leaking all tenants' draft views anonymously. Changed to `@NoAdminRequired` (login required).
- **H3 #335**: `streamProgress` SSE endpoint had no user-null guard and emitted `Access-Control-Allow-Origin: *`. Added the same `userSession` null-check used by `getProgress`; removed the wildcard CORS header.
- **H4 #336**: State-mutating `AanbodController::acceptAanbod`/`denyAanbod` and `AangebodenGebruikController::setGebruikSelfToActiveOrg`/`deleteGebruikAsAfnemer` were `@PublicPage`. Downgraded to `@NoAdminRequired` so NC enforces a logged-in session at the framework layer.
- **H5 #337**: `isUserInGroup` called bare `$groupManager->get()` (undefined variable, PHP warning, method always returns `false`). Fixed to `$this->groupManager->get()` (injected via constructor).

## Test plan

- [ ] Anonymous `GET /api/views` returns 401
- [ ] Authenticated `GET /api/views` returns 200 with only current-tenant views
- [ ] Anonymous `GET /api/settings/stream-progress/{id}` returns 401
- [ ] Authenticated stream-progress works as before
- [ ] Anonymous `PUT /api/aanbod/{uuid}/accept` returns 401
- [ ] Anonymous `DELETE /api/aanbod/{uuid}/deny` returns 401
- [ ] Admin group checks (`isAmbtenaar`, `isAdmin`) return correct boolean after the `$this->groupManager` fix