### PR TITLE
fix(contactpersoon): make e-mailadres nullable to prevent HTTP 500

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,7 +42,7 @@ Vrij en open source onder de EUPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <licence>agpl</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>SoftwareCatalog</namespace>

--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -1704,12 +1704,10 @@
         "slug": "contactpersoon",
         "title": "Contactpersoon",
         "description": "Contactgegevens van een persoon",
-        "version": "0.0.26",
+        "version": "0.0.27",
         "summary": "",
         "icon": "AccountMultiple",
-        "required": [
-          "e-mailadres"
-        ],
+        "required": [],
         "properties": {
           "voornaam": {
             "type": "string",
@@ -1884,7 +1882,7 @@
             "title": "E-mailadres",
             "type": "string",
             "format": "email",
-            "required": true,
+            "required": false,
             "visible": true,
             "facetable": false,
             "order": 6,


### PR DESCRIPTION
## Problem

Creating or updating a `contactpersoon` object without an `e-mailadres` field returned HTTP 500 due to a NOT NULL constraint violation. The constraint was enforced by OpenRegister's Magic Mapper translating the schema `required` setting into a NOT NULL DB column.

## Root cause

The `contactpersoon` schema in `lib/Settings/softwarecatalogus_register.json` had `e-mailadres` in **two** required locations:
1. Top-level `"required": ["e-mailadres"]` array on the schema object
2. `"required": true` on the `e-mailadres` property itself

## Fix

Contact persons do not universally require an email address (e.g. phone-only contacts, internal-only contacts). The `ContactpersoonService` already handles the no-email case gracefully — it logs a warning and skips user-account provisioning when email is absent. Making the field nullable at the schema level is the correct fix.

Changes:
- Remove `e-mailadres` from the schema-level `required` array (now `[]`)
- Set `required: false` on the `e-mailadres` property
- Bump schema version `0.0.26` → `0.0.27` so existing installations reload the schema
- Bump app version `0.2.2` → `0.2.3` for NC immutable cache-bust

## Verification

- `composer check:strict` exits 0 (PHPCS + PHPMD + Psalm + PHPStan all pass)
- No DB migrations needed — Magic Mapper will alter the column to nullable on next schema reload (triggered by the version bump)