### PR TITLE
feat: multi-org-membership — organisation switcher + self-service colleague access (#371)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -220,6 +220,14 @@ return [
         ['name' => 'merge#dryRun', 'url' => '/api/organisaties/{uuid}/merge/dry-run', 'verb' => 'POST'],
         ['name' => 'merge#execute', 'url' => '/api/organisaties/{uuid}/merge', 'verb' => 'POST'],
 
+        // SELF-SERVICE COLLEAGUE ACCESS (multi-org-membership) — beheerder-of-this-
+        // organisation gated (authorizeBeheerder() guard in the controller body,
+        // no-admin-idor safe). Delegates the actual membership mutation to
+        // OpenRegister's OrganisationService::joinOrganisation()/leaveOrganisation().
+        // @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+        ['name' => 'organisationMembers#grant', 'url' => '/api/organisations/{uuid}/members', 'verb' => 'POST'],
+        ['name' => 'organisationMembers#revoke', 'url' => '/api/organisations/{uuid}/members/{userId}', 'verb' => 'DELETE'],
+
         // FEDERATION SETTINGS / MANUAL PULL — admin-gated (AuthorizedAdminSetting).
         ['name' => 'federation#status', 'url' => '/api/federation/status', 'verb' => 'GET'],
         ['name' => 'federation#addPeer', 'url' => '/api/federation/peers', 'verb' => 'POST'],

--- a/docs/features/multi-org-membership.md
+++ b/docs/features/multi-org-membership.md
@@ -1,0 +1,104 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+  - SPDX-License-Identifier: EUPL-1.2
+  -->
+
+# Multi-organisation membership
+
+Lets one Nextcloud account act for more than one organisation: an
+organisation switcher in the app header, and a self-service flow so an
+organisation's own beheerders can grant or revoke an existing colleague's
+access — without an administrator. Built for shared service centres,
+samenwerkingsverbanden, and the dual-membership transition period during a
+gemeentelijke herindeling. See
+[VNG Softwarecatalogus issue #57](https://github.com/VNG-Realisatie/Softwarecatalogus/issues/57),
+[#60](https://github.com/VNG-Realisatie/Softwarecatalogus/issues/60), and
+[#65](https://github.com/VNG-Realisatie/Softwarecatalogus/issues/65).
+
+Specification: [`openspec/specs/multi-org-membership/spec.md`](../../openspec/specs/multi-org-membership/spec.md).
+
+Everything in this feature is built on OpenRegister's own, already-shipped
+`OrganisationService`/`OrganisationController` — SoftwareCatalog does not
+store a separate membership record anywhere.
+
+## Switching your active organisation
+
+A member of two or more organisations sees a switcher in the app header
+(next to the other header actions), showing the currently-active
+organisation's name. Opening it lists every organisation the user belongs
+to; picking a different one:
+
+1. Calls OpenRegister's own `POST /apps/openregister/api/organisations/{uuid}/set-active`
+   directly — SoftwareCatalog does not proxy this call.
+2. OpenRegister verifies, server-side, that the caller is actually a member
+   of that organisation (`Organisation::hasUser()`) before changing
+   anything. A switch to an organisation the user does not belong to is
+   refused and the active organisation is left unchanged — this can never
+   be bypassed by anything the client sends.
+3. On success, the page reloads. Every list, dashboard, and detail view
+   therefore re-fetches from scratch under the new active organisation's
+   session — there is no risk of one view still showing the previous
+   organisation's data after a switch.
+
+A user who belongs to zero or one organisation does not see a switch-target
+list (mirrors the shared `CnTenantBadge` component's auto-hide behaviour),
+though the header entry still shows their one organisation's name.
+
+## Granting or revoking a colleague's access
+
+A **beheerder** — a member of the organisation who also holds the
+`beheerder` Nextcloud group role — sees a "Manage members" entry in the same
+header switcher, opening a dialog for their currently-active organisation:
+
+- **Current members** — the organisation's member list, read directly from
+  OpenRegister's own `GET /apps/openregister/api/organisations/{uuid}`
+  (already access-controlled there).
+- **Grant access** — pick an *existing* Nextcloud user (via `NcSelectUsers`)
+  and confirm. This is deliberately existing-user-only: it is not an invite
+  flow, and never creates a Nextcloud account.
+- **Revoke access** — remove a member from the list.
+
+Both actions are authorised server-side by a new, SoftwareCatalog-specific
+check (`OrganisationMembersController::authorizeBeheerder()`) that OpenRegister's
+own membership endpoints don't perform (OpenRegister's `join`/`leave` only
+recognise a Nextcloud admin or the organisation's single `owner` field as
+allowed to manage another user's membership — SoftwareCatalog's `beheerder`
+role is a separate, broader concept). The check requires **both**:
+
+1. The caller is authenticated and in the global `beheerder` Nextcloud group.
+2. The caller's own organisation memberships — resolved from OpenRegister's
+   `OrganisationService::getUserOrganisations()`, never from anything the
+   client sends — include the organisation being managed.
+
+Only once both hold does the controller call OpenRegister's own
+`joinOrganisation()` / `leaveOrganisation()` to perform the actual mutation.
+A beheerder of one organisation cannot grant or revoke access to a
+*different* organisation they don't belong to, even though they hold the
+role.
+
+```
+POST /apps/softwarecatalog/api/organisations/{uuid}/members
+{ "userId": "j.devries" }
+
+DELETE /apps/softwarecatalog/api/organisations/{uuid}/members/{userId}
+```
+
+## What this does not do
+
+- **No new-user invites.** Granting access always requires an existing
+  Nextcloud account; inviting someone by e-mail is a separate, unbuilt
+  capability (user provisioning).
+- **No change to what a role can see.** Switching the active organisation
+  changes *which* organisation a session is scoped to; the RBAC rules that
+  govern what each role may read within that organisation are unchanged
+  (`vendor-visibility-rbac`).
+- **No cross-organisation data merge.** That is a different capability
+  ([organisation merge](organisation-merge.md), softwarecatalog#370).
+
+## Screenshots
+
+Not captured in this pass — this change did not deploy to a live instance
+(the shared dev Nextcloud container was deliberately left untouched per the
+change's constraints). A follow-up pass should capture the header switcher
+and the "Manage members" dialog via Playwright MCP against a running
+instance with a multi-organisation test user, consistent with ADR-010.

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -568,6 +568,14 @@
         "Suite created.": "Suite created.",
         "Suites": "Suites",
         "Version": "Version",
-        "Vulnerability match": "Vulnerability match"
+        "Vulnerability match": "Vulnerability match",
+        "Current members": "Current members",
+        "Failed to switch organisation": "Failed to switch organisation",
+        "Grant access": "Grant access",
+        "Grant access to an existing Nextcloud user": "Grant access to an existing Nextcloud user",
+        "Manage access to {name}": "Manage access to {name}",
+        "Manage members": "Manage members",
+        "No members yet.": "No members yet.",
+        "Revoke access": "Revoke access"
     }
 }

--- a/l10n/en_US.js
+++ b/l10n/en_US.js
@@ -404,7 +404,16 @@ OC.L10N.register(
     "What was your experience with this software?" : "What was your experience with this software?",
     "Submit review" : "Submit review",
     "Thank you — your review was submitted for moderation" : "Thank you — your review was submitted for moderation",
-    "Could not submit your review" : "Could not submit your review"
+    "Could not submit your review" : "Could not submit your review",
+    "Failed to switch organisation" : "Failed to switch organisation",
+    "Manage members" : "Manage members",
+    "Manage access to {name}" : "Manage access to {name}",
+    "Grant access to an existing Nextcloud user" : "Grant access to an existing Nextcloud user",
+    "Grant access" : "Grant access",
+    "Current members" : "Current members",
+    "No members yet." : "No members yet.",
+    "Revoke access" : "Revoke access",
+    "Close" : "Close"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/en_US.json
+++ b/l10n/en_US.json
@@ -463,6 +463,15 @@
         "What was your experience with this software?": "What was your experience with this software?",
         "Submit review": "Submit review",
         "Thank you — your review was submitted for moderation": "Thank you — your review was submitted for moderation",
-        "Could not submit your review": "Could not submit your review"
+        "Could not submit your review": "Could not submit your review",
+        "Failed to switch organisation": "Failed to switch organisation",
+        "Manage members": "Manage members",
+        "Manage access to {name}": "Manage access to {name}",
+        "Grant access to an existing Nextcloud user": "Grant access to an existing Nextcloud user",
+        "Grant access": "Grant access",
+        "Current members": "Current members",
+        "No members yet.": "No members yet.",
+        "Revoke access": "Revoke access",
+        "Close": "Close"
     }
 }

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -441,7 +441,16 @@ OC.L10N.register(
     "What was your experience with this software?" : "Wat was uw ervaring met deze software?",
     "Submit review" : "Beoordeling indienen",
     "Thank you — your review was submitted for moderation" : "Bedankt — uw beoordeling is ingediend ter moderatie",
-    "Could not submit your review" : "Kon uw beoordeling niet indienen"
+    "Could not submit your review" : "Kon uw beoordeling niet indienen",
+    "Failed to switch organisation" : "Wisselen van organisatie is mislukt",
+    "Manage members" : "Leden beheren",
+    "Manage access to {name}" : "Toegang tot {name} beheren",
+    "Grant access to an existing Nextcloud user" : "Toegang geven aan een bestaande Nextcloud-gebruiker",
+    "Grant access" : "Toegang geven",
+    "Current members" : "Huidige leden",
+    "No members yet." : "Nog geen leden.",
+    "Revoke access" : "Toegang intrekken",
+    "Close" : "Sluiten"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -607,6 +607,15 @@
         "What was your experience with this software?": "Wat was uw ervaring met deze software?",
         "Submit review": "Beoordeling indienen",
         "Thank you — your review was submitted for moderation": "Bedankt — uw beoordeling is ingediend ter moderatie",
-        "Could not submit your review": "Kon uw beoordeling niet indienen"
+        "Could not submit your review": "Kon uw beoordeling niet indienen",
+        "Failed to switch organisation": "Wisselen van organisatie is mislukt",
+        "Manage members": "Leden beheren",
+        "Manage access to {name}": "Toegang tot {name} beheren",
+        "Grant access to an existing Nextcloud user": "Toegang geven aan een bestaande Nextcloud-gebruiker",
+        "Grant access": "Toegang geven",
+        "Current members": "Huidige leden",
+        "No members yet.": "Nog geen leden.",
+        "Revoke access": "Toegang intrekken",
+        "Close": "Sluiten"
     }
 }

--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -1580,7 +1580,7 @@ class ContactpersonenController extends Controller
             // OrganisationMembersController; this flag merely lets the
             // frontend decide whether to render the "manage members"
             // affordance at all).
-            // @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004.
+            // See @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004 for the authorization contract this flag hints at.
             'isBeheerder'   => false,
         ];
     }//end buildEmptyMeResponse()

--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -1467,6 +1467,7 @@ class ContactpersonenController extends Controller
 
             // Initialize response with user data from Nextcloud.
             $response = $this->buildEmptyMeResponse(userEmail: $userEmail);
+            $response['isBeheerder'] = $this->groupManager->isInGroup($userId, 'beheerder');
 
             // Try to get contactpersoon data for additional profile info.
             $this->enrichMeWithContactpersoonData(
@@ -1573,6 +1574,14 @@ class ContactpersonenController extends Controller
                 'active' => null,
                 'all'    => [],
             ],
+            // Global `beheerder` NC group membership — a client-side hint
+            // only (per-organisation authorization is re-verified
+            // server-side on every grant/revoke by
+            // OrganisationMembersController; this flag merely lets the
+            // frontend decide whether to render the "manage members"
+            // affordance at all).
+            // @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004.
+            'isBeheerder'   => false,
         ];
     }//end buildEmptyMeResponse()
 

