### PR TITLE
fix(deps): bump twig/twig to ^3.27.0 (CVE-2026-48805/06/07/08, CVE-2026-46636)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
 		"symfony/http-client": "^6.4",
 		"symfony/mailer": "^6.4",
 		"symfony/mailjet-mailer": "^6.4",
-		"twig/twig": "^3.8"
+		"twig/twig": "^3.27.0"
 	},
 	"require-dev": {
 		"cyclonedx/cyclonedx-php-composer": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "488d4965da6a464096445a62b7b193c9",
+    "content-hash": "7d2c4e9b559c1d911715e534ad0eb442",
     "packages": [
         {
             "name": "adbario/php-dot-notation",
@@ -1729,16 +1729,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc"
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
-                "reference": "1fcae487b180d78e6351f4e0afa91f9eab96a2bc",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
+                "reference": "04ae1bfe9463c816cf72ca0abe7eae2c77a9a9ed",
                 "shasum": ""
             },
             "require": {
@@ -1793,7 +1793,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.26.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.27.0"
             },
             "funding": [
                 {
@@ -1805,7 +1805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T07:31:59+00:00"
+            "time": "2026-05-27T13:05:51+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Summary

- Bumps `twig/twig` constraint from `^3.8` to `^3.27.0` and upgrades lock from `v3.26.0` to `v3.27.0`
- Fixes 5 sandbox bypass CVEs all affecting `twig/twig < 3.27.0`:
  - **CVE-2026-48805** — Sandbox state regression in deprecated internal wrappers in `src/Resources/core.php`
  - **CVE-2026-48806** — Sandbox `__toString()` policy bypass via dynamic mapping keys
  - **CVE-2026-48807** — Sandbox `__toString()` policy bypass via `Traversable` in `join`/`replace` and `in`/`not in` operators
  - **CVE-2026-48808** — Sandbox property allowlist bypass via the `column` filter under `SourcePolicyInterface`
  - **CVE-2026-46636** — Sandbox filter, tag and function allow-list bypass when sandbox state changes between renders
- `composer audit` confirms no remaining security advisories after the bump
- No other dependencies changed; no application code touched

## Test plan

- [x] `composer install --ignore-platform-reqs` succeeds
- [x] `composer audit` returns "No security vulnerability advisories found"
- [x] `twig/twig` installed version is `v3.27.0`