### PR TITLE
fix(sync): correct processContactPerson username resolution and error logging

### DIFF
--- a/lib/Service/OrganizationSyncService.php
+++ b/lib/Service/OrganizationSyncService.php
@@ -1240,10 +1240,9 @@ class OrganizationSyncService
             }
 
             // Check if user already exists.
-            $userManager  = $this->container->get('OCP\IUserManager');
-                $username = $email;
-            if (empty($existingUsername) === false) {
-            }
+            $userManager = $this->container->get('OCP\IUserManager');
+            // Use the stored username when available, otherwise fall back to email as username.
+            $username = (empty($existingUsername) === false) ? $existingUsername : $email;
 
             $user = $userManager->get($username);
 
@@ -1268,8 +1267,7 @@ class OrganizationSyncService
                             'username'  => $username,
                         ]
                     );
-                }
-
+                } else {
                     $this->logger->error(
                         'OrganizationSyncService: Failed to create user account',
                         [
@@ -1277,9 +1275,10 @@ class OrganizationSyncService
                             'username'  => $username,
                         ]
                     );
+                }
             }//end if
 
-                // User exists, update username in contact if needed.
+            // Contact exists without a stored username — record the resolved username for future syncs.
             if (empty($existingUsername) === true) {
                 $this->logger->debug(
                     'OrganizationSyncService: Updating contact person with username',
@@ -1291,7 +1290,7 @@ class OrganizationSyncService
                 $stats['usersUpdated']++;
             }
 
-                return $username;
+            return $username;
         } catch (\Exception $e) {
             $this->logger->error(
                 'OrganizationSyncService: Failed to process contact person',


### PR DESCRIPTION
## Summary

- **H2** Fix empty-if in `processContactPerson` that caused `$username` to always fall back to the email address even when a stored `username` field existed in the contact record. The intended logic was: use `$existingUsername` if set, otherwise use email. The broken code always used email.
- **H2 / L4** The `$this->logger->error('Failed to create user account')` log was unconditional — it fired after every user creation attempt regardless of whether `processContactpersoon` succeeded or failed. Wrap it in the `else` branch of the success check.

**Before:**
```php
$username = $email;
if (empty($existingUsername) === false) { /* empty body */ }
// ...
if (empty($success) === false) { $stats['usersCreated']++; /* success log */ }
$this->logger->error('Failed to create user account'); // ALWAYS fires
```

**After:**
```php
$username = (empty($existingUsername) === false) ? $existingUsername : $email;
// ...
if (empty($success) === false) {
    $stats['usersCreated']++;
    /* success log */
} else {
    $this->logger->error('Failed to create user account'); // only on failure
}
```

## Test plan
- [ ] Sync a contact with an existing `username` field — verify the existing username is used (not email)
- [ ] Sync a contact without `username` — verify email is used as fallback
- [ ] Verify no phantom error log in NC logs when user creation succeeds