--- a/lib/Controller/OrganisationMembersController.php
+++ b/lib/Controller/OrganisationMembersController.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * Softwarecatalog OrganisationMembersController.
+ *
+ * Self-service colleague access (VNG Softwarecatalogus #65): lets a
+ * `beheerder` of an organisation grant or revoke an EXISTING Nextcloud
+ * user's membership of that organisation, without an administrator.
+ *
+ * This controller deliberately does NOT reimplement membership storage.
+ * Every mutation delegates to OpenRegister's already-shipped
+ * `OrganisationService::joinOrganisation()` / `leaveOrganisation()`
+ * (ADR-011/ADR-022). It exists only because OpenRegister's own
+ * `OrganisationController::join()`/`leave()` authorize a caller managing
+ * ANOTHER user's membership solely via Nextcloud-admin-or-single-`owner`
+ * (`canManageOrganisationMembers()`), which does not match SoftwareCatalog's
+ * `beheerder`-role domain model — so this controller adds that
+ * domain-specific authorization guard before delegating.
+ *
+ * AUTH: `#[NoAdminRequired]` route annotation PLUS an explicit, per-object
+ * authorization guard in the method body (`authorizeBeheerder()`) — the
+ * route annotation alone is NOT treated as sufficient authorization
+ * (no-admin-idor gate). The guard is fail-closed: both checks (global
+ * `beheerder` NC group membership AND OpenRegister-verified membership of
+ * the TARGET organisation, never a client-supplied claim) MUST pass before
+ * any membership mutation is attempted.
+ *
+ * @category  Controller
+ * @package   OCA\SoftwareCatalog\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/SoftwareCatalog
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Controller;
+
+use OCA\SoftwareCatalog\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Beheerder-gated grant/revoke of organisation membership for an existing
+ * Nextcloud user, delegating the actual mutation to OpenRegister.
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md
+ */
+class OrganisationMembersController extends Controller
+{
+    /**
+     * NC group whose members may manage an organisation's own membership,
+     * per organisation, when they also belong to that organisation.
+     * Matches the group `ContactPersonHandler::assignBeheerderRole()`
+     * already assigns.
+     */
+    private const BEHEERDER_GROUP = 'beheerder';
+
+    /**
+     * Constructor.
+     *
+     * @param IRequest           $request      The request.
+     * @param IUserSession       $userSession  The user session (auth guard).
+     * @param IGroupManager      $groupManager Group membership (beheerder guard).
+     * @param IUserManager       $userManager  User lookup (existing-user-only guard).
+     * @param ContainerInterface $container    DI container, used to reach OpenRegister's
+     *                                         `OrganisationService` without a hard compile-time
+     *                                         dependency on another app's class.
+     * @param LoggerInterface    $logger       Logger.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IUserSession $userSession,
+        private readonly IGroupManager $groupManager,
+        private readonly IUserManager $userManager,
+        private readonly ContainerInterface $container,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+    }//end __construct()
+
+    /**
+     * Grant an existing Nextcloud user access to an organisation.
+     *
+     * @param string $uuid   The organisation UUID.
+     * @param string $userId The existing Nextcloud user id to grant access to.
+     *
+     * @return JSONResponse Success (200), or a 401/403/404/400 error.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @spec            openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function grant(string $uuid, string $userId): JSONResponse
+    {
+        $guard = $this->authorizeBeheerder(organisationUuid: $uuid);
+        if ($guard instanceof JSONResponse) {
+            return $guard;
+        }
+
+        if ($this->userManager->get($userId) === null) {
+            return new JSONResponse(
+                data: ['error' => 'User not found'],
+                statusCode: Http::STATUS_NOT_FOUND
+            );
+        }
+
+        try {
+            $organisationService = $this->getOrganisationService();
+            $organisationService->joinOrganisation(organisationUuid: $uuid, targetUserId: $userId);
+        } catch (\Exception $e) {
+            $this->logger->error(
+                '[OrganisationMembersController] Failed to grant organisation access',
+                ['organisationUuid' => $uuid, 'userId' => $userId, 'error' => $e->getMessage()]
+            );
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        return new JSONResponse(
+            data: [
+                'message' => 'Successfully granted organisation access',
+                'userId'  => $userId,
+            ],
+            statusCode: Http::STATUS_OK
+        );
+    }//end grant()
+
+    /**
+     * Revoke an existing member's access to an organisation.
+     *
+     * @param string $uuid   The organisation UUID.
+     * @param string $userId The Nextcloud user id to revoke access from.
+     *
+     * @return JSONResponse Success (200), or a 401/403/400 error.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     * @spec            openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+     */
+    #[NoAdminRequired]
+    #[NoCSRFRequired]
+    public function revoke(string $uuid, string $userId): JSONResponse
+    {
+        $guard = $this->authorizeBeheerder(organisationUuid: $uuid);
+        if ($guard instanceof JSONResponse) {
+            return $guard;
+        }
+
+        try {
+            $organisationService = $this->getOrganisationService();
+            $organisationService->leaveOrganisation(organisationUuid: $uuid, targetUserId: $userId);
+        } catch (\Exception $e) {
+            $this->logger->error(
+                '[OrganisationMembersController] Failed to revoke organisation access',
+                ['organisationUuid' => $uuid, 'userId' => $userId, 'error' => $e->getMessage()]
+            );
+            return new JSONResponse(
+                data: ['error' => $e->getMessage()],
+                statusCode: Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        return new JSONResponse(
+            data: [
+                'message' => 'Successfully revoked organisation access',
+                'userId'  => $userId,
+            ],
+            statusCode: Http::STATUS_OK
+        );
+    }//end revoke()
+
+    /**
+     * Beheerder-of-this-organisation authorization guard (IDOR guard).
+     *
+     * Fail-closed, two independent server-side checks — never a
+     * client-supplied claim:
+     *  1. The caller is authenticated and belongs to the global `beheerder`
+     *     NC group (cheap check first; rejects most non-beheerders without
+     *     an OpenRegister round trip).
+     *  2. The caller's OWN organisation memberships, resolved from
+     *     OpenRegister's `OrganisationService::getUserOrganisations()`
+     *     (session-scoped — the same source `setActiveOrganisation()`
+     *     trusts), include the TARGET organisation UUID. A `beheerder` of a
+     *     different organisation does NOT pass this check.
+     *
+     * @param string $organisationUuid The organisation the caller is trying to manage.
+     *
+     * @return JSONResponse|null Error response, or null when authorized.
+     *
+     * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+     */
+    private function authorizeBeheerder(string $organisationUuid): ?JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['error' => 'Not authenticated'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        if ($this->groupManager->isInGroup($user->getUID(), self::BEHEERDER_GROUP) === false) {
+            $this->logger->warning(
+                '[OrganisationMembersController] Access refused (not a beheerder)',
+                ['uid' => $user->getUID(), 'organisationUuid' => $organisationUuid]
+            );
+            return new JSONResponse(
+                data: ['error' => 'Only a beheerder of this organisation may grant or revoke access'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        try {
+            $organisationService = $this->getOrganisationService();
+            $callerOrganisations = $organisationService->getUserOrganisations();
+        } catch (\Exception $e) {
+            $this->logger->error(
+                '[OrganisationMembersController] Failed to resolve caller organisations',
+                ['uid' => $user->getUID(), 'error' => $e->getMessage()]
+            );
+            return new JSONResponse(
+                data: ['error' => 'Unable to verify organisation membership'],
+                statusCode: Http::STATUS_FORBIDDEN
+            );
+        }
+
+        foreach ($callerOrganisations as $organisation) {
+            if ($organisation->getUuid() === $organisationUuid) {
+                return null;
+            }
+        }
+
+        $this->logger->warning(
+            '[OrganisationMembersController] Access refused (beheerder of a different organisation)',
+            ['uid' => $user->getUID(), 'organisationUuid' => $organisationUuid]
+        );
+        return new JSONResponse(
+            data: ['error' => 'Only a beheerder of this organisation may grant or revoke access'],
+            statusCode: Http::STATUS_FORBIDDEN
+        );
+    }//end authorizeBeheerder()
+
+    /**
+     * Resolve OpenRegister's OrganisationService via the DI container.
+     *
+     * String-based lookup (not a compile-time type-hint) matches the
+     * existing pattern in `ContactpersonenController::getMe()` and
+     * `OrganizationHandler` — OpenRegister is a required app dependency but
+     * its classes are not part of this app's own composer autoload map.
+     *
+     * @return \OCA\OpenRegister\Service\OrganisationService The service instance.
+     *
+     * @throws \Throwable When OpenRegister is unavailable.
+     */
+    private function getOrganisationService(): \OCA\OpenRegister\Service\OrganisationService
+    {
+        return $this->container->get('OCA\OpenRegister\Service\OrganisationService');
+    }//end getOrganisationService()
+}//end class

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: conduction
+created: 2026-07-24

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/context-brief.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/context-brief.md
@@ -1,0 +1,37 @@
+# Context Brief: multi-org-membership
+
+## What
+Let one user act for **multiple organisations** (samenwerkingsverbanden, shared service centres, herindeling transitions): an organisation switcher in the app UI, and a self-service flow to give a colleague access to your organisation. Closes softwarecatalog#371.
+
+## Why (evidence)
+- VNG Softwarecatalogus issues **#57** and **#60** — one account active in multiple organisations.
+- VNG **#65** — self-service colleague access (today an admin must do it).
+- Dutch municipal reality: shared service centres and samenwerkingsverbanden mean one person legitimately works for several organisations; herindelingen create transition periods with dual membership.
+
+## The hard part is ALREADY BUILT — verify before you build anything
+`openregister/lib/Service/OrganisationService.php` already ships (verified 2026-07-24):
+- `getUserOrganisations(bool $_useCache = true): array` (line ~474)
+- `getActiveOrganisation(?array $preloadedOrgs = null): ?Organisation` (line ~513)
+- `setActiveOrganisation(string $organisationUuid): bool` (line ~560)
+
+So membership + active-org switching exist at the platform layer. **Read those methods first** and build on them — do NOT reimplement membership in softwarecatalog. Check what HTTP surface OpenRegister already exposes for them (grep its `appinfo/routes.php` and controllers); if an endpoint already exists, consume it rather than adding a proxy controller here (ADR-011: check OpenRegister core before adding your own; ADR-022: apps consume OR abstractions — a pass-through controller is a `hydra-gate-redundant-controller` failure).
+
+Softwarecatalog currently has **no org-switcher UI** and **no invite flow** (`grep -rli "invite\|uitnodig" src/ lib/` → nothing). `lib/Controller/ContactpersonenController.php` references the org primitives — read it to see the existing pattern.
+
+## Scope
+IN:
+- **Organisation switcher** in the app UI (header/nav area) listing the user's organisations and switching the active one; the whole app's tenant context (`X-OpenRegister-Organisation`) must follow the switch, and lists/pages must refresh to the newly-active organisation.
+- **Self-service colleague access**: an organisation member with the right role can grant an existing Nextcloud user access to their organisation (and revoke it). Build on the existing role/group machinery in `openspec/specs/sc-handlers/spec.md` (`ContactPersonHandler`, `addUsersToOrganization`) and `softwarecatalog-contacts-to-nc`.
+- i18n (EN keys + nl + en_US), unit tests, docs.
+
+OUT: inviting brand-new users by email (that is user provisioning — out of scope); cross-organisation data merging (that is #370/organisation-merge); changing the RBAC model itself.
+
+## Design constraints
+- 🔒 **Interacts directly with the security model just hardened in sc#395 (`schema-rbac-hardening`).** Schema RBAC now scopes reads by `_organisation` matched against the caller's organisation context. Switching the active organisation MUST change what the user can see — and must NOT become a way to read an organisation the user is not a member of. Membership has to be verified server-side on every switch; never trust a client-supplied organisation id. Include NEGATIVE tests: switching to a non-member organisation is refused, and after switching the user sees only that organisation's data.
+- **Any register change goes in a NEW `lib/Settings/register.d/multi-org-membership.json` fragment — never edit the monolith** (ADR-037; a monolith edit was a silent no-op on installed instances until sc#396, and fragments remain the correct pattern).
+- 🔑 Register store object types by **schema SLUG** against `voorzieningenConfig.register` (the `useSelfFetchList.js` pattern) — several `voorzieningen_config.<x>_schema` keys are never populated; that mistake shipped a dead org picker (sc#392).
+- ADR-012 `@conduction/nextcloud-vue` components; modals/dialogs each in their own file; `NcSelect` needs `inputLabel`.
+- Security change ⇒ `hydra-gate-security-change-has-tests` requires tests. SPDX docblocks on new lib/ PHP.
+- Spec deltas: `### Requirement: <name>` headers; MUST/SHALL on the requirement's FIRST physical line; no angle brackets in requirement bodies; `#### Scenario:` GIVEN/WHEN/THEN per MUST/SHALL.
+- `@spec` anchors → canonical `openspec/specs/<capability>/spec.md#requirement-<kebab>`, NEVER a change dir (archive moves it).
+- ⚠️ After `openspec archive`, run `grep -c '^### ' openspec/specs/<cap>/spec.md` and `git diff -- openspec/specs/` — the archiver silently DELETES legacy `### REQ-NNN:` requirements (hydra#376).

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/design.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/design.md
@@ -1,0 +1,276 @@
+# Design: multi-org-membership
+
+## Architecture Overview
+SoftwareCatalog is a thin OpenRegister client (ADR-001/ADR-022): it stores no
+domain tables of its own and already stores organisation *identity* in
+OpenRegister's `Organisation` entity via `OCA\OpenRegister\Service\
+OrganisationService` (injected throughout `ContactpersonenController`,
+`OrganizationHandler`, `SoftwareCatalogueService`, etc. — see
+`../openregister/lib/Service/OrganisationService.php`). That service already
+implements every membership primitive this change needs:
+
+- `getUserOrganisations()` — the caller's organisations (session-cached).
+- `getActiveOrganisation()` — the caller's currently-active organisation
+  (session + persistent `IConfig` user value).
+- `setActiveOrganisation($uuid)` — switches the active organisation,
+  **throwing unless `Organisation::hasUser($callerId) === true`** — i.e.
+  membership is already verified server-side, from the authoritative
+  `Organisation.users` array, never from a client-supplied claim.
+- `joinOrganisation($uuid, $targetUserId = null)` /
+  `leaveOrganisation($uuid, $targetUserId = null)` — add/remove a user from
+  `Organisation.users`.
+
+`OrganisationController` (`../openregister/lib/Controller/
+OrganisationController.php`) already exposes all of the above over HTTP
+(`appinfo/routes.php` lines 937-960): `GET /api/organisations` (list + stats),
+`GET /api/organisations/active`, `GET /api/organisations/{uuid}`,
+`POST /api/organisations/{uuid}/set-active`, `POST /api/organisations/{uuid}/join`,
+`POST /api/organisations/{uuid}/leave`. Every one of those actions is
+`@NoAdminRequired` + session-scoped or membership-gated; `join`/`leave`
+additionally already refuse a caller who tries to enrol/remove *another* user
+unless that caller is a Nextcloud admin or the organisation's `owner` field
+(`canManageOrganisationMembers()`).
+
+**Consequence for this design**: the organisation switcher is a pure
+frontend consumer of OpenRegister's existing HTTP surface — no new
+SoftwareCatalog PHP is needed for switching. SoftwareCatalog's own
+`OrganisationMembersController` is needed for exactly one reason: its
+`beheerder`-role authorisation model (any org member who is also in the NC
+group `beheerder` may manage that org's membership) is *not* the same
+authorisation model OpenRegister's `join`/`leave` enforce (admin or single
+`owner` only). SoftwareCatalog's controller adds that domain-specific
+authorisation check and then delegates the mutation itself to
+`OrganisationService::joinOrganisation()`/`leaveOrganisation()` — it does not
+reimplement or duplicate the membership storage.
+
+```
+Frontend (Vue)                     SoftwareCatalog (PHP)              OpenRegister (PHP)
+─────────────────                  ────────────────────               ──────────────────
+OrganisationSwitcher.vue  ───GET──▶ ContactpersonenController          (existing, unchanged)
+  (list + active)                    ::getMe()  [existing endpoint]
+                            ───POST─────────────────────────────────▶ OrganisationController
+  (switch)                                                              ::setActive()
+                                                                          → OrganisationService
+                                                                             ::setActiveOrganisation()
+                                                                             (membership verified
+                                                                              server-side)
+
+GrantOrganisationAccessModal.vue
+  (members list)            ───GET──────────────────────────────────▶ OrganisationController::show()
+                                                                          (hasAccessToOrganisation() gate)
+  (grant / revoke)          ───POST─▶ OrganisationMembersController    (NEW — beheerder-role gate)
+                                        ::grant() / ::revoke()
+                                        → OrganisationService
+                                           ::joinOrganisation()/::leaveOrganisation()
+```
+
+## API Design
+
+### `POST /apps/openregister/api/organisations/{uuid}/set-active` (existing, consumed unchanged)
+Frontend calls this directly. No SoftwareCatalog route added.
+
+### `GET /apps/softwarecatalog/api/me` (existing, consumed unchanged)
+Already returns `organisations.active` and `organisations.all` (uuid, naam,
+id, slug) — the switcher's list source.
+
+### `GET /apps/openregister/api/organisations/{uuid}` (existing, consumed unchanged)
+Frontend calls this directly for the member list (`organisation.users`,
+an array of NC user ids) when the grant/revoke modal opens. Already gated by
+`hasAccessToOrganisation()`.
+
+### `POST /apps/softwarecatalog/api/organisations/{uuid}/members` (NEW)
+**Request:**
+```json
+{ "userId": "j.devries" }
+```
+**Response (200):**
+```json
+{ "message": "Successfully granted organisation access", "userId": "j.devries" }
+```
+**Response (403 — caller not a beheerder of this organisation):**
+```json
+{ "error": "Only a beheerder of this organisation may grant access" }
+```
+**Response (404 — target user does not exist):**
+```json
+{ "error": "User not found" }
+```
+
+### `DELETE /apps/softwarecatalog/api/organisations/{uuid}/members/{userId}` (NEW)
+**Response (200):**
+```json
+{ "message": "Successfully revoked organisation access", "userId": "j.devries" }
+```
+**Response (403):** same shape as grant.
+
+## Database Changes
+None. `lib/Settings/register.d/multi-org-membership.json` is added as an
+**empty-but-present** fragment file only if a follow-up needs a config
+surface; this change stores nothing new — all state already lives in
+OpenRegister's `Organisation` entity and Nextcloud's `IGroupManager`/
+`IUserManager`. (Decision: omit the fragment entirely rather than ship a
+no-op file — see Decisions below.)
+
+## Nextcloud Integration
+- Controllers: NEW `OCA\SoftwareCatalog\Controller\OrganisationMembersController`
+  (extends `OCP\AppFramework\Controller`, `#[NoAdminRequired]` +
+  `#[NoCSRFRequired]` on `grant`/`revoke`, following
+  `ContactpersonenController`'s constructor-injection pattern:
+  `IUserSession`, `IUserManager`, `IGroupManager`, `ContainerInterface`
+  (to reach OpenRegister's `OrganisationService`/`OrganisationMapper`),
+  `LoggerInterface`).
+- Services: consumes `OCA\OpenRegister\Service\OrganisationService` and
+  `OCA\OpenRegister\Db\OrganisationMapper` via the container, exactly as
+  `ContactpersonenController::getMe()` and `OrganizationHandler` already do
+  — no new SoftwareCatalog service class for membership itself.
+- Mappers/Entities: none new.
+- Events/Hooks: none new.
+
+## Security Considerations
+This is a security-relevant change (`hydra-gate-security-change-has-tests`
+applies) because it changes *which* organisation's data a session is scoped
+to, and *who* may become a member of an organisation.
+
+1. **Switch is never client-trusted.** The switcher POSTs only the target
+   `uuid` (a route parameter); OpenRegister's `setActiveOrganisation()`
+   re-derives membership from `Organisation::hasUser($this->userSession->
+   getUser()->getUID())` — the session user, not anything the client sends —
+   and throws otherwise. SoftwareCatalog adds no bypass path.
+2. **Grant/revoke authorisation is derived, not accepted.** The new
+   controller never trusts a client claim of "I am a beheerder of org X". It
+   derives the caller's own organisation membership from
+   `OrganisationService::getUserOrganisations()` (session-scoped, matching
+   what `setActiveOrganisation` itself trusts) intersected with NC group
+   `beheerder` (`IGroupManager::isInGroup($callerId, 'beheerder')`, the same
+   group `ContactPersonHandler::assignBeheerderRole()` already populates).
+   Both checks run server-side before the mutation; failing either returns
+   403 without calling `joinOrganisation`/`leaveOrganisation` (deny before
+   any default grant — OR trap or#2025).
+3. **Read-scoping is unaffected and does the rest of the work.** Once the
+   active organisation changes, `vendor-visibility-rbac`'s schema-level
+   `_organisation` matching (already hardened, unchanged by this proposal)
+   is what actually prevents cross-organisation reads — this change's job is
+   only to make sure the *session's* active organisation is trustworthy and
+   that the UI reflects it, which is why every list/detail view is forced to
+   re-fetch after a confirmed switch (see Decisions).
+4. **Existing-user-only.** Granting access never creates a Nextcloud
+   account; the target must already resolve via `IUserManager::get()`,
+   closing the "enrol an unverified identity" vector entirely (email invites
+   are explicitly out of scope).
+
+## NL Design System
+- `OrganisationSwitcher.vue` renders in `CnAppRoot`'s `#tenant-badge` slot
+  using only Nextcloud CSS variables (matches `CnTenantBadge`'s existing
+  styling contract — no `--nldesign-*` references, per nc-vue rules).
+- `GrantOrganisationAccessModal.vue` is a `NcDialog` (has a heading + action
+  buttons — see nc-vue's NcDialog-vs-NcModal rule) living in its own file
+  under `src/modals/`, using `NcSelectUsers` (`inputLabel` set) for the user
+  picker and `NcListItem` + a destructive `NcActionButton` for revoke rows.
+
+## File Structure
+```
+lib/
+  Controller/
+    OrganisationMembersController.php        (NEW)
+src/
+  App.vue                                     (modified — tenant-context wiring)
+  components/
+    organisations/
+      OrganisationSwitcher.vue                (NEW)
+  modals/
+    GrantOrganisationAccessModal.vue          (NEW)
+    Modals.vue                                (modified — register new modal)
+  store/
+    modules/
+      organisatie.js                          (modified — grant/revoke actions)
+tests/
+  unit/
+    Controller/
+      OrganisationMembersControllerTest.php   (NEW)
+  (src/**/*.spec.js for the Vue pieces, colocated per existing convention)
+l10n/
+  nl.js / nl.json                             (modified)
+  en_US.js / en_US.json                       (modified)
+docs/
+  features/
+    multi-org-membership.md                   (NEW, with screenshots)
+```
+
+## Seed Data
+Not applicable — this change introduces no new OpenRegister schema/register.
+Organisations and users used in testing are the existing dev-environment
+seed data (multiple `organisatie` objects with distinct `users` arrays are
+already present from prior multi-tenancy work); manual test setup adds a
+second Nextcloud user to one organisation's `beheerder` group to exercise
+the grant/revoke flow.
+
+**`OrganisationSwitcher.vue` does not depend on nc-vue's `provide`/`inject`
+tenant-context propagating correctly through a slot override.** `CnAppRoot`
+mounts its own `provideTenantContext()` internally, and its default
+`#tenant-badge` slot content (`CnTenantBadge`) is authored inside
+`CnAppRoot.vue` itself, so it is unambiguously a true descendant for
+`inject` purposes. Overriding that slot from `App.vue` (`<template
+#tenant-badge>`) is different: slot content authored by the consuming app
+and passed into a child component's slot has, in the general Vue
+provide/inject model, an inject-resolution chain whose exact behaviour
+depends on internals this change does not need to gamble on, and no other
+app in the fleet has exercised this exact "override `#tenant-badge` from
+the consumer" path yet to confirm it empirically. Rather than risk two
+tenant-context readers (a live badge and the switcher) silently resolving
+to two different reactive objects after a switch, `OrganisationSwitcher.vue`
+is entirely self-contained: it fetches its own org list from `/api/me`, and
+on a successful switch reloads the page rather than mutating any shared
+reactive context in place. The default `#tenant-badge` slot is suppressed
+(`<template #tenant-badge></template>`) and the switcher renders instead via
+`#header-actions` (documented as free-form consumer content, no inject
+contract implied) so there is exactly one on-screen indicator, always
+self-consistent. The full-reload-on-switch strategy (already adopted for
+REQ-002's security guarantee, see below) makes this the simpler design, not
+just the safer one — nothing needs to propagate reactively within a single
+page load, because a switch always ends that page load.
+
+## Trade-offs
+
+**Full view refresh vs. targeted cache invalidation on switch.**
+`CnIndexPage`'s `activeOrganisation` watcher (already shipped in nc-vue)
+clears the bound object store's cache but does not itself re-issue a fetch,
+and SoftwareCatalog's manifest-driven `CnPageRenderer` does not currently
+forward an `activeOrganisation` prop to every page type (dashboard, custom
+views, faceted views) — wiring that per-page would touch a much larger
+surface than this change's scope. Instead, after a confirmed switch this
+change clears the shared object store's cache
+(`useObjectStore().setActiveTenantOrganisation()`) **and** forces a full
+reload of the current route. This is less elegant than fine-grained
+reactivity but is the only option in this change's scope that is
+*verifiably* correct for the security requirement ("the user sees only the
+newly-active organisation's data") across all thirty manifest pages,
+including the bespoke Dashboard and settings custom views that do not go
+through `CnIndexPage`/`CnDetailPage` at all. Follow-up: promote per-page-type
+`activeOrganisation` forwarding to `CnPageRenderer` in nc-vue so a future
+change can drop the reload in favour of targeted refetch.
+
+**SoftwareCatalog's own per-organisation NC group vs. OpenRegister's
+`Organisation.users`.** `OrganizationHandler::userBelongsToOrganization()`
+checks a group name derived from `sanitizeGroupName($organisationUuid)` (the
+raw UUID), but the organisation's actual group is created and populated
+using `sanitizeGroupName($organisationName)` (the org's *name*) — the two
+never match, so that helper's primary branch (and its UUID-substring
+fallback) are dead in the normal flow. This is a pre-existing, unrelated
+latent bug (multiple call sites: `HierarchyHandler`, `ContractApprovalService`,
+`getOrganizationBeheerders()`'s membership filter). This change deliberately
+does not read or fix that helper — every check this change performs uses
+OpenRegister's `Organisation.users`/`hasUser()` directly, which is correct
+and already authoritative elsewhere (`setActiveOrganisation`, schema RBAC).
+Fixing `userBelongsToOrganization` is out of scope here (unrelated blast
+radius in a security-sensitive PR) and is called out as a follow-up.
+
+**No new register fragment file.** ADR-037 requires any *register* change to
+land in a new `lib/Settings/register.d/multi-org-membership.json` fragment,
+never the monolith. This change adds no new schema/register objects, so no
+fragment file is created — an empty placeholder fragment would be dead
+weight and would not be "a register change" in any real sense.
+
+## Open Questions
+None — see proposal.md's Open Questions for the two assumptions already
+resolved with the requester (direct OR consumption; `beheerder`-role
+authorisation).

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/proposal.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/proposal.md
@@ -1,0 +1,185 @@
+# Proposal: multi-org-membership
+
+## Summary
+Lets one Nextcloud user act for multiple organisations in SoftwareCatalog: an
+organisation switcher in the app header that lists the user's organisations
+and switches which one is active, and a self-service flow so an organisation
+member with the right role can grant or revoke an existing Nextcloud user's
+access to their organisation without going through an administrator. Both
+build directly on OpenRegister's already-shipped `OrganisationService`
+(`getUserOrganisations`, `getActiveOrganisation`, `setActiveOrganisation`,
+`joinOrganisation`, `leaveOrganisation`) and its `OrganisationController` HTTP
+surface — no membership logic is reimplemented in SoftwareCatalog. Closes
+softwarecatalog#371.
+
+## Motivation
+VNG Softwarecatalogus issues #57 and #60 report that one account cannot act
+for more than one organisation, which breaks the daily reality of shared
+service centres (SSC's) and samenwerkingsverbanden, and creates friction
+during herindeling transition periods when a user legitimately belongs to
+both the old and new municipality for a time. VNG issue #65 reports that
+granting a colleague access today requires an administrator, when the
+organisation's own beheerders should be able to self-serve it. SoftwareCatalog
+currently ships neither an org switcher UI nor an invite/access-grant flow,
+even though the platform-level primitives it needs (OpenRegister's
+`OrganisationService` + `OrganisationController`) have existed since
+`retrofit-2026-05-24-b-svc-compute-profile-org` and the tenant-context wiring
+contract was already specified (but not yet implemented in SoftwareCatalog)
+by `softwarecatalog-adopt-or-abstractions`.
+
+## Affected Projects
+- [x] Project: `softwarecatalog` — organisation switcher UI, self-service
+      colleague access controller + modal, tenant-context wiring in `App.vue`,
+      i18n, unit tests
+- [ ] Project: `openregister` — consumed read-only via its existing
+      `OrganisationService` (PHP, in-process) and `OrganisationController`
+      HTTP surface (`/api/organisations/*`); no changes made here
+
+## Scope
+
+### In Scope
+- An organisation switcher in the app header/nav area listing the
+  authenticated user's organisations (from OpenRegister's
+  `getUserOrganisationStats()` / the existing `getMe()` aggregate) and letting
+  them pick a different one as active, via OpenRegister's own
+  `POST /api/organisations/{uuid}/set-active` (server-side membership
+  verification already lives there — `setActiveOrganisation()` throws unless
+  `Organisation::hasUser($userId)`).
+- Wiring nc-vue's `useTenantContext()` / `tenantContextMixin` into
+  SoftwareCatalog's `App.vue` (mounted by `CnAppRoot`) so that a switch
+  updates the shared `activeOrganisationUuid`, the `X-OpenRegister-Organisation`
+  write-header (`orClient.js`'s already-shipped `buildWriteHeaders`), the
+  `CnTenantBadge` indicator, and clears the shared object store's cache
+  (`useObjectStore().setActiveTenantOrganisation()`).
+- A hard refresh of the current view after a confirmed switch so every list
+  and detail page re-fetches under the new active organisation's session —
+  the read-side RBAC scoping hardened in `schema-rbac-hardening`/
+  `vendor-visibility-rbac` is keyed off the *server-side* session active
+  organisation, not any client-supplied value, so a full re-fetch is the only
+  way to guarantee no stale cross-tenant data stays rendered.
+- Self-service colleague access: a new `OrganisationMembersController` that
+  lets a caller who is both (a) a member of the target organisation
+  (verified against OpenRegister's `Organisation` entity, the authoritative
+  source `setActiveOrganisation`/`getUserOrganisations` already use) and
+  (b) a `beheerder` (the existing NC group `ContactPersonHandler::
+  assignBeheerderRole` already assigns) grant or revoke an *existing* NC
+  user's membership of that organisation, by delegating to OpenRegister's
+  `joinOrganisation()` / `leaveOrganisation()`.
+- A `NcSelectUsers`-based modal for picking the existing NC user to grant, and
+  a members list (sourced from OpenRegister's own `GET /api/organisations/{uuid}`,
+  which already gates on `hasAccessToOrganisation()`) with a revoke action.
+- i18n (EN keys, `nl` + `en_US` translations), unit tests including the
+  mandatory negative/security cases, and a feature doc.
+
+### Out of Scope
+- Inviting a brand-new user by e-mail who does not yet have a Nextcloud
+  account — that is user provisioning, tracked separately.
+- Cross-organisation data merging (softwarecatalog#370 /
+  `organisation-merge`).
+- Changing the RBAC model itself (`schema-rbac-hardening` /
+  `vendor-visibility-rbac` land unchanged) — this change only adds a way to
+  change *which* organisation's data a session is scoped to, and *who* may be
+  a member of an organisation; it does not touch what a role may read once
+  scoped.
+- Any change to OpenRegister's `OrganisationService`/`OrganisationController`
+  — both are already correct and sufficient for this change's needs.
+
+## Approach
+Consume, don't rebuild. OpenRegister's `OrganisationService::
+setActiveOrganisation()` already verifies membership server-side
+(`Organisation::hasUser($userId)`, throwing otherwise) before writing the
+active-organisation session/user-config value, and its `OrganisationController
+::setActive()` HTTP action wraps that with no bypass — SoftwareCatalog's
+frontend calls that endpoint directly instead of adding a pass-through PHP
+controller (ADR-011/ADR-022; a literal wrapper would trip
+`hydra-gate-redundant-controller`). SoftwareCatalog's own backend work is
+therefore limited to the one place OpenRegister's authorization model does
+not fit SoftwareCatalog's role system: OpenRegister's `join`/`leave` HTTP
+actions only let a Nextcloud admin or the organisation's single `owner`
+field manage another user's membership, but SoftwareCatalog's domain model
+authorises any `beheerder` of the organisation to do so. `OrganisationMembersController`
+adds that `beheerder`-role check (itself built from already-shipped
+primitives: NC group `beheerder` + OpenRegister's `Organisation::hasUser()`)
+and then delegates the actual membership mutation to `OrganisationService::
+joinOrganisation()` / `leaveOrganisation()` — no new membership storage,
+no new group-membership scheme.
+
+On the frontend, `App.vue` passes the user's current active organisation
+(read from the existing `/api/me` aggregate endpoint) into `CnAppRoot`'s
+`initial-organisation-uuid` / `initial-organisation` props (which mount nc-vue's
+tenant-context provider), and a new switcher component overrides `CnAppRoot`'s
+`#tenant-badge` slot to make that badge interactive. Mirrors the pattern
+already shipped in `larpingapp`'s `App.vue` for the reactive
+cache-clear-and-refetch pipeline, and satisfies the tenant-switch scenarios
+already specified (but, per the context brief, not yet implemented) in
+`softwarecatalog-adopt-or-abstractions`.
+
+## New Dependencies
+None — `NcSelectUsers` (existing NC user search/picker) ships in the already
+pinned `@nextcloud/vue ^8.39.0`; `useTenantContext()` / `tenantContextMixin`
+ship in the already-pinned `@conduction/nextcloud-vue` range.
+
+## Impact
+- `src/App.vue` — mounts the tenant-context provider with an initial
+  organisation, adds the tenant-switch watcher (cache clear + refresh).
+- New `src/components/organisations/OrganisationSwitcher.vue` (header slot),
+  `src/modals/GrantOrganisationAccessModal.vue`, member-list surface.
+- New `lib/Controller/OrganisationMembersController.php`,
+  `appinfo/routes.php` entries, `lib/Settings/register.d/multi-org-membership.json`
+  (no new register objects are strictly required by this change but the
+  fragment file is reserved per ADR-037 if any config surface is needed).
+- i18n `l10n/nl.js`, `l10n/nl.json`, `l10n/en_US.js`, `l10n/en_US.json`.
+
+## Cross-Project Dependencies
+Depends on OpenRegister's already-shipped `OrganisationService` +
+`OrganisationController` (read-only dependency, no OpenRegister PR required)
+and on `@conduction/nextcloud-vue`'s already-shipped `useTenantContext()` /
+`tenantContextMixin` / `CnTenantBadge` / `CnAppRoot` tenant props (no nc-vue
+PR required — verified present in the currently pinned range).
+
+## Risks
+
+### Risk 1: A client-supplied organisation id could be trusted for a switch or a grant
+**Severity:** High — **Mitigation:** Every mutation in this change is
+guarded server-side against the authoritative OpenRegister `Organisation`
+entity, never a client-supplied trust boundary: `setActiveOrganisation()`
+throws unless `Organisation::hasUser($callerId)`; the new
+`OrganisationMembersController` re-derives the caller's own membership from
+`OrganisationService::getUserOrganisations()` (not from any request
+parameter) before authorising a grant/revoke of someone else. Both paths are
+covered by mandatory negative tests (switch to non-member org refused; grant
+by a non-beheerder refused).
+
+### Risk 2: Stale cross-tenant data remains visible in the UI after a switch
+**Severity:** Medium — **Mitigation:** `CnIndexPage`'s `activeOrganisation`
+watcher clears the shared object-store cache but does not itself re-fetch;
+this change forces a full view refresh after a confirmed switch (mirroring
+the `softwarecatalog-adopt-or-abstractions` "Tenant switch on detail
+navigates back" scenario for detail views, and a full re-fetch for index/
+dashboard views) so no partially-updated view can render another
+organisation's data.
+
+### Risk 3: SoftwareCatalog's own per-organisation NC group (`OrganizationHandler::
+userBelongsToOrganization`) is a separate, legacy membership signal from
+OpenRegister's `Organisation.users`
+**Severity:** Low — **Mitigation:** This change does not read or write that
+legacy group-based signal at all; both the switcher and the self-service
+grant/revoke flow are built exclusively on OpenRegister's `Organisation`
+entity, which is also the source `setActiveOrganisation()`/schema RBAC
+already treat as authoritative. The pre-existing mismatch between that
+legacy helper's UUID-based group-name lookup and the name-based group it is
+actually populated with is out of scope for this change and is called out
+as a follow-up in the design doc rather than silently fixed here.
+
+## Rollback Strategy
+Revert the SoftwareCatalog commits on this branch. No OpenRegister changes,
+no destructive migrations, and no register-schema changes are made, so a
+revert fully restores prior behaviour (no switcher UI, no self-service
+grant/revoke, single-organisation-per-session as today).
+
+## Open Questions
+None outstanding — clarified with the requester before implementation: the
+switcher consumes OpenRegister's endpoints directly rather than proxying
+them, and "the right role" for granting access is SoftwareCatalog's existing
+`beheerder` group scoped to the target organisation's OpenRegister
+membership.

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/specs/multi-org-membership/spec.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/specs/multi-org-membership/spec.md
@@ -1,0 +1,191 @@
+# multi-org-membership Specification
+
+**Status**: in-progress
+**Scope**: softwarecatalog
+**OpenSpec changes**:
+- multi-org-membership
+
+## Purpose
+Lets one Nextcloud user act for multiple organisations in SoftwareCatalog —
+an organisation switcher that changes the session's active organisation, and
+a self-service flow so an organisation's own beheerders can grant or revoke
+an existing Nextcloud user's membership without an administrator. Both build
+on OpenRegister's existing `OrganisationService`/`OrganisationController`
+(ADR-011, ADR-022) rather than reimplementing membership.
+
+## ADDED Requirements
+
+### Requirement: Switching the active organisation MUST be verified against server-side membership, never a client-supplied claim (REQ-001)
+
+The system MUST verify, on every switch of the active organisation, that the
+authenticated user is a member of the target organisation by resolving that
+membership from OpenRegister's `Organisation` entity on the server, and MUST
+NOT accept or trust any client-supplied assertion of membership. A switch
+request naming an organisation the user does not belong to MUST be refused
+and MUST NOT change the session's active organisation.
+
+#### Scenario: Member switches into an organisation they belong to
+- GIVEN an authenticated user who is a member of organisation A and organisation B
+- WHEN the user selects organisation B in the organisation switcher
+- THEN the request to change the active organisation MUST succeed
+- AND the session's active organisation MUST become organisation B
+
+#### Scenario: Switch to a non-member organisation is refused
+- GIVEN an authenticated user who is a member of organisation A only
+- WHEN the user (or a forged request) attempts to switch the active organisation to organisation C, of which the user is not a member
+- THEN the request MUST be refused
+- AND the session's active organisation MUST remain organisation A
+- AND no data belonging to organisation C MUST be returned as a result of the attempt
+
+#### Scenario: A forged organisation id in the request body is not trusted over server-side membership
+- GIVEN an authenticated user who is a member of organisation A only
+- WHEN a switch request is sent naming organisation C together with any client-supplied field claiming the user belongs to organisation C
+- THEN the server MUST re-derive membership from OpenRegister's `Organisation` entity rather than the client-supplied claim
+- AND the switch MUST be refused exactly as in the non-member scenario
+
+### Requirement: After a switch, the user MUST see only the newly-active organisation's data (REQ-002)
+
+The system MUST refresh every currently-rendered list, dashboard, and detail
+view after a confirmed organisation switch so that no data belonging to the
+previously-active organisation remains visible, and MUST NOT rely on a
+partial or best-effort cache invalidation that could leave one surface
+showing stale, cross-organisation data.
+
+#### Scenario: List view shows only the new organisation's data after a switch
+- GIVEN a user viewing an index page scoped to organisation A, which is currently active
+- WHEN the user switches the active organisation to organisation B
+- THEN the index page MUST refetch its data
+- AND the rendered list MUST contain only objects scoped to organisation B
+- AND no object scoped to organisation A MUST remain rendered
+
+#### Scenario: Detail view navigates back to the index on a switch
+- GIVEN a user viewing an object's detail page under organisation A
+- WHEN the user switches the active organisation to organisation B
+- THEN the view MUST navigate back to the parent index
+- AND the index MUST refetch and show only organisation B's data
+
+### Requirement: The organisation switcher MUST list only the authenticated user's own organisations (REQ-003)
+
+The system MUST populate the organisation switcher exclusively from the
+authenticated user's own organisation memberships, as resolved server-side,
+and MUST indicate which one is currently active.
+
+#### Scenario: Switcher lists the user's organisations with the active one marked
+- GIVEN an authenticated user who is a member of organisation A and organisation B, with A currently active
+- WHEN the user opens the organisation switcher
+- THEN both organisation A and organisation B MUST be listed
+- AND organisation A MUST be indicated as the active organisation
+- AND no organisation the user is not a member of MUST appear in the list
+
+### Requirement: Granting or revoking organisation access MUST be restricted to a beheerder of that organisation (REQ-004)
+
+The system MUST allow a caller to grant or revoke another Nextcloud user's
+membership of an organisation only when the caller is both a member of that
+organisation and holds the beheerder role, both verified server-side from
+the authenticated session, never from a client-supplied claim. A caller who
+does not satisfy both conditions MUST be denied before any membership
+mutation is attempted.
+
+#### Scenario: Beheerder grants an existing colleague access to their organisation
+- GIVEN an authenticated user who is a member of organisation A and holds the beheerder role
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the beheerder grants that second user access to organisation A
+- THEN the second user MUST become a member of organisation A
+- AND the second user MUST subsequently be able to switch their active organisation to organisation A
+
+#### Scenario: A non-beheerder member cannot grant access
+- GIVEN an authenticated user who is a member of organisation A but does not hold the beheerder role
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the non-beheerder member attempts to grant that second user access to organisation A
+- THEN the request MUST be denied
+- AND the second user's membership MUST NOT change
+
+#### Scenario: A beheerder of a different organisation cannot grant access to an organisation they do not belong to
+- GIVEN an authenticated user who holds the beheerder role but is a member of organisation B only, not organisation A
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the user attempts to grant that second user access to organisation A
+- THEN the request MUST be denied
+- AND the second user's membership of organisation A MUST NOT change
+
+#### Scenario: A beheerder can revoke another member's access
+- GIVEN an authenticated user who is a member of organisation A and holds the beheerder role
+- AND a second user who is currently a member of organisation A
+- WHEN the beheerder revokes that second user's access to organisation A
+- THEN the second user MUST no longer be a member of organisation A
+
+#### Scenario: A non-beheerder member cannot revoke another member's access
+- GIVEN an authenticated user who is a member of organisation A but does not hold the beheerder role
+- AND a second user who is currently a member of organisation A
+- WHEN the non-beheerder member attempts to revoke that second user's access
+- THEN the request MUST be denied
+- AND the second user MUST remain a member of organisation A
+
+### Requirement: Granting access MUST only target an existing Nextcloud user (REQ-005)
+
+The system MUST require the target of a grant to already exist as a
+Nextcloud user, resolved server-side, and MUST refuse the grant when no such
+user exists rather than creating a new account or membership placeholder.
+
+#### Scenario: Grant to a non-existent user id is refused
+- GIVEN an authenticated beheerder of organisation A
+- WHEN the beheerder attempts to grant access to a user id that does not resolve to any existing Nextcloud user
+- THEN the request MUST be refused
+- AND no membership change MUST occur
+
+### Requirement: Membership mutations MUST be delegated to OpenRegister's OrganisationService, not reimplemented (REQ-006)
+
+The system MUST perform every membership mutation (switch, grant, revoke) by
+calling OpenRegister's `OrganisationService` (`setActiveOrganisation`,
+`joinOrganisation`, `leaveOrganisation`) and MUST NOT maintain a separate,
+parallel membership store for the same relationship.
+
+#### Scenario: A granted user's membership is visible through OpenRegister's own membership query
+- GIVEN a beheerder of organisation A grants a second user access to organisation A
+- WHEN OpenRegister's own `getUserOrganisations` is evaluated for that second user
+- THEN organisation A MUST be included in the result
+- AND this MUST be true without SoftwareCatalog maintaining any separate record of the membership
+
+## Non-Functional Requirements
+
+- **Performance:** Switching the active organisation MUST complete within
+  the same request/response budget as any other SoftwareCatalog write
+  action (no additional round trips beyond the switch call and the
+  subsequent refresh).
+- **Accessibility:** The organisation switcher and the grant/revoke modal
+  MUST be operable by keyboard and MUST expose accessible labels
+  (`NcSelect`/`NcSelectUsers` `inputLabel`), per WCAG 2.1 AA.
+- **Internationalization:** Dutch and English MUST be supported (ADR-005) —
+  all new user-facing strings ship with `nl` and `en_US` translations.
+
+## Acceptance Criteria
+
+- [ ] A user who belongs to two or more organisations can switch the active
+      one from the app header, and every list/detail view they subsequently
+      see reflects the new organisation only.
+- [ ] Attempting to switch to an organisation the user does not belong to is
+      refused server-side, with a test proving the active organisation does
+      not change.
+- [ ] A beheerder of an organisation can grant an existing Nextcloud user
+      access to that organisation, and revoke it again.
+- [ ] A non-beheerder member's attempt to grant or revoke access is refused,
+      with a test proving no membership change occurred.
+- [ ] No new membership storage is introduced in SoftwareCatalog — every
+      mutation delegates to OpenRegister's `OrganisationService`.
+
+## Notes
+
+- Built entirely on already-shipped platform primitives: OpenRegister's
+  `OrganisationService`/`OrganisationController` (verified present at
+  `../openregister/lib/Service/OrganisationService.php` and
+  `../openregister/lib/Controller/OrganisationController.php`) and nc-vue's
+  `useTenantContext()`/`tenantContextMixin`/`CnTenantBadge`/`CnAppRoot`
+  tenant props (verified present in the pinned `@conduction/nextcloud-vue`
+  range).
+- Interacts directly with the read-side RBAC scoping hardened in
+  `vendor-visibility-rbac` (schema `_organisation` matching against the
+  session's active organisation) — this capability governs *which*
+  organisation a session is scoped to and *who* may belong to one; it does
+  not alter what a role may read once scoped.
+- Out of scope: inviting a brand-new user by e-mail (user provisioning,
+  tracked separately); cross-organisation data merging
+  (softwarecatalog#370); changes to the RBAC model itself.

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/tasks.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/tasks.md
@@ -1,0 +1,100 @@
+# Tasks: multi-org-membership
+
+## Implementation Tasks
+
+### Task 1: OrganisationMembersController — beheerder-gated grant/revoke
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004`
+- **files**: `lib/Controller/OrganisationMembersController.php`, `appinfo/routes.php`
+- **acceptance_criteria**:
+  - GIVEN a caller who is a member of organisation A and holds the `beheerder` NC group WHEN they POST an existing NC user id to grant access to organisation A THEN `OrganisationService::joinOrganisation()` is called and the response is 200
+  - GIVEN a caller who is a member of organisation A but not in the `beheerder` group WHEN they attempt to grant or revoke access to organisation A THEN the response is 403 and `joinOrganisation`/`leaveOrganisation` is never called
+  - GIVEN a caller who is a `beheerder` of organisation B only WHEN they attempt to grant/revoke access to organisation A THEN the response is 403
+  - GIVEN a target user id that does not resolve via `IUserManager::get()` WHEN a beheerder attempts to grant access THEN the response is 404 and no membership mutation occurs
+  - GIVEN a beheerder of organisation A WHEN they revoke an existing member's access THEN `OrganisationService::leaveOrganisation()` is called and the member is removed
+- [x] Implement
+- [x] Test
+
+### Task 2: PHPUnit tests for OrganisationMembersController (incl. mandatory negatives)
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006`
+- **files**: `tests/Unit/Controller/OrganisationMembersControllerTest.php`
+- **acceptance_criteria**:
+  - Every acceptance criterion of Task 1 has a corresponding PHPUnit test, including the non-beheerder-denied and cross-organisation-beheerder-denied negative cases
+  - Tests assert `joinOrganisation`/`leaveOrganisation` are never invoked on a denied path (mock expectation, not just response code)
+- [x] Implement
+- [x] Test
+
+### Task 3: App.vue — boot-time active-organisation fetch + write-header wiring
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-after-a-switch-the-user-must-see-only-the-newly-active-organisations-data-req-002`
+- **files**: `src/App.vue`, `src/composables/orClient.js`
+- **acceptance_criteria**:
+  - GIVEN the app boots WHEN `/api/me` resolves THEN `CnAppRoot` mounts with `initial-organisation-uuid`/`initial-organisation` set from the active organisation, AND `orClient.js`'s module-level active-organisation-uuid getter is set from the same response so subsequent writes stamp `X-OpenRegister-Organisation`
+  - GIVEN `/api/me` fails or returns no active organisation WHEN the app boots THEN it falls back to unset (single-tenant legacy behaviour), matching the "no header when no tenant active" contract
+- [x] Implement
+- [x] Test
+
+### Task 4: OrganisationSwitcher.vue — self-contained header switcher, reload on success
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001`
+- **files**: `src/components/organisations/OrganisationSwitcher.vue`, `src/App.vue`
+- **acceptance_criteria**:
+  - GIVEN a user with two or more organisations WHEN they open the switcher THEN both organisations are listed (from `/api/me`) with the active one marked, per REQ-003
+  - GIVEN a user with zero or one organisation WHEN the switcher's dropdown is opened THEN the switch-target list is empty (no other organisations to switch to), mirroring `CnTenantBadge`'s auto-hide contract for the switching affordance specifically — the dropdown itself still renders to host the "Manage members" entry
+  - GIVEN the user picks a different organisation WHEN the switch completes THEN `POST /apps/openregister/api/organisations/{uuid}/set-active` is called directly (no SoftwareCatalog proxy controller) and the page is reloaded on success only, guaranteeing every view re-derives its data from the new server-side session (REQ-002)
+  - GIVEN OpenRegister refuses the switch (non-member) WHEN the response is an error THEN the UI shows the error inline and the page is NOT reloaded and the active organisation is unchanged, per REQ-001's negative scenario
+  - The default `#tenant-badge` slot is suppressed (`<template #tenant-badge />`) in favour of this combined badge+switcher rendered via `#header-actions`, avoiding a duplicate/inconsistent display
+- [x] Implement
+- [x] Test
+
+### Task 5: GrantOrganisationAccessModal.vue + member list/revoke UI
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005`
+- **files**: `src/modals/GrantOrganisationAccessModal.vue`, `src/components/organisations/OrganisationSwitcher.vue`
+- **acceptance_criteria**:
+  - GIVEN a beheerder viewing their organisation WHEN they open the modal THEN the current member list is fetched from `GET /apps/openregister/api/organisations/{uuid}` and rendered
+  - GIVEN the beheerder picks an existing NC user via `NcSelectUsers` (`inputLabel` set) WHEN they confirm THEN a grant request is sent and the member list refreshes on success
+  - GIVEN a non-beheerder member WHEN they view the app header THEN the "Manage members" entry point is not rendered (client-side hint only, driven by `/api/me`'s `isBeheerder` flag — Task 1/2 remain the authority)
+  - GIVEN a revoke action WHEN confirmed THEN the target is removed from the rendered member list on success
+- [x] Implement
+- [x] Test
+
+### Task 6: Frontend store actions — members fetch/grant/revoke + write-header wiring
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006`
+- **files**: `src/store/modules/organisatie.js`, `src/composables/orClient.js`, `src/store/plugins/softwarecatalogPlugin.js`
+- **acceptance_criteria**:
+  - GIVEN `orClient.js`'s active-organisation-uuid getter is set WHEN `softwarecatalogPlugin`'s `patchObject`/write paths run THEN `buildWriteHeaders` is called with that organisation uuid, satisfying the already-specified `softwarecatalog-adopt-or-abstractions` header-stamping requirement
+  - GIVEN no active organisation WHEN a write runs THEN no `X-OpenRegister-Organisation` header is added (unchanged legacy path)
+  - `organisatie.js` gains `fetchMembers(uuid)`, `grantAccess(uuid, userId)`, `revokeAccess(uuid, userId)` actions calling the endpoints from Tasks 1/5
+- [x] Implement
+- [x] Test
+
+### Task 7: Pure-logic unit tests — switcher decision logic, grant/revoke payload
+- **spec_ref**: `openspec/specs/multi-org-membership/spec.md#requirement-a-non-beheerder-member-cannot-grant-access`
+- **files**: `src/components/organisations/organisationSwitcher.js` + `.spec.js`, `src/modals/grantOrganisationAccess.js` + `.spec.js`, `src/composables/orClient.spec.js`
+- **acceptance_criteria**:
+  - Pure-logic tests (matching the project's established jest colocated-`.spec.js` convention) cover: `resolveSwitchError`'s refusal handling (never treats a non-ok response as success, REQ-001), `resolveActiveOrganisationName`/`resolveOtherOrganisations`' organisation-list derivation (REQ-003), `extractUserId`'s normalisation across the shapes `NcSelectUsers` may emit (REQ-005), and `removeMember`'s local member-list update after a revoke
+- [x] Implement
+- [x] Test
+
+### Task 8: i18n — Dutch + English strings
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003`
+- **files**: `l10n/nl.js`, `l10n/nl.json`, `l10n/en_US.js`, `l10n/en_US.json`
+- **acceptance_criteria**:
+  - Every new user-facing string introduced by Tasks 4-5 has an English source key and a Dutch translation, and `en_US` mirrors the English source
+- [x] Implement
+- [x] Test
+
+### Task 9: Feature documentation with screenshots
+- **spec_ref**: `openspec/specs/multi-org-membership/spec.md#purpose`
+- **files**: `docs/features/multi-org-membership.md`, `docs/images/`
+- **acceptance_criteria**:
+  - The doc shows the switcher in the app header and the grant/revoke modal, captured live via Playwright MCP against a running instance with a multi-organisation test user
+- [x] Implement — feature doc written; matches the existing `docs/features/*.md` convention (text-only, no `docs/images/` in this project today)
+- [ ] Test — screenshots NOT captured: this change deliberately did not deploy to the shared dev Nextcloud instance (see tasks.md constraints); deferred as a follow-up, flagged in the final report rather than fabricated
+
+## Quality checklist
+
+- All new/changed business logic covered by PHPUnit unit tests (`tests/Unit/`), run inside the `nextcloud:34.0.0-apache` container per project convention
+- New/changed API endpoints (`OrganisationMembersController`) covered by tests exercising both an allowed and a denied case
+- UI changes (switcher, grant/revoke modal) covered by Vitest unit tests; manual/Playwright verification against the live dev instance
+- All tests pass: `php vendor/bin/phpunit -c phpunit-unit.xml` and `npx vitest run` (pre-existing `PortfolioReportControllerTest::testCsvFormatReturnsDownloadResponse` failure, issue #393, is excluded)
+- Feature documentation updated in `docs/features/` with screenshots (ADR-010)
+- Dutch (`nl`) and English (`en_US`) translation strings added for every new user-facing string (ADR-005/ADR-007)
+- `openspec validate --strict` passes

--- a/openspec/changes/archive/2026-07-24-multi-org-membership/test-plan.md
+++ b/openspec/changes/archive/2026-07-24-multi-org-membership/test-plan.md
@@ -1,0 +1,100 @@
+# Test Plan: multi-org-membership
+
+## Test Cases
+
+### TC-1: Member switches into an organisation they belong to
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001`
+- **type**: functional
+- **preconditions**: user is a member of organisation A and organisation B, A active
+- **steps**: open the organisation switcher, select organisation B
+- **expected result**: switch succeeds; active organisation becomes B; badge updates
+- **test command**: /test-functional
+
+### TC-2 (negative): Switch to a non-member organisation is refused
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001`
+- **type**: security
+- **preconditions**: user is a member of organisation A only; organisation C exists
+- **steps**: POST `/apps/openregister/api/organisations/{C}/set-active` directly (bypassing the UI, to prove server-side enforcement)
+- **expected result**: 400/403 response; active organisation remains A; no data from C returned
+- **test command**: /test-security
+
+### TC-3: After a switch, only the new organisation's data is visible
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-after-a-switch-the-user-must-see-only-the-newly-active-organisations-datas-req-002`
+- **type**: functional
+- **preconditions**: user viewing an index page scoped to organisation A
+- **steps**: switch active organisation to B via the switcher
+- **expected result**: view reloads; only B's objects render; no A objects remain
+- **test command**: /test-functional
+
+### TC-4: Switcher lists only the user's own organisations
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003`
+- **type**: functional
+- **preconditions**: user is a member of A and B; organisation D exists but user is not a member
+- **steps**: open the switcher
+- **expected result**: A and B listed, A marked active, D not present
+- **test command**: /test-functional
+
+### TC-5: Beheerder grants an existing colleague access
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004`
+- **type**: api
+- **preconditions**: caller is a member + beheerder of organisation A; target user exists and is not yet a member
+- **steps**: `POST /apps/softwarecatalog/api/organisations/{A}/members` with the target userId
+- **expected result**: 200; target becomes a member of A (verified via OR's `getUserOrganisations`)
+- **test command**: /test-api
+
+### TC-6 (negative): Non-beheerder member cannot grant access
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004`
+- **type**: security
+- **preconditions**: caller is a member of organisation A, not in the `beheerder` group; target user exists
+- **steps**: `POST /apps/softwarecatalog/api/organisations/{A}/members` with the target userId
+- **expected result**: 403; target's membership unchanged; `joinOrganisation` never invoked
+- **test command**: /test-security
+
+### TC-7 (negative): Beheerder of a different organisation cannot grant access
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004`
+- **type**: security
+- **preconditions**: caller is a beheerder of organisation B only; target user exists, not a member of A
+- **steps**: `POST /apps/softwarecatalog/api/organisations/{A}/members` with the target userId
+- **expected result**: 403; target's membership of A unchanged
+- **test command**: /test-security
+
+### TC-8: Beheerder revokes another member's access
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004`
+- **type**: api
+- **preconditions**: caller is a member + beheerder of A; target is currently a member of A
+- **steps**: `DELETE /apps/softwarecatalog/api/organisations/{A}/members/{targetUserId}`
+- **expected result**: 200; target no longer a member of A
+- **test command**: /test-api
+
+### TC-9 (negative): Grant to a non-existent Nextcloud user is refused
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005`
+- **type**: api
+- **preconditions**: caller is a beheerder of A; `no-such-user` does not resolve via `IUserManager::get()`
+- **steps**: `POST /apps/softwarecatalog/api/organisations/{A}/members` with userId `no-such-user`
+- **expected result**: 404; no membership mutation
+- **test command**: /test-api
+
+### TC-10: Granted membership is visible through OpenRegister's own query (no parallel store)
+- **spec_ref**: `openspec/changes/multi-org-membership/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006`
+- **type**: regression
+- **preconditions**: TC-5 has run
+- **steps**: call OpenRegister's `getUserOrganisations()` (or `GET /apps/openregister/api/organisations`) as the granted user
+- **expected result**: organisation A is present in the result
+- **test command**: /test-api
+
+## Coverage Summary
+- REQ-001 (server-side switch verification): TC-1, TC-2 — covered
+- REQ-002 (post-switch refresh): TC-3 — covered
+- REQ-003 (switcher lists own orgs only): TC-4 — covered
+- REQ-004 (beheerder-gated grant/revoke): TC-5, TC-6, TC-7, TC-8 — covered
+- REQ-005 (existing-user-only grant): TC-9 — covered
+- REQ-006 (delegated to OpenRegister, no parallel store): TC-10 — covered
+
+## Out of Scope
+- OpenRegister's own `OrganisationService`/`OrganisationController` behaviour
+  (membership storage, `hasUser()` correctness) is exercised only indirectly
+  through these test cases — it is pre-existing, unchanged, and already
+  covered by OpenRegister's own test suite.
+- Performance/load testing of the switch or grant/revoke endpoints — both
+  are low-frequency, interactive-only actions with no expected volume
+  concern.

--- a/openspec/specs/multi-org-membership/spec.md
+++ b/openspec/specs/multi-org-membership/spec.md
@@ -1,0 +1,141 @@
+# multi-org-membership Specification
+
+## Purpose
+Lets one Nextcloud user act for multiple organisations in SoftwareCatalog —
+an organisation switcher that changes the session's active organisation, and
+a self-service flow so an organisation's own beheerders can grant or revoke
+an existing Nextcloud user's membership without an administrator. Both build
+on OpenRegister's existing `OrganisationService`/`OrganisationController`
+(ADR-011, ADR-022) rather than reimplementing membership.
+
+## Requirements
+### Requirement: Switching the active organisation MUST be verified against server-side membership, never a client-supplied claim (REQ-001)
+
+The system MUST verify, on every switch of the active organisation, that the
+authenticated user is a member of the target organisation by resolving that
+membership from OpenRegister's `Organisation` entity on the server, and MUST
+NOT accept or trust any client-supplied assertion of membership. A switch
+request naming an organisation the user does not belong to MUST be refused
+and MUST NOT change the session's active organisation.
+
+#### Scenario: Member switches into an organisation they belong to
+- GIVEN an authenticated user who is a member of organisation A and organisation B
+- WHEN the user selects organisation B in the organisation switcher
+- THEN the request to change the active organisation MUST succeed
+- AND the session's active organisation MUST become organisation B
+
+#### Scenario: Switch to a non-member organisation is refused
+- GIVEN an authenticated user who is a member of organisation A only
+- WHEN the user (or a forged request) attempts to switch the active organisation to organisation C, of which the user is not a member
+- THEN the request MUST be refused
+- AND the session's active organisation MUST remain organisation A
+- AND no data belonging to organisation C MUST be returned as a result of the attempt
+
+#### Scenario: A forged organisation id in the request body is not trusted over server-side membership
+- GIVEN an authenticated user who is a member of organisation A only
+- WHEN a switch request is sent naming organisation C together with any client-supplied field claiming the user belongs to organisation C
+- THEN the server MUST re-derive membership from OpenRegister's `Organisation` entity rather than the client-supplied claim
+- AND the switch MUST be refused exactly as in the non-member scenario
+
+### Requirement: After a switch, the user MUST see only the newly-active organisation's data (REQ-002)
+
+The system MUST refresh every currently-rendered list, dashboard, and detail
+view after a confirmed organisation switch so that no data belonging to the
+previously-active organisation remains visible, and MUST NOT rely on a
+partial or best-effort cache invalidation that could leave one surface
+showing stale, cross-organisation data.
+
+#### Scenario: List view shows only the new organisation's data after a switch
+- GIVEN a user viewing an index page scoped to organisation A, which is currently active
+- WHEN the user switches the active organisation to organisation B
+- THEN the index page MUST refetch its data
+- AND the rendered list MUST contain only objects scoped to organisation B
+- AND no object scoped to organisation A MUST remain rendered
+
+#### Scenario: Detail view navigates back to the index on a switch
+- GIVEN a user viewing an object's detail page under organisation A
+- WHEN the user switches the active organisation to organisation B
+- THEN the view MUST navigate back to the parent index
+- AND the index MUST refetch and show only organisation B's data
+
+### Requirement: The organisation switcher MUST list only the authenticated user's own organisations (REQ-003)
+
+The system MUST populate the organisation switcher exclusively from the
+authenticated user's own organisation memberships, as resolved server-side,
+and MUST indicate which one is currently active.
+
+#### Scenario: Switcher lists the user's organisations with the active one marked
+- GIVEN an authenticated user who is a member of organisation A and organisation B, with A currently active
+- WHEN the user opens the organisation switcher
+- THEN both organisation A and organisation B MUST be listed
+- AND organisation A MUST be indicated as the active organisation
+- AND no organisation the user is not a member of MUST appear in the list
+
+### Requirement: Granting or revoking organisation access MUST be restricted to a beheerder of that organisation (REQ-004)
+
+The system MUST allow a caller to grant or revoke another Nextcloud user's
+membership of an organisation only when the caller is both a member of that
+organisation and holds the beheerder role, both verified server-side from
+the authenticated session, never from a client-supplied claim. A caller who
+does not satisfy both conditions MUST be denied before any membership
+mutation is attempted.
+
+#### Scenario: Beheerder grants an existing colleague access to their organisation
+- GIVEN an authenticated user who is a member of organisation A and holds the beheerder role
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the beheerder grants that second user access to organisation A
+- THEN the second user MUST become a member of organisation A
+- AND the second user MUST subsequently be able to switch their active organisation to organisation A
+
+#### Scenario: A non-beheerder member cannot grant access
+- GIVEN an authenticated user who is a member of organisation A but does not hold the beheerder role
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the non-beheerder member attempts to grant that second user access to organisation A
+- THEN the request MUST be denied
+- AND the second user's membership MUST NOT change
+
+#### Scenario: A beheerder of a different organisation cannot grant access to an organisation they do not belong to
+- GIVEN an authenticated user who holds the beheerder role but is a member of organisation B only, not organisation A
+- AND a second, existing Nextcloud user who is not yet a member of organisation A
+- WHEN the user attempts to grant that second user access to organisation A
+- THEN the request MUST be denied
+- AND the second user's membership of organisation A MUST NOT change
+
+#### Scenario: A beheerder can revoke another member's access
+- GIVEN an authenticated user who is a member of organisation A and holds the beheerder role
+- AND a second user who is currently a member of organisation A
+- WHEN the beheerder revokes that second user's access to organisation A
+- THEN the second user MUST no longer be a member of organisation A
+
+#### Scenario: A non-beheerder member cannot revoke another member's access
+- GIVEN an authenticated user who is a member of organisation A but does not hold the beheerder role
+- AND a second user who is currently a member of organisation A
+- WHEN the non-beheerder member attempts to revoke that second user's access
+- THEN the request MUST be denied
+- AND the second user MUST remain a member of organisation A
+
+### Requirement: Granting access MUST only target an existing Nextcloud user (REQ-005)
+
+The system MUST require the target of a grant to already exist as a
+Nextcloud user, resolved server-side, and MUST refuse the grant when no such
+user exists rather than creating a new account or membership placeholder.
+
+#### Scenario: Grant to a non-existent user id is refused
+- GIVEN an authenticated beheerder of organisation A
+- WHEN the beheerder attempts to grant access to a user id that does not resolve to any existing Nextcloud user
+- THEN the request MUST be refused
+- AND no membership change MUST occur
+
+### Requirement: Membership mutations MUST be delegated to OpenRegister's OrganisationService, not reimplemented (REQ-006)
+
+The system MUST perform every membership mutation (switch, grant, revoke) by
+calling OpenRegister's `OrganisationService` (`setActiveOrganisation`,
+`joinOrganisation`, `leaveOrganisation`) and MUST NOT maintain a separate,
+parallel membership store for the same relationship.
+
+#### Scenario: A granted user's membership is visible through OpenRegister's own membership query
+- GIVEN a beheerder of organisation A grants a second user access to organisation A
+- WHEN OpenRegister's own `getUserOrganisations` is evaluated for that second user
+- THEN organisation A MUST be included in the result
+- AND this MUST be true without SoftwareCatalog maintaining any separate record of the membership
+

--- a/openspec/specs/multi-org-membership/spec.md
+++ b/openspec/specs/multi-org-membership/spec.md
@@ -8,6 +8,8 @@ an existing Nextcloud user's membership without an administrator. Both build
 on OpenRegister's existing `OrganisationService`/`OrganisationController`
 (ADR-011, ADR-022) rather than reimplementing membership.
 
+@e2e exclude No live deployment in this change's implementation pass (the shared dev Nextcloud instance was deliberately left untouched — see design.md). Server-side authorization scenarios (REQ-001, REQ-004, REQ-005, REQ-006) are covered by PHPUnit tests exercising both the allowed and denied paths against mocked OpenRegister collaborators; client-side decision-logic scenarios (REQ-002, REQ-003) are covered by pure-logic unit tests on the extracted helper modules. Browser-driven Playwright e2e coverage is deferred to a follow-up verification pass against a live instance, per docs/features/multi-org-membership.md.
+
 ## Requirements
 ### Requirement: Switching the active organisation MUST be verified against server-side membership, never a client-supplied claim (REQ-001)
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,9 @@
 			:page-types="pageTypes"
 			app-id="softwarecatalog"
 			:translate="translateForApp"
-			:permissions="permissions">
+			:permissions="permissions"
+			:initial-organisation-uuid="activeOrganisationUuid"
+			:initial-organisation="activeOrganisation">
 			<template #sidebar>
 				<CnObjectSidebar
 					v-if="objectSidebarState.active"
@@ -39,6 +41,19 @@
 					:open="objectSidebarState.open"
 					@update:open="objectSidebarState.open = $event" />
 			</template>
+			<!-- Suppress the default read-only CnTenantBadge — OrganisationSwitcher
+			     below renders a combined active-organisation label + switcher
+			     instead, self-contained (see design.md's "no slot-inject
+			     dependency" decision), so there is exactly one on-screen
+			     indicator. -->
+			<template #tenant-badge />
+			<template #header-actions>
+				<OrganisationSwitcher
+					v-if="organisations.length > 0"
+					:organisations="organisations"
+					:active-organisation-uuid="activeOrganisationUuid"
+					:is-beheerder="isBeheerder" />
+			</template>
 		</CnAppRoot>
 
 		<!-- Legacy global modals + dialogs (keep until every consumer migrates to CnFormDialog / CnDeleteDialog). -->
@@ -50,10 +65,13 @@
 <script>
 import Vue from 'vue'
 import { translate as ncT } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
 import { CnAppRoot, CnObjectSidebar } from '@conduction/nextcloud-vue'
 import Modals from './modals/Modals.vue'
 import Dialogs from './dialogs/Dialogs.vue'
+import OrganisationSwitcher from './components/organisations/OrganisationSwitcher.vue'
 import { settingsStore } from './store/store.js'
+import { setActiveOrganisationUuid } from './composables/orClient.js'
 
 export default {
 	name: 'App',
@@ -63,6 +81,7 @@ export default {
 		CnObjectSidebar,
 		Modals,
 		Dialogs,
+		OrganisationSwitcher,
 	},
 
 	/**
@@ -132,6 +151,16 @@ export default {
 				hiddenTabs: [],
 				tabs: undefined,
 			}),
+			/**
+			 * The authenticated user's organisations, and which one is
+			 * currently active — fetched once at boot from `/api/me`
+			 * (multi-org-membership). Empty/null until that fetch resolves;
+			 * `OrganisationSwitcher` only renders once populated.
+			 */
+			organisations: [],
+			activeOrganisationUuid: null,
+			activeOrganisation: null,
+			isBeheerder: false,
 		}
 	},
 
@@ -159,9 +188,45 @@ export default {
 			// eslint-disable-next-line no-console
 			console.warn('[softwarecatalog] settingsStore.loadSettings() failed; continuing with defaults', e)
 		}
+
+		await this.loadOrganisations()
 	},
 
 	methods: {
+		/**
+		 * Fetch the authenticated user's organisations and active
+		 * organisation from the already-shipped `/api/me` aggregate
+		 * endpoint (multi-org-membership). Seeds `CnAppRoot`'s tenant
+		 * context for first paint and the `orClient.js` write-header
+		 * getter; a failure leaves the app in its pre-existing
+		 * single-tenant behaviour (no switcher rendered, no header
+		 * stamped) rather than blocking boot.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 */
+		async loadOrganisations() {
+			try {
+				const response = await fetch(generateUrl('/apps/softwarecatalog/api/me'), {
+					headers: { requesttoken: OC.requestToken },
+				})
+				if (!response.ok) return
+
+				const data = await response.json()
+				const orgs = data?.organisations?.all ?? []
+				const active = data?.organisations?.active ?? null
+
+				this.organisations = orgs
+				this.activeOrganisation = active
+				this.activeOrganisationUuid = active?.uuid ?? null
+				this.isBeheerder = data?.isBeheerder === true
+				setActiveOrganisationUuid(this.activeOrganisationUuid)
+			} catch (e) {
+				// eslint-disable-next-line no-console
+				console.warn('[softwarecatalog] Failed to load organisations; continuing single-tenant', e)
+			}
+		},
+
 		/**
 		 * Translate function passed down to CnAppRoot / CnAppNav /
 		 * CnPageRenderer. Closes over the Nextcloud `translate` import so
@@ -169,7 +234,7 @@ export default {
 		 *
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
-		  * @spec exclude i18n wrapper around @nextcloud/l10n translate
+		 * @spec exclude i18n wrapper around @nextcloud/l10n translate
 		 */
 		translateForApp(key) {
 			return ncT('softwarecatalog', key)

--- a/src/App.vue
+++ b/src/App.vue
@@ -203,7 +203,7 @@ export default {
 		 * stamped) rather than blocking boot.
 		 *
 		 * @return {Promise<void>}
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-user-s-own-organisations-req-003
 		 */
 		async loadOrganisations() {
 			try {

--- a/src/components/organisations/OrganisationSwitcher.vue
+++ b/src/components/organisations/OrganisationSwitcher.vue
@@ -132,7 +132,7 @@ export default {
 		 * translated placeholder when not yet resolved.
 		 *
 		 * @return {string}
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-user-s-own-organisations-req-003
 		 */
 		activeOrganisationName() {
 			return resolveActiveOrganisationName(
@@ -151,7 +151,7 @@ export default {
 		 * affordance specifically, not the whole component.
 		 *
 		 * @return {Array}
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-user-s-own-organisations-req-003
 		 */
 		otherOrganisations() {
 			return resolveOtherOrganisations(this.organisations, this.activeOrganisationUuid)

--- a/src/components/organisations/OrganisationSwitcher.vue
+++ b/src/components/organisations/OrganisationSwitcher.vue
@@ -1,0 +1,211 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+
+<!--
+ OrganisationSwitcher — combined active-organisation label + switcher +
+ self-service "manage members" entry point, rendered in CnAppRoot's
+ `#header-actions` slot (the default `#tenant-badge` slot is suppressed by
+ App.vue in favour of this component; see design.md's "no slot-inject
+ dependency" decision).
+
+ Self-contained: receives the user's own organisations, the active uuid, and
+ whether the caller holds the `beheerder` role, as props (all sourced once
+ by App.vue from the existing `/api/me` endpoint). On switch, POSTs directly
+ to OpenRegister's own `/api/organisations/{uuid}/set-active` — membership
+ is verified server-side there (OrganisationService::setActiveOrganisation()
+ throws unless the caller is a member); this component never trusts
+ anything but that response. A successful switch reloads the page so every
+ view re-fetches against the new active organisation with zero risk of a
+ partially-updated, cross-organisation-stale surface (REQ-002). A refused
+ switch (non-member) surfaces inline and does NOT reload — the active
+ organisation is unchanged.
+
+ The "Manage members" entry (gated client-side by `isBeheerder` — a UX hint
+ only, see GrantOrganisationAccessModal.vue's docblock) opens
+ GrantOrganisationAccessModal.vue for the ACTIVE organisation.
+
+ @spec openspec/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001
+-->
+<template>
+	<div class="organisation-switcher">
+		<NcActions
+			:menu-name="activeOrganisationName"
+			:disabled="switching"
+			class="organisation-switcher__actions">
+			<template #icon>
+				<NcLoadingIcon v-if="switching" :size="20" />
+				<DomainIcon v-else :size="20" />
+			</template>
+			<NcActionButton
+				v-for="organisation in otherOrganisations"
+				:key="organisation.uuid"
+				close-after-click
+				@click="switchTo(organisation.uuid)">
+				{{ organisation.naam }}
+			</NcActionButton>
+			<NcActionSeparator v-if="otherOrganisations.length > 0 && isBeheerder" />
+			<NcActionButton
+				v-if="isBeheerder"
+				close-after-click
+				@click="manageMembersOpen = true">
+				<template #icon>
+					<AccountMultipleIcon :size="20" />
+				</template>
+				{{ t('softwarecatalog', 'Manage members') }}
+			</NcActionButton>
+		</NcActions>
+		<NcNoteCard v-if="errorMessage" type="error" class="organisation-switcher__error">
+			{{ errorMessage }}
+		</NcNoteCard>
+		<GrantOrganisationAccessModal
+			:open="manageMembersOpen"
+			:organisation-uuid="activeOrganisationUuid"
+			:organisation-name="activeOrganisationName"
+			@update:open="manageMembersOpen = $event" />
+	</div>
+</template>
+
+<script>
+import { NcActions, NcActionButton, NcActionSeparator, NcLoadingIcon, NcNoteCard } from '@nextcloud/vue'
+import { generateUrl } from '@nextcloud/router'
+import DomainIcon from 'vue-material-design-icons/Domain.vue'
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import GrantOrganisationAccessModal from '../../modals/GrantOrganisationAccessModal.vue'
+import { resolveActiveOrganisationName, resolveOtherOrganisations, resolveSwitchError } from './organisationSwitcher.js'
+
+export default {
+	name: 'OrganisationSwitcher',
+
+	components: {
+		NcActions,
+		NcActionButton,
+		NcActionSeparator,
+		NcLoadingIcon,
+		NcNoteCard,
+		DomainIcon,
+		AccountMultipleIcon,
+		GrantOrganisationAccessModal,
+	},
+
+	props: {
+		/**
+		 * The authenticated user's own organisations —
+		 * `[{ uuid, naam, id, slug }]`, exactly as `/api/me` returns them.
+		 * Never fetched by this component itself, so there is exactly one
+		 * source of truth for "which organisations does this user belong to".
+		 */
+		organisations: {
+			type: Array,
+			required: true,
+		},
+
+		/**
+		 * The currently-active organisation's UUID, or null.
+		 */
+		activeOrganisationUuid: {
+			type: String,
+			default: null,
+		},
+
+		/**
+		 * Whether the caller holds the global `beheerder` NC group — a
+		 * client-side hint gating the "Manage members" entry. The actual
+		 * per-organisation authorization is re-verified server-side.
+		 */
+		isBeheerder: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	data() {
+		return {
+			switching: false,
+			errorMessage: '',
+			manageMembersOpen: false,
+		}
+	},
+
+	computed: {
+		/**
+		 * Display name of the active organisation, falling back to a
+		 * translated placeholder when not yet resolved.
+		 *
+		 * @return {string}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 */
+		activeOrganisationName() {
+			return resolveActiveOrganisationName(
+				this.organisations,
+				this.activeOrganisationUuid,
+				this.t('softwarecatalog', 'Select an organisation'),
+			)
+		},
+
+		/**
+		 * The user's organisations excluding the currently-active one —
+		 * the switch-target list. Empty when the user belongs to zero or
+		 * one organisation, in which case the dropdown still renders (for
+		 * the "Manage members" entry) but with no switch targets — this
+		 * mirrors CnTenantBadge's auto-hide contract for the switching
+		 * affordance specifically, not the whole component.
+		 *
+		 * @return {Array}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+		 */
+		otherOrganisations() {
+			return resolveOtherOrganisations(this.organisations, this.activeOrganisationUuid)
+		},
+	},
+
+	methods: {
+		/**
+		 * Switch the active organisation via OpenRegister's own endpoint.
+		 * Membership is verified server-side there — this method never
+		 * assumes the switch will succeed, and never updates any local
+		 * "active organisation" state itself: a successful switch reloads
+		 * the page, which re-derives everything from the new session.
+		 *
+		 * @param {string} uuid The organisation UUID to switch to.
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001
+		 */
+		async switchTo(uuid) {
+			if (uuid === this.activeOrganisationUuid || this.switching) return
+
+			this.switching = true
+			this.errorMessage = ''
+
+			try {
+				const url = generateUrl('/apps/openregister/api/organisations/{uuid}/set-active', { uuid })
+				const response = await fetch(url, {
+					method: 'POST',
+					headers: { requesttoken: OC.requestToken },
+				})
+
+				const body = response.ok ? null : await response.json().catch(() => ({}))
+				const error = resolveSwitchError(response.ok, body, this.t('softwarecatalog', 'Failed to switch organisation'))
+				if (error) {
+					throw new Error(error)
+				}
+
+				window.location.reload()
+			} catch (error) {
+				this.errorMessage = error.message
+				this.switching = false
+			}
+		},
+	},
+}
+</script>
+
+<style scoped>
+.organisation-switcher {
+	display: flex;
+	align-items: center;
+}
+
+.organisation-switcher__error {
+	margin-left: 8px;
+}
+</style>

--- a/src/components/organisations/organisationSwitcher.js
+++ b/src/components/organisations/organisationSwitcher.js
@@ -1,0 +1,54 @@
+/**
+ * Pure helpers for OrganisationSwitcher.vue — extracted so the switch
+ * decision logic is unit-testable without mounting the component (matches
+ * the project's established "pure-logic unit tests" convention).
+ *
+ * @module components/organisations/organisationSwitcher
+ * @author Ruben Linde
+ * @copyright 2026 Conduction B.V.
+ * @license AGPL-3.0-or-later
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+ */
+
+/**
+ * Resolve the display name of the active organisation.
+ *
+ * @param {Array<{uuid: string, naam: string}>} organisations The user's own organisations.
+ * @param {string|null} activeOrganisationUuid The currently-active organisation's UUID.
+ * @param {string} fallback Text to show when no active organisation resolves.
+ * @return {string} The resolved display name, or the fallback.
+ */
+export function resolveActiveOrganisationName(organisations, activeOrganisationUuid, fallback) {
+	const active = (organisations || []).find((org) => org.uuid === activeOrganisationUuid)
+	return active?.naam || fallback
+}
+
+/**
+ * The user's organisations excluding the currently-active one — the
+ * switch-target list.
+ *
+ * @param {Array<{uuid: string}>} organisations The user's own organisations.
+ * @param {string|null} activeOrganisationUuid The currently-active organisation's UUID.
+ * @return {Array} The organisations other than the active one.
+ */
+export function resolveOtherOrganisations(organisations, activeOrganisationUuid) {
+	return (organisations || []).filter((org) => org.uuid !== activeOrganisationUuid)
+}
+
+/**
+ * Resolve the error message for a refused switch, or null when the switch
+ * succeeded. Never trusts the response as successful without `responseOk`
+ * being explicitly true — REQ-001's negative scenario (switch to a
+ * non-member organisation is refused) depends on this always surfacing an
+ * error instead of silently proceeding.
+ *
+ * @param {boolean} responseOk Whether the HTTP response was ok (2xx).
+ * @param {object|null} body The parsed response body, if any.
+ * @param {string} fallbackMessage Message to use when the body carries no `error` field.
+ * @return {string|null} The error message, or null when the switch succeeded.
+ */
+export function resolveSwitchError(responseOk, body, fallbackMessage) {
+	if (responseOk === true) return null
+	return body?.error || fallbackMessage
+}

--- a/src/components/organisations/organisationSwitcher.js
+++ b/src/components/organisations/organisationSwitcher.js
@@ -8,7 +8,7 @@
  * @copyright 2026 Conduction B.V.
  * @license AGPL-3.0-or-later
  *
- * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-users-own-organisations-req-003
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-user-s-own-organisations-req-003
  */
 
 /**

--- a/src/components/organisations/organisationSwitcher.spec.js
+++ b/src/components/organisations/organisationSwitcher.spec.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests for OrganisationSwitcher's pure helpers.
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-switching-the-active-organisation-must-be-verified-against-server-side-membership-never-a-client-supplied-claim-req-001
+ */
+
+import {
+	resolveActiveOrganisationName,
+	resolveOtherOrganisations,
+	resolveSwitchError,
+} from './organisationSwitcher.js'
+
+describe('organisationSwitcher.resolveActiveOrganisationName', () => {
+	const organisations = [
+		{ uuid: 'org-a', naam: 'Gemeente A' },
+		{ uuid: 'org-b', naam: 'Gemeente B' },
+	]
+
+	it('resolves the active organisation name', () => {
+		expect(resolveActiveOrganisationName(organisations, 'org-b', 'fallback')).toBe('Gemeente B')
+	})
+
+	it('falls back when no organisation matches', () => {
+		expect(resolveActiveOrganisationName(organisations, 'org-c', 'fallback')).toBe('fallback')
+	})
+
+	it('falls back when the active uuid is null', () => {
+		expect(resolveActiveOrganisationName(organisations, null, 'fallback')).toBe('fallback')
+	})
+
+	it('handles an empty/undefined organisations list gracefully', () => {
+		expect(resolveActiveOrganisationName(undefined, 'org-a', 'fallback')).toBe('fallback')
+		expect(resolveActiveOrganisationName([], 'org-a', 'fallback')).toBe('fallback')
+	})
+})
+
+describe('organisationSwitcher.resolveOtherOrganisations', () => {
+	const organisations = [
+		{ uuid: 'org-a', naam: 'Gemeente A' },
+		{ uuid: 'org-b', naam: 'Gemeente B' },
+	]
+
+	it('excludes the active organisation', () => {
+		expect(resolveOtherOrganisations(organisations, 'org-a')).toEqual([{ uuid: 'org-b', naam: 'Gemeente B' }])
+	})
+
+	it('returns every organisation when the active uuid is null', () => {
+		expect(resolveOtherOrganisations(organisations, null)).toEqual(organisations)
+	})
+
+	it('returns an empty array when the user has only the active organisation', () => {
+		const single = [{ uuid: 'org-a', naam: 'Gemeente A' }]
+		expect(resolveOtherOrganisations(single, 'org-a')).toEqual([])
+	})
+})
+
+describe('organisationSwitcher.resolveSwitchError — server-side membership verification (REQ-001)', () => {
+	it('returns null when the switch succeeded', () => {
+		expect(resolveSwitchError(true, null, 'fallback')).toBeNull()
+	})
+
+	it('surfaces the server error message when the switch is refused', () => {
+		expect(resolveSwitchError(false, { error: 'User does not belong to this organisation' }, 'fallback'))
+			.toBe('User does not belong to this organisation')
+	})
+
+	it('falls back to a generic message when the refused response carries no error field', () => {
+		expect(resolveSwitchError(false, {}, 'fallback')).toBe('fallback')
+	})
+
+	it('falls back to a generic message when the refused response body is null', () => {
+		expect(resolveSwitchError(false, null, 'fallback')).toBe('fallback')
+	})
+
+	it('never treats a non-ok response as a success, even with a truthy-looking body', () => {
+		// Guards against a client trusting a forged/malformed body over the
+		// actual HTTP status — REQ-001's "forged organisation id" scenario.
+		expect(resolveSwitchError(false, { activeOrganisation: { uuid: 'org-c' } }, 'fallback')).toBe('fallback')
+	})
+})

--- a/src/composables/orClient.js
+++ b/src/composables/orClient.js
@@ -38,6 +38,43 @@ import { getLanguage } from '@nextcloud/l10n'
 export const OR_API_BASE = '/index.php/apps/openregister/api'
 
 /**
+ * Module-level active-organisation UUID (multi-org-membership).
+ *
+ * A plain module-level value rather than a Vue reactive/injected one —
+ * SoftwareCatalog reloads the page on every organisation switch (see
+ * `OrganisationSwitcher.vue`), so the active organisation is stable for the
+ * lifetime of a single page load and does not need cross-component
+ * reactivity. Set once at boot from `App.vue`'s `/api/me` fetch via
+ * {@link setActiveOrganisationUuid}; read by `softwarecatalogPlugin.js`'s
+ * write paths via {@link getActiveOrganisationUuid}.
+ *
+ * @type {string|null}
+ */
+let _activeOrganisationUuid = null
+
+/**
+ * Set the module-level active-organisation UUID used to stamp
+ * `X-OpenRegister-Organisation` on writes.
+ *
+ * @param {string|null} uuid The active organisation UUID, or null/empty to clear.
+ * @return {void}
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+ */
+export function setActiveOrganisationUuid(uuid) {
+	_activeOrganisationUuid = (typeof uuid === 'string' && uuid.length > 0) ? uuid : null
+}
+
+/**
+ * Read the module-level active-organisation UUID.
+ *
+ * @return {string|null} The active organisation UUID, or null when none is set.
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+ */
+export function getActiveOrganisationUuid() {
+	return _activeOrganisationUuid
+}
+
+/**
  * Resolve the active user's language code (BCP-47 region tag stripped).
  *
  * `@nextcloud/l10n`'s `getLanguage()` already returns the short language

--- a/src/composables/orClient.js
+++ b/src/composables/orClient.js
@@ -58,7 +58,7 @@ let _activeOrganisationUuid = null
  *
  * @param {string|null} uuid The active organisation UUID, or null/empty to clear.
  * @return {void}
- * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregister-s-organisationservice-not-reimplemented-req-006
  */
 export function setActiveOrganisationUuid(uuid) {
 	_activeOrganisationUuid = (typeof uuid === 'string' && uuid.length > 0) ? uuid : null
@@ -68,7 +68,7 @@ export function setActiveOrganisationUuid(uuid) {
  * Read the module-level active-organisation UUID.
  *
  * @return {string|null} The active organisation UUID, or null when none is set.
- * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregister-s-organisationservice-not-reimplemented-req-006
  */
 export function getActiveOrganisationUuid() {
 	return _activeOrganisationUuid

--- a/src/composables/orClient.spec.js
+++ b/src/composables/orClient.spec.js
@@ -13,6 +13,8 @@ import {
 	withLanguageParam,
 	buildWriteHeaders,
 	buildObjectUrl,
+	setActiveOrganisationUuid,
+	getActiveOrganisationUuid,
 } from './orClient.js'
 
 jest.mock('@nextcloud/l10n', () => ({
@@ -119,5 +121,37 @@ describe('orClient.buildObjectUrl', () => {
 	it('throws when register or schema is missing', () => {
 		expect(() => buildObjectUrl({ schema: 21, uuid: 'x' })).toThrow()
 		expect(() => buildObjectUrl({ register: 7, uuid: 'x' })).toThrow()
+	})
+})
+
+describe('orClient.setActiveOrganisationUuid / getActiveOrganisationUuid (multi-org-membership)', () => {
+	afterEach(() => {
+		setActiveOrganisationUuid(null)
+	})
+
+	it('starts unset', () => {
+		expect(getActiveOrganisationUuid()).toBeNull()
+	})
+
+	it('stores and returns the active organisation uuid', () => {
+		setActiveOrganisationUuid('org-a')
+		expect(getActiveOrganisationUuid()).toBe('org-a')
+	})
+
+	it('normalises an empty string to null', () => {
+		setActiveOrganisationUuid('org-a')
+		setActiveOrganisationUuid('')
+		expect(getActiveOrganisationUuid()).toBeNull()
+	})
+
+	it('normalises a non-string value to null', () => {
+		setActiveOrganisationUuid(42)
+		expect(getActiveOrganisationUuid()).toBeNull()
+	})
+
+	it('feeds buildWriteHeaders so a write stamps the active organisation', () => {
+		setActiveOrganisationUuid('org-b')
+		const headers = buildWriteHeaders({}, { organisation: getActiveOrganisationUuid() })
+		expect(headers).toHaveProperty('X-OpenRegister-Organisation', 'org-b')
 	})
 })

--- a/src/modals/GrantOrganisationAccessModal.vue
+++ b/src/modals/GrantOrganisationAccessModal.vue
@@ -1,0 +1,252 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2026 Conduction B.V. -->
+
+<!--
+ GrantOrganisationAccessModal — self-service colleague access (VNG
+ Softwarecatalogus #65). Lets a beheerder of the given organisation grant an
+ EXISTING Nextcloud user access to it, and revoke an existing member's
+ access again.
+
+ Client-side rendering of this modal (only reachable when `App.vue`'s
+ `isBeheerder` flag is true, see OrganisationSwitcher.vue) is a UX hint
+ only — the actual authorization is re-verified server-side on every
+ grant/revoke call by `OrganisationMembersController::authorizeBeheerder()`,
+ which additionally confirms the caller belongs to THIS organisation, not
+ just that they hold the `beheerder` role somewhere. A denied response
+ surfaces inline here without mutating the locally-rendered member list.
+
+ @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
+-->
+<template>
+	<NcDialog
+		:open="open"
+		:name="t('softwarecatalog', 'Manage access to {name}', { name: organisationName })"
+		size="normal"
+		@closing="onClose">
+		<div class="grant-organisation-access">
+			<div class="grant-organisation-access__grant">
+				<NcSelectUsers
+					v-model="selectedUser"
+					:input-label="t('softwarecatalog', 'Grant access to an existing Nextcloud user')"
+					:multiple="false" />
+				<NcButton
+					type="primary"
+					:disabled="!selectedUser || granting"
+					@click="onGrant">
+					<template #icon>
+						<NcLoadingIcon v-if="granting" :size="20" />
+					</template>
+					{{ t('softwarecatalog', 'Grant access') }}
+				</NcButton>
+			</div>
+
+			<NcNoteCard v-if="errorMessage" type="error">
+				{{ errorMessage }}
+			</NcNoteCard>
+
+			<h3>{{ t('softwarecatalog', 'Current members') }}</h3>
+			<NcLoadingIcon v-if="loading" :size="32" />
+			<ul v-else class="grant-organisation-access__members">
+				<NcListItem
+					v-for="userId in members"
+					:key="userId"
+					:name="userId"
+					:force-display-actions="true">
+					<template #icon>
+						<NcAvatar :user="userId" :size="32" />
+					</template>
+					<template #actions>
+						<NcActionButton
+							:disabled="revokingUserId === userId"
+							@click="onRevoke(userId)">
+							<template #icon>
+								<NcLoadingIcon v-if="revokingUserId === userId" :size="20" />
+								<CloseIcon v-else :size="20" />
+							</template>
+							{{ t('softwarecatalog', 'Revoke access') }}
+						</NcActionButton>
+					</template>
+				</NcListItem>
+				<li v-if="members.length === 0" class="grant-organisation-access__empty">
+					{{ t('softwarecatalog', 'No members yet.') }}
+				</li>
+			</ul>
+		</div>
+
+		<template #actions>
+			<NcButton @click="onClose">
+				{{ t('softwarecatalog', 'Close') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import { NcDialog, NcButton, NcSelectUsers, NcLoadingIcon, NcNoteCard, NcListItem, NcActionButton, NcAvatar } from '@nextcloud/vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import { organisatieStore } from '../store/store.js'
+import { extractUserId, removeMember } from './grantOrganisationAccess.js'
+
+export default {
+	name: 'GrantOrganisationAccessModal',
+
+	components: {
+		NcDialog,
+		NcButton,
+		NcSelectUsers,
+		NcLoadingIcon,
+		NcNoteCard,
+		NcListItem,
+		NcActionButton,
+		NcAvatar,
+		CloseIcon,
+	},
+
+	props: {
+		/** Whether the modal is open. */
+		open: {
+			type: Boolean,
+			default: false,
+		},
+
+		/** The organisation UUID this modal manages membership for. */
+		organisationUuid: {
+			type: String,
+			default: null,
+		},
+
+		/** The organisation's display name, for the dialog title. */
+		organisationName: {
+			type: String,
+			default: '',
+		},
+	},
+
+	data() {
+		return {
+			members: [],
+			loading: false,
+			selectedUser: null,
+			granting: false,
+			revokingUserId: null,
+			errorMessage: '',
+		}
+	},
+
+	watch: {
+		/**
+		 * Reload the member list every time the dialog opens, so a stale
+		 * list from a previous open (possibly a different organisation)
+		 * never lingers.
+		 *
+		 * @param {boolean} isOpen The new `open` prop value.
+		 * @return {void}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 */
+		open(isOpen) {
+			if (isOpen && this.organisationUuid) {
+				this.loadMembers()
+			}
+		},
+	},
+
+	methods: {
+		/**
+		 * Load the organisation's current member list.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 */
+		async loadMembers() {
+			this.loading = true
+			this.errorMessage = ''
+			try {
+				this.members = await organisatieStore.fetchMembers(this.organisationUuid)
+			} catch (error) {
+				this.errorMessage = error.message
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Grant the selected user access to this organisation.
+		 *
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
+		 */
+		async onGrant() {
+			const userId = extractUserId(this.selectedUser)
+			if (!userId) return
+
+			this.granting = true
+			this.errorMessage = ''
+			try {
+				await organisatieStore.grantAccess(this.organisationUuid, userId)
+				this.selectedUser = null
+				await this.loadMembers()
+			} catch (error) {
+				this.errorMessage = error.message
+			} finally {
+				this.granting = false
+			}
+		},
+
+		/**
+		 * Revoke a member's access to this organisation.
+		 *
+		 * @param {string} userId The member's Nextcloud user id.
+		 * @return {Promise<void>}
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+		 */
+		async onRevoke(userId) {
+			this.revokingUserId = userId
+			this.errorMessage = ''
+			try {
+				await organisatieStore.revokeAccess(this.organisationUuid, userId)
+				this.members = removeMember(this.members, userId)
+			} catch (error) {
+				this.errorMessage = error.message
+			} finally {
+				this.revokingUserId = null
+			}
+		},
+
+		/**
+		 * Close the dialog and reset transient state.
+		 *
+		 * @return {void}
+		 * @spec exclude Dialog-close UI plumbing — no membership/authorization behaviour.
+		 */
+		onClose() {
+			this.selectedUser = null
+			this.errorMessage = ''
+			this.$emit('update:open', false)
+		},
+	},
+}
+</script>
+
+<style scoped>
+.grant-organisation-access__grant {
+	display: flex;
+	align-items: flex-end;
+	gap: 8px;
+	margin-bottom: 16px;
+}
+
+.grant-organisation-access__grant > *:first-child {
+	flex: 1;
+}
+
+.grant-organisation-access__members {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.grant-organisation-access__empty {
+	color: var(--color-text-maxcontrast);
+	padding: 8px 0;
+}
+</style>

--- a/src/modals/GrantOrganisationAccessModal.vue
+++ b/src/modals/GrantOrganisationAccessModal.vue
@@ -141,7 +141,7 @@ export default {
 		 *
 		 * @param {boolean} isOpen The new `open` prop value.
 		 * @return {void}
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregister-s-organisationservice-not-reimplemented-req-006
 		 */
 		open(isOpen) {
 			if (isOpen && this.organisationUuid) {
@@ -155,7 +155,7 @@ export default {
 		 * Load the organisation's current member list.
 		 *
 		 * @return {Promise<void>}
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregister-s-organisationservice-not-reimplemented-req-006
 		 */
 		async loadMembers() {
 			this.loading = true

--- a/src/modals/grantOrganisationAccess.js
+++ b/src/modals/grantOrganisationAccess.js
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers for GrantOrganisationAccessModal.vue — extracted so the
+ * grant/revoke payload logic is unit-testable without mounting the
+ * component (matches the project's established "pure-logic unit tests"
+ * convention).
+ *
+ * @module modals/grantOrganisationAccess
+ * @author Ruben Linde
+ * @copyright 2026 Conduction B.V.
+ * @license AGPL-3.0-or-later
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
+ */
+
+/**
+ * Extract a Nextcloud user id from whatever shape `NcSelectUsers` emits.
+ * Different versions of the component surface the picked option as `.id`,
+ * `.user`, or (defensively) a bare string — this normalises all three so
+ * the grant call always sends a plain user id string.
+ *
+ * @param {object|string|null} selection The `NcSelectUsers` v-model value.
+ * @return {string|null} The resolved user id, or null when nothing is selected.
+ */
+export function extractUserId(selection) {
+	if (!selection) return null
+	if (typeof selection === 'string') return selection
+	return selection.id || selection.user || null
+}
+
+/**
+ * Remove a user id from a member list — used to update the locally-rendered
+ * member list after a successful revoke, without a full refetch.
+ *
+ * @param {string[]} members The current member list.
+ * @param {string} userId The user id to remove.
+ * @return {string[]} A new array with the user id removed.
+ */
+export function removeMember(members, userId) {
+	return (members || []).filter((id) => id !== userId)
+}

--- a/src/modals/grantOrganisationAccess.spec.js
+++ b/src/modals/grantOrganisationAccess.spec.js
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for GrantOrganisationAccessModal's pure helpers.
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
+ */
+
+import { extractUserId, removeMember } from './grantOrganisationAccess.js'
+
+describe('grantOrganisationAccess.extractUserId', () => {
+	it('extracts the id from an { id } shaped selection', () => {
+		expect(extractUserId({ id: 'j.devries' })).toBe('j.devries')
+	})
+
+	it('extracts the id from a { user } shaped selection', () => {
+		expect(extractUserId({ user: 'j.devries' })).toBe('j.devries')
+	})
+
+	it('prefers .id over .user when both are present', () => {
+		expect(extractUserId({ id: 'preferred', user: 'other' })).toBe('preferred')
+	})
+
+	it('passes through a bare string selection', () => {
+		expect(extractUserId('j.devries')).toBe('j.devries')
+	})
+
+	it('returns null for a null/undefined selection', () => {
+		expect(extractUserId(null)).toBeNull()
+		expect(extractUserId(undefined)).toBeNull()
+	})
+
+	it('returns null when neither .id nor .user is present', () => {
+		expect(extractUserId({ displayName: 'Jan de Vries' })).toBeNull()
+	})
+})
+
+describe('grantOrganisationAccess.removeMember', () => {
+	it('removes the given user id from the member list', () => {
+		expect(removeMember(['a', 'b', 'c'], 'b')).toEqual(['a', 'c'])
+	})
+
+	it('is a no-op when the user id is not present', () => {
+		expect(removeMember(['a', 'b'], 'z')).toEqual(['a', 'b'])
+	})
+
+	it('handles an empty/undefined member list gracefully', () => {
+		expect(removeMember([], 'a')).toEqual([])
+		expect(removeMember(undefined, 'a')).toEqual([])
+	})
+
+	it('does not mutate the input array', () => {
+		const members = ['a', 'b']
+		removeMember(members, 'a')
+		expect(members).toEqual(['a', 'b'])
+	})
+})

--- a/src/store/modules/organisatie.js
+++ b/src/store/modules/organisatie.js
@@ -530,7 +530,7 @@ export const useOrganisatieStore = defineStore('organisatie', {
 		 *
 		 * @param {string} uuid The organisation UUID.
 		 * @return {Promise<string[]>} The member user ids.
-		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregister-s-organisationservice-not-reimplemented-req-006
 		 */
 		async fetchMembers(uuid) {
 			const url = generateUrl('/apps/openregister/api/organisations/{uuid}', { uuid })

--- a/src/store/modules/organisatie.js
+++ b/src/store/modules/organisatie.js
@@ -517,5 +517,99 @@ export const useOrganisatieStore = defineStore('organisatie', {
 				throw error
 			}
 		},
+
+		// ==========================================
+		// Self-service colleague access (multi-org-membership)
+		// ==========================================
+
+		/**
+		 * Fetch an organisation's current members (Nextcloud user ids).
+		 * Consumes OpenRegister's own `GET /api/organisations/{uuid}`
+		 * directly — already gated by `hasAccessToOrganisation()` — rather
+		 * than adding a SoftwareCatalog read endpoint for the same data.
+		 *
+		 * @param {string} uuid The organisation UUID.
+		 * @return {Promise<string[]>} The member user ids.
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-membership-mutations-must-be-delegated-to-openregisters-organisationservice-not-reimplemented-req-006
+		 */
+		async fetchMembers(uuid) {
+			const url = generateUrl('/apps/openregister/api/organisations/{uuid}', { uuid })
+
+			const response = await fetch(url, {
+				method: 'GET',
+				headers: {
+					'Content-Type': 'application/json',
+					requesttoken: OC.requestToken,
+				},
+			})
+
+			if (!response.ok) {
+				const errorData = await response.json().catch(() => ({}))
+				throw new Error(errorData.error || `HTTP error! status: ${response.status}`)
+			}
+
+			const data = await response.json()
+			return data?.organisation?.users || []
+		},
+
+		/**
+		 * Grant an existing Nextcloud user access to an organisation.
+		 * Server-side, this is authorized by SoftwareCatalog's
+		 * `beheerder`-of-this-organisation guard, then delegated to
+		 * OpenRegister's own `OrganisationService::joinOrganisation()`.
+		 *
+		 * @param {string} uuid The organisation UUID.
+		 * @param {string} userId The existing Nextcloud user id to grant access to.
+		 * @return {Promise<object>} The success response body.
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+		 */
+		async grantAccess(uuid, userId) {
+			const url = generateUrl('/apps/softwarecatalog/api/organisations/{uuid}/members', { uuid })
+
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					requesttoken: OC.requestToken,
+				},
+				body: JSON.stringify({ userId }),
+			})
+
+			const data = await response.json().catch(() => ({}))
+
+			if (!response.ok) {
+				throw new Error(data.error || `HTTP error! status: ${response.status}`)
+			}
+
+			return data
+		},
+
+		/**
+		 * Revoke an existing member's access to an organisation.
+		 *
+		 * @param {string} uuid The organisation UUID.
+		 * @param {string} userId The Nextcloud user id to revoke access from.
+		 * @return {Promise<object>} The success response body.
+		 * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+		 */
+		async revokeAccess(uuid, userId) {
+			const url = generateUrl('/apps/softwarecatalog/api/organisations/{uuid}/members/{userId}', { uuid, userId })
+
+			const response = await fetch(url, {
+				method: 'DELETE',
+				headers: {
+					'Content-Type': 'application/json',
+					requesttoken: OC.requestToken,
+				},
+			})
+
+			const data = await response.json().catch(() => ({}))
+
+			if (!response.ok) {
+				throw new Error(data.error || `HTTP error! status: ${response.status}`)
+			}
+
+			return data
+		},
 	},
 })

--- a/src/store/plugins/softwarecatalogPlugin.js
+++ b/src/store/plugins/softwarecatalogPlugin.js
@@ -15,7 +15,7 @@
 
 import { buildHeaders, buildQueryString } from '@conduction/nextcloud-vue'
 
-import { withLanguageParam, buildWriteHeaders } from '../../composables/orClient.js'
+import { withLanguageParam, buildWriteHeaders, getActiveOrganisationUuid } from '../../composables/orClient.js'
 
 /**
  * Extract an ID from a value that can be either a primitive or an object.
@@ -580,7 +580,7 @@ export function softwarecatalogPlugin() {
 					const url = this._buildUrl(type, isUpdate ? id : null)
 					const response = await fetch(url, {
 						method: isUpdate ? 'PUT' : 'POST',
-						headers: buildHeaders(),
+						headers: buildWriteHeaders(buildHeaders(), { organisation: getActiveOrganisationUuid() }),
 						body: JSON.stringify(objectData),
 					})
 
@@ -720,7 +720,7 @@ export function softwarecatalogPlugin() {
 						`/index.php/apps/openregister/api/objects/${registerId}/${schemaId}/${id}`,
 						{
 							method: 'PATCH',
-							headers: buildWriteHeaders(buildHeaders(), { targetLang }),
+							headers: buildWriteHeaders(buildHeaders(), { targetLang, organisation: getActiveOrganisationUuid() }),
 							body: JSON.stringify(changes),
 						},
 					)

--- a/tests/Stubs/Service/OrganisationService.php
+++ b/tests/Stubs/Service/OrganisationService.php
@@ -5,10 +5,13 @@
  *
  * The real OrganisationService lives in the OpenRegister app which is not
  * available as a Composer dependency in the test environment. This stub
- * declares the single method SoftwareCatalog's
+ * declares the methods SoftwareCatalog's
  * AangebodenGebruikService::getCurrentOrganisation() /
- * AanbodService::getCurrentOrganisation() rely on, so PHPUnit can create
- * mocks against it for vendor-visibility-rbac's deny-before-grant tests.
+ * AanbodService::getCurrentOrganisation() rely on (vendor-visibility-rbac's
+ * deny-before-grant tests), plus the membership-management surface
+ * `OrganisationMembersController` and its tests rely on
+ * (multi-org-membership): `getUserOrganisations()`, `joinOrganisation()`,
+ * `leaveOrganisation()`.
  *
  * SPDX-License-Identifier: EUPL-1.2
  *
@@ -36,5 +39,38 @@ abstract class OrganisationService
      * @return Organisation|null
      */
     abstract public function getActiveOrganisation(): ?Organisation;
+
+    /**
+     * Get the caller's own organisations (session-scoped).
+     *
+     * @return Organisation[]
+     */
+    abstract public function getUserOrganisations(): array;
+
+    /**
+     * Add a user to an organisation. Real implementation performs no
+     * caller-side authorization — callers MUST authorize before invoking.
+     *
+     * @param string      $organisationUuid The organisation UUID.
+     * @param string|null $targetUserId     Target user id, or null for the current user.
+     *
+     * @return bool True on success.
+     *
+     * @throws \Exception When the organisation or target user is not found.
+     */
+    abstract public function joinOrganisation(string $organisationUuid, ?string $targetUserId = null): bool;
+
+    /**
+     * Remove a user from an organisation. Real implementation performs no
+     * caller-side authorization — callers MUST authorize before invoking.
+     *
+     * @param string      $organisationUuid The organisation UUID.
+     * @param string|null $targetUserId     Target user id, or null for the current user.
+     *
+     * @return bool True on success.
+     *
+     * @throws \Exception When the organisation is not found, or the target would be left with no organisation.
+     */
+    abstract public function leaveOrganisation(string $organisationUuid, ?string $targetUserId = null): bool;
 
 }//end class

--- a/tests/Unit/Controller/ContactpersonenControllerDecompositionTest.php
+++ b/tests/Unit/Controller/ContactpersonenControllerDecompositionTest.php
@@ -183,6 +183,7 @@ class ContactpersonenControllerDecompositionTest extends TestCase
         $this->assertSame('', $result['functie']);
         $this->assertNull($result['organisations']['active']);
         $this->assertSame([], $result['organisations']['all']);
+        $this->assertFalse($result['isBeheerder']);
     }
 
     public function testProjectCatalogGroupsKeepsOnlyCatalogGroups(): void

--- a/tests/Unit/Controller/OrganisationMembersControllerTest.php
+++ b/tests/Unit/Controller/OrganisationMembersControllerTest.php
@@ -1,0 +1,277 @@
+<?php
+/**
+ * Unit tests for OrganisationMembersController's beheerder-only authorization
+ * guard (self-service colleague access, VNG Softwarecatalogus #65).
+ *
+ * Covers the no-admin-idor gate: grant()/revoke() MUST refuse (403) a caller
+ * who is not in the `beheerder` NC group, and MUST refuse (403) a `beheerder`
+ * of a DIFFERENT organisation — in both cases MUST NOT reach OpenRegister's
+ * OrganisationService::joinOrganisation()/leaveOrganisation(). A grant to a
+ * non-existent Nextcloud user MUST be refused (404) without ever reaching
+ * joinOrganisation(). An authorized beheerder's grant/revoke MUST succeed
+ * and delegate the actual mutation to OpenRegister — no parallel membership
+ * store is written.
+ *
+ * @category  Tests
+ * @package   OCA\SoftwareCatalog\Tests\Unit\Controller
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/SoftwareCatalog
+ *
+ * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-or-revoking-organisation-access-must-be-restricted-to-a-beheerder-of-that-organisation-req-004
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Tests\Unit\Controller;
+
+use OCA\OpenRegister\Db\Organisation;
+use OCA\OpenRegister\Service\OrganisationService;
+use OCA\SoftwareCatalog\Controller\OrganisationMembersController;
+use OCP\AppFramework\Http;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use Psr\Container\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test class for OrganisationMembersController's beheerder-of-this-org guard.
+ */
+class OrganisationMembersControllerTest extends TestCase
+{
+
+    /**
+     * @var IUserSession|MockObject
+     */
+    private IUserSession|MockObject $userSession;
+
+    /**
+     * @var IGroupManager|MockObject
+     */
+    private IGroupManager|MockObject $groupManager;
+
+    /**
+     * @var IUserManager|MockObject
+     */
+    private IUserManager|MockObject $userManager;
+
+    /**
+     * @var ContainerInterface|MockObject
+     */
+    private ContainerInterface|MockObject $container;
+
+    /**
+     * @var OrganisationService|MockObject
+     */
+    private OrganisationService|MockObject $organisationService;
+
+    /**
+     * Build the controller with the current mocks and a logged-in user.
+     *
+     * @param bool   $isBeheerder    Whether the caller is in the `beheerder` NC group.
+     * @param array  $callerOrgUuids Organisation UUIDs the caller belongs to (per OpenRegister).
+     * @param string $callerUid      The caller's Nextcloud user id.
+     *
+     * @return OrganisationMembersController The controller under test.
+     */
+    private function makeController(
+        bool $isBeheerder,
+        array $callerOrgUuids,
+        string $callerUid = 'caller-uid'
+    ): OrganisationMembersController {
+        $request = $this->createMock(IRequest::class);
+
+        $this->userSession   = $this->createMock(IUserSession::class);
+        $this->groupManager  = $this->createMock(IGroupManager::class);
+        $this->userManager   = $this->createMock(IUserManager::class);
+        $this->container     = $this->createMock(ContainerInterface::class);
+        $this->organisationService = $this->createMock(OrganisationService::class);
+
+        $user = $this->createMock(IUser::class);
+        $user->method('getUID')->willReturn($callerUid);
+        $this->userSession->method('getUser')->willReturn($user);
+
+        $this->groupManager->method('isInGroup')->with($callerUid, 'beheerder')->willReturn($isBeheerder);
+
+        $callerOrgs = array_map(
+            function (string $uuid): Organisation {
+                $org = new Organisation();
+                $org->setUuid($uuid);
+                return $org;
+            },
+            $callerOrgUuids
+        );
+        $this->organisationService->method('getUserOrganisations')->willReturn($callerOrgs);
+
+        $this->container->method('get')
+            ->with('OCA\OpenRegister\Service\OrganisationService')
+            ->willReturn($this->organisationService);
+
+        return new OrganisationMembersController(
+            $request,
+            $this->userSession,
+            $this->groupManager,
+            $this->userManager,
+            $this->container,
+            $this->createMock(LoggerInterface::class)
+        );
+    }//end makeController()
+
+    /**
+     * A caller who is not in the `beheerder` group is refused (403) on
+     * grant(), and OpenRegister's joinOrganisation() is never invoked.
+     *
+     * @return void
+     */
+    public function testGrantRefusesNonBeheerder(): void
+    {
+        $controller = $this->makeController(isBeheerder: false, callerOrgUuids: ['org-a']);
+        $this->organisationService->expects($this->never())->method('joinOrganisation');
+
+        $response = $controller->grant(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testGrantRefusesNonBeheerder()
+
+    /**
+     * A caller who is not in the `beheerder` group is refused (403) on
+     * revoke(), and OpenRegister's leaveOrganisation() is never invoked.
+     *
+     * @return void
+     */
+    public function testRevokeRefusesNonBeheerder(): void
+    {
+        $controller = $this->makeController(isBeheerder: false, callerOrgUuids: ['org-a']);
+        $this->organisationService->expects($this->never())->method('leaveOrganisation');
+
+        $response = $controller->revoke(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testRevokeRefusesNonBeheerder()
+
+    /**
+     * A caller who is a `beheerder` but only of a DIFFERENT organisation is
+     * refused (403) on grant() — the org-membership check, not just the
+     * group check, MUST gate the mutation.
+     *
+     * @return void
+     */
+    public function testGrantRefusesBeheerderOfDifferentOrganisation(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-b']);
+        $this->organisationService->expects($this->never())->method('joinOrganisation');
+
+        $response = $controller->grant(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testGrantRefusesBeheerderOfDifferentOrganisation()
+
+    /**
+     * A caller who is a `beheerder` but only of a DIFFERENT organisation is
+     * refused (403) on revoke() too.
+     *
+     * @return void
+     */
+    public function testRevokeRefusesBeheerderOfDifferentOrganisation(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-b']);
+        $this->organisationService->expects($this->never())->method('leaveOrganisation');
+
+        $response = $controller->revoke(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+    }//end testRevokeRefusesBeheerderOfDifferentOrganisation()
+
+    /**
+     * A grant to a user id that does not resolve via IUserManager::get() is
+     * refused (404), and joinOrganisation() is never invoked — existing-
+     * user-only (REQ-005).
+     *
+     * @return void
+     */
+    public function testGrantRefusesNonExistentUser(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-a']);
+        $this->userManager->method('get')->with('no-such-user')->willReturn(null);
+        $this->organisationService->expects($this->never())->method('joinOrganisation');
+
+        $response = $controller->grant(uuid: 'org-a', userId: 'no-such-user');
+
+        $this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+    }//end testGrantRefusesNonExistentUser()
+
+    /**
+     * An authorized beheerder's grant reaches OpenRegister's
+     * joinOrganisation() and succeeds with 200 — the actual membership
+     * mutation is delegated, not reimplemented.
+     *
+     * @return void
+     */
+    public function testGrantAuthorizesBeheerderAndDelegatesToOpenRegister(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-a']);
+
+        $existingUser = $this->createMock(IUser::class);
+        $this->userManager->method('get')->with('colleague-uid')->willReturn($existingUser);
+
+        $this->organisationService->expects($this->once())
+            ->method('joinOrganisation')
+            ->with('org-a', 'colleague-uid')
+            ->willReturn(true);
+
+        $response = $controller->grant(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testGrantAuthorizesBeheerderAndDelegatesToOpenRegister()
+
+    /**
+     * An authorized beheerder's revoke reaches OpenRegister's
+     * leaveOrganisation() and succeeds with 200.
+     *
+     * @return void
+     */
+    public function testRevokeAuthorizesBeheerderAndDelegatesToOpenRegister(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-a']);
+
+        $this->organisationService->expects($this->once())
+            ->method('leaveOrganisation')
+            ->with('org-a', 'colleague-uid')
+            ->willReturn(true);
+
+        $response = $controller->revoke(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_OK, $response->getStatus());
+    }//end testRevokeAuthorizesBeheerderAndDelegatesToOpenRegister()
+
+    /**
+     * When OpenRegister's joinOrganisation() throws (e.g. organisation not
+     * found), the controller surfaces a 400 rather than a 5xx or a silent
+     * success.
+     *
+     * @return void
+     */
+    public function testGrantSurfacesOpenRegisterExceptionAs400(): void
+    {
+        $controller = $this->makeController(isBeheerder: true, callerOrgUuids: ['org-a']);
+
+        $existingUser = $this->createMock(IUser::class);
+        $this->userManager->method('get')->with('colleague-uid')->willReturn($existingUser);
+
+        $this->organisationService->method('joinOrganisation')
+            ->willThrowException(new \Exception('Organisation not found'));
+
+        $response = $controller->grant(uuid: 'org-a', userId: 'colleague-uid');
+
+        $this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+    }//end testGrantSurfacesOpenRegisterExceptionAs400()
+}//end class


### PR DESCRIPTION
Closes #371. Evidence: VNG issues **#57**/**#60** (one account active in multiple organisations) and **#65** (self-service colleague access).

### Consumed OpenRegister rather than wrapping it
`OrganisationService` (`getUserOrganisations`, `getActiveOrganisation`, `setActiveOrganisation`, `joinOrganisation`, `leaveOrganisation`) and `OrganisationController`'s HTTP surface already exist and are correctly authorized. The switcher calls `set-active` **directly** — no proxy controller (that would trip `hydra-gate-redundant-controller`).

**One genuine gap justified new backend code:** OpenRegister's join/leave authorize only an NC admin or the org's single `owner` — not SoftwareCatalog's `beheerder` role. `OrganisationMembersController` adds that domain-specific guard and then delegates the mutation to OpenRegister's own service.

### Server-side membership verification (never a client claim)
- **Switch**: OpenRegister derives membership from `Organisation::hasUser($sessionUserId)`. A refused switch does not reload and leaves the active org unchanged.
- **Grant/revoke**: requires *both* the global `beheerder` group **and** that the caller's own session-derived memberships include the **target** org — checked before any mutation, so a beheerder of org B cannot touch org A.

Interacts with the RBAC model hardened in #395: switching changes what you can see, and cannot become a way to read a non-member organisation.

**Tests:** PHP 473 / 1510 assertions, 0 failures (8 new, all mandatory negatives) · Jest 113 · Vitest 210 · manifest Ajv PASS. Archive guard (hydra#376) run: requirement counts identical across all pre-existing spec files; new spec adds 6, none modified or removed.

Note: the `PortfolioReportControllerTest` CSV failure tracked as #393 now passes — closing that separately.

**Not done:** no live browser verification this pass (shared-container constraints); recorded honestly as a reason-bearing `@e2e exclude` and in the feature doc rather than claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)