### PR TITLE
fix(email): prevent SMTP-cred round-trip, template XSS, and DSN encoding

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -2014,13 +2014,13 @@ class SettingsController extends Controller
             $data          = $this->request->getParams();
             $emailSettings = $data['emailSettings'] ?? $data;
 
-            $result = $this->settingsService->updateEmailSettings($emailSettings);
+            $updatedSettings = $this->settingsService->updateEmailSettings($emailSettings);
 
             return new JSONResponse(
                     [
-                        'success'       => $result['success'],
-                        'message'       => $result['message'] ?? 'Email settings updated successfully',
-                        'emailSettings' => $result['emailSettings'] ?? null,
+                        'success'       => true,
+                        'message'       => 'Email settings updated successfully',
+                        'emailSettings' => $updatedSettings,
                     ]
                     );
         } catch (\Exception $e) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -2085,17 +2085,22 @@ class SettingsService
             'mailjetApiKey'                   => 'email_mailjet_api_key',
             'mailjetSecretKey'                => 'email_mailjet_secret_key',
         ];
+        // Secret fields that are masked in GET responses — skip any value that is the mask placeholder.
+        $secretFields    = ['smtpPassword', 'sendgridApiKey', 'mailgunApiKey', 'postmarkApiKey', 'sesSecretKey', 'mailjetSecretKey'];
         $updatedSettings = [];
 
         foreach ($allowedSettings as $settingKey => $configKey) {
             if (array_key_exists($settingKey, $emailSettings) === true) {
                 $value = $emailSettings[$settingKey];
 
+                // Skip masked placeholder — the client is echoing back the redacted value; preserve the real stored secret.
+                if (in_array($settingKey, $secretFields, true) === true && $value === '••••••••') {
+                    continue;
+                }
+
                 // Convert boolean values to strings.
                 if (is_bool($value) === true) {
-                        $value = 'false';
-                    if ($value === true) {
-                    }
+                    $value = ($value === true) ? 'true' : 'false';
                 }
 
                 $this->config->setValueString($this->appName, $configKey, (string) $value);
@@ -2808,8 +2813,8 @@ class SettingsService
 
         $dsn = sprintf(
             'smtp://%s:%s@%s:%d',
-            urlencode($username),
-            urlencode($password),
+            rawurlencode($username),
+            rawurlencode($password),
             $host,
             $port
         );
@@ -2818,9 +2823,7 @@ class SettingsService
             $dsn .= '?encryption='.$encryption;
         }
 
-            $encSuffix = '';
-        if (empty($encryption) === false && $encryption !== 'none') {
-        }
+        $encSuffix = (empty($encryption) === false && $encryption !== 'none') ? '?encryption='.$encryption : '';
 
         $dsnPattern = sprintf('smtp://***:***@%s:%d%s', $host, $port, $encSuffix);
 

--- a/lib/Service/SymfonyEmailService.php
+++ b/lib/Service/SymfonyEmailService.php
@@ -329,8 +329,8 @@ class SymfonyEmailService
 
         $dsn = sprintf(
             'smtp://%s:%s@%s:%d',
-            rawrawurlencode($username),
-            rawrawurlencode($password),
+            rawurlencode($username),
+            rawurlencode($password),
             $host,
             $port
         );
@@ -998,44 +998,27 @@ class SymfonyEmailService
             $org       = $templateData['organization'];
             $processed = str_replace(
                 search: '{{ organization.name }}',
-                replace: ($org['name'] ?? ''),
+                replace: htmlspecialchars((string) ($org['name'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 subject: $processed
             );
         }
 
-        // Replace user variables.
+        // Replace user variables — never include passwords in email output.
         if (isset($templateData['user']) === true) {
             $user      = $templateData['user'];
             $processed = str_replace(
                 search: '{{ user.name }}',
-                replace: ($user['name'] ?? ''),
+                replace: htmlspecialchars((string) ($user['name'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 subject: $processed
             );
             $processed = str_replace(
                 search: '{{ user.email }}',
-                replace: ($user['email'] ?? ''),
+                replace: htmlspecialchars((string) ($user['email'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 subject: $processed
             );
-            $processed = str_replace(
-                search: '{{ user.password }}',
-                replace: ($user['password'] ?? ''),
-                subject: $processed
-            );
-        }
-
-        // Replace contact variables (backward compatibility).
-        if (isset($templateData['user']) === true) {
-            $user      = $templateData['user'];
-            $processed = str_replace(
-                search: '{{ user.name }}',
-                replace: ($user['name'] ?? ''),
-                subject: $processed
-            );
-            $processed = str_replace(
-                search: '{{ user.email }}',
-                replace: ($user['email'] ?? ''),
-                subject: $processed
-            );
+            // Remove any {{ user.password }} placeholder that may appear in custom templates
+            // to prevent accidental credential exposure.
+            $processed = str_replace(search: '{{ user.password }}', replace: '', subject: $processed);
         }
 
         return $processed;


### PR DESCRIPTION
## Summary

- **C2** Skip `••••••••` masked placeholder in `updateEmailSettings` so stored secrets are never overwritten by the redacted display value echoed back from the GET endpoint.
- **C4** HTML-escape all user-controlled template variables (`organization.name`, `user.name`, `user.email`) with `htmlspecialchars(ENT_QUOTES|ENT_HTML5)` before substitution, preventing stored XSS in outgoing emails.
- **H5** Remove `{{ user.password }}` substitution from `processTemplate` — no caller passes a password in templateData, but this eliminates any path by which a custom template could expose credentials.
- **M1** Use `rawurlencode` (RFC 3986) instead of `urlencode` (HTML form encoding) for SMTP DSN userinfo in `SettingsService::createSmtpTransport`.
- **M2** Fix empty-if `encSuffix` branch so the logged DSN pattern includes the encryption query string when configured.
- **L2** Remove duplicate backward-compat block in `processTemplate` (dead code).
- **bonus** Fix `rawrawurlencode` typo in `SymfonyEmailService::createSmtpTransport`.

## Test plan
- [ ] POST to `updateEmailSettings` with all secret fields as `••••••••` — verify stored secrets unchanged
- [ ] POST to `updateEmailSettings` with a new real secret value — verify it is stored
- [ ] Send a test email with `<script>` in org name — verify it is escaped in email body
- [ ] Configure SMTP transport with special chars in password — verify DSN encodes correctly