### PR TITLE
fix(security): wave-3 critical fixes

### DIFF
--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -23,6 +23,7 @@ use OCA\SoftwareCatalog\Service\SettingsService;
 use OCA\SoftwareCatalog\Service\SoftwareCatalogue\ContactPersonHandler;
 use OCA\SoftwareCatalog\Service\ContactpersoonService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserManager;
@@ -569,6 +570,19 @@ class ContactpersonenController extends Controller
      */
     public function updateUserGroups(string $username, array $groups=[]): JSONResponse
     {
+        $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
+            return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        // Only admins and org-admins may modify group assignments.
+        $isAdmin    = $this->groupManager->isAdmin($currentUser->getUID());
+        $isOrgAdmin = $this->groupManager->isInGroup($currentUser->getUID(), 'gebruik-beheerder')
+            || $this->groupManager->isInGroup($currentUser->getUID(), 'aanbod-beheerder');
+        if ($isAdmin === false && $isOrgAdmin === false) {
+            return new JSONResponse(['message' => 'Insufficient permissions'], Http::STATUS_FORBIDDEN);
+        }
+
         try {
             $user = $this->userManager->get($username);
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -5797,7 +5797,7 @@ class SettingsService
      */
     private function determineOrganisationType(\OCA\OpenRegister\Db\Organisation $organisation): string
     {
-        $name = strtolower($organisation->getName() === true);
+        $name = strtolower($organisation->getName());
 
         if (strpos($name, 'gemeente') !== false) {
             return 'Gemeente';


### PR DESCRIPTION
## Summary

Fixes remaining wave-3 CRITICAL findings from `/tmp/triage-softwarecatalog.md` that were still present on `main`. The `development` branch had all 7 bugs; `main` has already resolved C2/C4/C5/C6/C7 via prior commits.

- **C1** `ContactpersonenController::updateUserGroups` — Add admin/org-admin gate (`$this->groupManager->isAdmin()` + `gebruik-beheerder`/`aanbod-beheerder` group check). The method was `@NoAdminRequired` with no auth check at all — any authenticated user could grant themselves or others write-tier catalog groups (privilege escalation).
- **C3** `SettingsService::determineOrganisationType` — Fix `strtolower($organisation->getName() === true)` type-coercion bug. The `=== true` comparison turns the string name into a boolean (`false`), which `strtolower` coerces to `''`, making `strpos` never match — all organisations were classified as `Leverancier` regardless of name.

Changes C2/C4/C5/C6/C7 are already resolved on `main` and were not re-applied.

`development` branch also received all 7 fixes at commit `91bf0e4`.

## Test plan

- [ ] PHPStan: no new errors introduced (17 errors pre and post fix)
- [ ] C1: Log in as non-admin/non-org-admin; `PATCH /contactpersonen/{username}/groups` returns 403
- [ ] C1: Log in as `gebruik-beheerder` group member; group update succeeds
- [ ] C3: Sync an organisation with "gemeente" in the name; `determineOrganisationType` returns `'Gemeente'` (not `'Leverancier'`)