### PR TITLE
fix(sync): H6-H8 sync engine bugs + M2 empty full-sync branch + M5 cron Throwable guard

### DIFF
--- a/lib/BackgroundJob/OrganizationContactSyncJob.php
+++ b/lib/BackgroundJob/OrganizationContactSyncJob.php
@@ -94,6 +94,17 @@ class OrganizationContactSyncJob extends TimedJob
         }
 
         $this->logger->info('[OrganizationContactSyncJob] Starting scheduled organization sync');
-        $this->orgSyncService->performScheduledSync();
+        try {
+            $this->orgSyncService->performScheduledSync();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                '[OrganizationContactSyncJob] Fatal error during sync — cron pass protected',
+                [
+                    'error' => $e->getMessage(),
+                    'file'  => $e->getFile(),
+                    'line'  => $e->getLine(),
+                ]
+            );
+        }//end try
     }//end run()
 }//end class

--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -671,7 +671,7 @@ class ContactpersonenController extends Controller
             $curCatalogGroups = [];
 
             foreach ($currentGroups as $group) {
-                if (in_array(needle: $group->getGID() === true, haystack: $allowedGroups) === true) {
+                if (in_array(needle: $group->getGID(), haystack: $allowedGroups) === true) {
                     $curCatalogGroups[] = $group->getGID();
                 }
             }

--- a/lib/Service/OrganizationSyncService.php
+++ b/lib/Service/OrganizationSyncService.php
@@ -426,11 +426,9 @@ class OrganizationSyncService
                 $contactEntityObject = $contactEntity->getObject();
                 $contactEntityObject['username'] = $contact['uid'];
 
-                // Temporarily remove organisatie field to avoid validation error.
-                // (schema expects object type but field stores a UUID string).
-                $savedOrganisatie = $contactEntityObject['organisatie'] ?? null;
-                unset($contactEntityObject['organisatie']);
-
+                // Keep organisatie in the object so it is never temporarily absent from the
+                // persisted record. The schema validation warning for a UUID-string value is
+                // benign compared to a data-corruption window where the field is missing.
                 $contactEntity->setObject($contactEntityObject);
                 $objectService->saveObject(
                     object: $contactEntity,
@@ -439,15 +437,6 @@ class OrganizationSyncService
                     _rbac: false,
                     _multitenancy: false
                 );
-
-                // Restore the organisatie field so the link is preserved.
-                if ($savedOrganisatie !== null) {
-                    $restoredData = $contactEntity->getObject();
-                    $restoredData['organisatie'] = $savedOrganisatie;
-                    $contactEntity->setObject($restoredData);
-                    $objectMapper = \OC::$server->get('OCA\OpenRegister\Db\MagicMapper');
-                    $objectMapper->update($contactEntity);
-                }
 
                 $stats['contactPersonsProcessed']++;
             } catch (\Exception $e) {
@@ -493,8 +482,10 @@ class OrganizationSyncService
         $platform   = $this->db->getDatabasePlatform();
         $isPostgres = $platform instanceof \Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 
-            $jsonContainsCheck = "JSON_CONTAINS(oo.users, CONCAT('\"', o.username, '\"')) = 0";
         if ($isPostgres === true) {
+            $jsonContainsCheck = "NOT (oo.users::jsonb @> to_jsonb(o.username::text))";
+        } else {
+            $jsonContainsCheck = "JSON_CONTAINS(oo.users, CONCAT('\"', o.username, '\"')) = 0";
         }
 
         // Find contacts with a username whose username is NOT in their org's users array.
@@ -503,7 +494,7 @@ class OrganizationSyncService
             ->from($contactTableName, 'o')
             ->leftJoin('o', 'openregister_organisations', 'oo', 'oo.uuid = o.organisatie')
             ->where($qb->createFunction('o.username IS NOT NULL'))
-            ->andWhere($qb->createFunction('o.username !== '.$qb->createNamedParameter('')))
+            ->andWhere($qb->createFunction('o.username <> '.$qb->createNamedParameter('')))
             ->andWhere($qb->createFunction('o.organisatie IS NOT NULL'))
             ->andWhere($qb->createFunction($jsonContainsCheck));
 
@@ -2815,8 +2806,10 @@ class OrganizationSyncService
      */
     public function performScheduledSync(int $minutesBack=0): array
     {
-            $syncModeValue = 'incremental';
         if ($minutesBack === 0) {
+            $syncModeValue = 'full';
+        } else {
+            $syncModeValue = 'incremental';
         }
 
         $this->logger->info(


### PR DESCRIPTION
## Summary

Fixes five HIGH/MEDIUM severity bugs in the sync engine and background job.

- **H6 #338**: `updateUserGroups` — `in_array(needle: $group->getGID() === true, ...)` evaluated `needle` as the boolean result of `=== true` (always `false`). `$curCatalogGroups` was always empty, so group removal never ran. Fixed: `in_array(needle: $group->getGID(), ...)`.
- **H7 #339**: `performUserSync` — Postgres branch was empty (MySQL `JSON_CONTAINS` used on both platforms). Also the `WHERE` clause contained the PHP `!==` operator in a raw SQL string, producing an invalid query. Fixed: proper `if ($isPostgres) { … } else { … }` with `jsonb @> to_jsonb()` for Postgres, and `<>` for the empty-string comparison.
- **H8 #340**: `performContactSync` — `unset($contactEntityObject['organisatie'])` before `saveObject` created a window where the contact record had no `organisatie`. Removed the strip/restore pattern; `organisatie` is now kept in the saved object throughout.
- **M2 #342**: `performScheduledSync` — empty `if ($minutesBack === 0) {}` block meant `$syncModeValue` was always `'incremental'`, so full syncs never ran. Fixed with proper `if/else`.
- **M5 #345**: `OrganizationContactSyncJob::run()` had no `\Throwable` guard. An `Error` (e.g. from remaining `\OC::$server->get()` calls on NC34) would kill the entire cron pass. Wrapped in `try/catch \Throwable`.

## Test plan

- [ ] `updateUserGroups` removes users from groups they no longer belong to
- [ ] `performUserSync` runs without error on a Postgres installation
- [ ] Contact records retain their `organisatie` field after a sync pass
- [ ] Manual trigger with `minutesBack=0` logs `syncMode: full`
- [ ] A thrown `Error` in `performScheduledSync` is caught and logged without crashing subsequent cron jobs