### PR TITLE
fix(state): correct inverted boolean conversion and empty-if status-code bugs

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -2167,9 +2167,7 @@ class SettingsController extends Controller
                 templateContent: $templateContent
             );
 
-                $updateMsg = "Failed to update template {$templateName}";
-            if ($success === true) {
-            }
+            $updateMsg = ($success === true) ? "Template {$templateName} updated successfully" : "Failed to update template {$templateName}";
 
             return new JSONResponse(
                     [
@@ -2713,9 +2711,7 @@ class SettingsController extends Controller
         try {
             $result = $this->settingsService->cancelArchiMateImport();
 
-                $message = 'ArchiMate import cancellation failed';
-            if ($result['cancelled'] === true) {
-            }
+            $message = ($result['cancelled'] === true) ? 'ArchiMate import cancellation succeeded' : 'ArchiMate import cancellation failed';
 
             return new JSONResponse(
                     [
@@ -3436,9 +3432,7 @@ class SettingsController extends Controller
             // Call the settings service method.
             $result = $this->settingsService->syncOrganisationsToVoorzieningenOptimized($options);
 
-                $statusCode = 500;
-            if ($result['success'] === true) {
-            }
+            $statusCode = ($result['success'] === true) ? 200 : 500;
 
             $this->logger->info(
                     'SettingsController: Organisation sync completed',
@@ -3581,9 +3575,7 @@ class SettingsController extends Controller
             $data   = $this->request->getParams();
             $result = $this->settingsService->updateCronjobConfig($data);
 
-                $statusCode = 400;
-            if ($result['success'] === true) {
-            }
+            $statusCode = ($result['success'] === true) ? 200 : 400;
 
             return new JSONResponse($result, $statusCode);
         } catch (\Exception $e) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -2093,9 +2093,7 @@ class SettingsService
 
                 // Convert boolean values to strings.
                 if (is_bool($value) === true) {
-                        $value = 'false';
-                    if ($value === true) {
-                    }
+                    $value = ($value === true) ? 'true' : 'false';
                 }
 
                 $this->config->setValueString($this->appName, $configKey, (string) $value);
@@ -2631,9 +2629,7 @@ class SettingsService
 
         switch ($transportType) {
             case 'smtp':
-                    $usernameValue = 'none';
-                if (empty($emailSettings['smtpUsername']) === false) {
-                }
+                $usernameValue = (empty($emailSettings['smtpUsername']) === false) ? 'configured' : 'none';
                 return [
                     'type'       => 'SMTP',
                     'host'       => $emailSettings['smtpHost'] ?? '',
@@ -2971,9 +2967,7 @@ class SettingsService
             $openRegisterInstalled = $this->isOpenRegisterInstalled();
             $openRegisterEnabled   = $openRegisterInstalled && $this->isOpenRegisterEnabled();
 
-                $versionComparisonValue = null;
-            if ($storedConfigVersion !== null) {
-            }
+            $versionComparisonValue = ($storedConfigVersion !== null) ? version_compare($currentAppVersion, $storedConfigVersion) : null;
 
             $versionInfo = [
                 'appName'               => 'SoftwareCatalog',
@@ -3055,9 +3049,7 @@ class SettingsService
                     );
 
             // Return concise response to avoid serialization issues with large nested structures.
-                $messageValue = 'Force update completed but configuration needs attention';
-            if ($success === true) {
-            }
+            $messageValue = ($success === true) ? 'Force update completed successfully' : 'Force update completed but configuration needs attention';
 
             return [
                 'success'           => $success,
@@ -3207,9 +3199,7 @@ class SettingsService
             // If force import is requested or auto-config not completed, reset auto-configuration flag.
             if ($forceImport === true || $versionInfo['autoConfigCompleted'] === false) {
                 $this->config->setValueString($this->appName, 'auto_config_completed', 'false');
-                    $reasonValue = 'auto_config_not_completed';
-                if ($forceImport === true) {
-                }
+                $reasonValue = ($forceImport === true) ? 'force_import_requested' : 'auto_config_not_completed';
 
                 $this->logger->info(
                         'SettingsService: Reset auto-configuration flag',


### PR DESCRIPTION
## Summary

- **C1** Fix boolean-to-string conversion in `updateEmailSettings` — the empty-if caused every boolean `true` to persist as string `'false'`, silently disabling all boolean settings.
- **C3** Fix empty-if branches that leave status-code/message variables at their wrong default values across 8 sites:
  - `syncOrganisations`: `statusCode` stayed `500` on success → now `200`
  - `cancelArchiMateImport`: `message` stayed `'failed'` on success → now `'succeeded'`
  - `updateEmailTemplate`: `updateMsg` stayed `'failed'` on success → now `'updated successfully'`
  - `updateCronjobConfig`: `statusCode` stayed `400` on success → now `200`
  - `forceUpdate` (SettingsService): `messageValue` never set to success message
  - `getVersionInfo`: `versionComparisonValue` always `null` even when version available → now `version_compare()` result
  - `getTransportConfig` SMTP: `usernameValue` always `'none'` even when configured → now `'configured'`
  - `forceManualImport`: `reasonValue` always `'auto_config_not_completed'` even on explicit force → now `'force_import_requested'`

## Test plan
- [ ] Toggle a boolean email setting (e.g. `enabled`) to `true` — verify stored value is `'true'` not `'false'`
- [ ] POST to `/api/settings/sync/organisations` — verify response is HTTP 200 on success
- [ ] POST to `/api/archimate/import/cancel` — verify message says 'succeeded' when cancellation works
- [ ] POST to `/api/settings/cronjobs` with valid data — verify HTTP 200 (was 400)