### PR TITLE
fix(suite-wizard): Applications step was blank — no application could be attached (#372)

### DIFF
--- a/src/dialogs/SuiteWizard/Step2Applications.vue
+++ b/src/dialogs/SuiteWizard/Step2Applications.vue
@@ -41,6 +41,7 @@
 <script>
 import { NcSelect, NcNoteCard } from '@nextcloud/vue'
 import { objectStore } from '../../store/store.js'
+import { mapApplicationOptions } from '../../utils/suiteWizard.js'
 
 export default {
 	name: 'Step2Applications',
@@ -74,15 +75,13 @@ export default {
 		 * @return {Array<{uuid: string, label: string, raw: object}>}
 		 */
 		applicationOptions() {
-			const modules = objectStore.getCollection ? objectStore.getCollection('module') : []
-			return (modules || []).map((mod) => {
-				const uuid = mod.uuid || mod.id || mod['@self']?.id
-				return {
-					uuid,
-					label: mod.naam || mod.title || uuid,
-					raw: mod,
-				}
-			})
+			// `getCollection()` returns the paginated ENVELOPE ({ results, ... }),
+			// not a bare array. Mapping lives in `mapApplicationOptions()` so it
+			// is unit-testable against both shapes — reading the envelope as an
+			// array threw "(intermediate value).map is not a function" and left
+			// this step blank, and no test covered this computed.
+			const collection = objectStore.getCollection ? objectStore.getCollection('module') : null
+			return mapApplicationOptions(collection)
 		},
 
 		/**

--- a/src/utils/suiteWizard.js
+++ b/src/utils/suiteWizard.js
@@ -90,3 +90,33 @@ export function summarizeApplications(applications) {
 	if (!Array.isArray(applications)) return []
 	return applications.map((app) => (app && (app.naam || app.id)) || '')
 }
+
+/**
+ * Map an object-store collection of modules to `NcSelect` option shape.
+ *
+ * Accepts the paginated ENVELOPE that `objectStore.getCollection()` actually
+ * returns (`{ results: [...] }`) as well as a bare array, and tolerates
+ * null/undefined while the collection is still loading. Reading the envelope
+ * as an array threw `(intermediate value).map is not a function` at runtime and
+ * left the wizard's Applications step blank, so no application could ever be
+ * attached to a suite — the component's own computed had no unit test.
+ *
+ * @param {object|Array|null} collection Collection envelope, bare array, or null.
+ *
+ * @return {Array<{uuid: string, label: string, raw: object}>} Option list.
+ *
+ * @spec openspec/specs/suite-wizard/spec.md#requirement-the-wizard-must-let-the-user-attach-one-or-more-existing-applications-to-the-new-suite
+ */
+export function mapApplicationOptions(collection) {
+	const modules = Array.isArray(collection) ? collection : (collection?.results || [])
+
+	return modules.map((mod) => {
+		const uuid = mod.uuid || mod.id || mod['@self']?.id
+
+		return {
+			uuid,
+			label: mod.naam || mod.title || uuid,
+			raw: mod,
+		}
+	})
+}

--- a/src/utils/suiteWizard.spec.js
+++ b/src/utils/suiteWizard.spec.js
@@ -9,6 +9,7 @@ import {
 	isApplicationsStepValid,
 	buildSuitePayload,
 	summarizeApplications,
+	mapApplicationOptions,
 } from './suiteWizard.js'
 
 describe('suiteWizard.isDetailsStepValid', () => {
@@ -110,5 +111,43 @@ describe('suiteWizard.summarizeApplications', () => {
 
 	it('returns an empty array for non-array input', () => {
 		expect(summarizeApplications(undefined)).toEqual([])
+	})
+})
+
+
+describe('suiteWizard.mapApplicationOptions', () => {
+	// Regression: `objectStore.getCollection()` returns the paginated ENVELOPE,
+	// not a bare array. The component computed mapped it as an array, which threw
+	// "(intermediate value).map is not a function" at runtime and left the
+	// wizard's Applications step blank — no application could be attached to a
+	// suite. Found only by running the wizard in a browser (2026-07-24); no test
+	// covered the computed. These cases pin BOTH shapes.
+	it('maps the paginated envelope shape returned by getCollection()', () => {
+		const envelope = { results: [{ uuid: 'u1', naam: 'Zaaksysteem' }], total: 1, page: 1 }
+
+		expect(mapApplicationOptions(envelope)).toEqual([
+			{ uuid: 'u1', label: 'Zaaksysteem', raw: { uuid: 'u1', naam: 'Zaaksysteem' } },
+		])
+	})
+
+	it('still maps a bare array', () => {
+		expect(mapApplicationOptions([{ uuid: 'u2', naam: 'DMS' }])).toEqual([
+			{ uuid: 'u2', label: 'DMS', raw: { uuid: 'u2', naam: 'DMS' } },
+		])
+	})
+
+	it('returns an empty list while the collection is still loading', () => {
+		expect(mapApplicationOptions(null)).toEqual([])
+		expect(mapApplicationOptions(undefined)).toEqual([])
+		expect(mapApplicationOptions({})).toEqual([])
+	})
+
+	it('falls back to id and @self.id for the identifier, and to the uuid for the label', () => {
+		const envelope = { results: [{ id: 'i1' }, { '@self': { id: 's1' } }] }
+
+		expect(mapApplicationOptions(envelope).map((o) => [o.uuid, o.label])).toEqual([
+			['i1', 'i1'],
+			['s1', 's1'],
+		])
 	})
 })


### PR DESCRIPTION
Found by the live-verification pass on 8080 (#386), 2026-07-24.

### Defect
The suite wizard's **Applications step rendered completely empty**:
```
TypeError: ((intermediate value) || []).map is not a function
    at applicationOptions
```
`objectStore.getCollection('module')` returns the paginated **envelope** (`{ results, ... }`), not a bare array. The computed mapped it as an array, so the step crashed and **no application could ever be attached to a suite** — the wizard's entire purpose.

It shipped green because the specs only covered the pure helpers in `src/utils/suiteWizard.js`; **nothing exercised that computed**. Same access shape is already used correctly by `LicensePostureView` and `OrganisatieIndex`.

### Fix
Mapping extracted to `mapApplicationOptions()` (testable, matching the repo's utils pattern) which accepts the envelope, a bare array, and null-while-loading. 4 regression cases pin both shapes plus id-fallback. Jest 19/19.

### Live-verified after the fix
- Step 2 renders the picker with **all 18 applications** (matches the dashboard's Applicatie count).
- Completed the wizard end-to-end: the suite persisted with its `applicaties` relation populated (`["0cee17dc-…"]` = Open Zaak). Test object deleted afterwards.
- 0 console errors.

I also swept for the same mistake — `Dashboard.vue` and `OrganisatieIndex.vue` already handle `?.results` correctly; this was the only occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)