### PR TITLE
fix(ratings): resolve beoordeeling register+schema — reviews were 100% dead (#375)

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -881,6 +881,19 @@ class SettingsService
             'compliancy'    => 'compliancy_schema',
             'moduleVersie'  => 'moduleVersie_schema',
             'sbomComponent' => 'sbomComponent_schema',
+            // Every catalog object type stored in the voorzieningen register must
+            // be mapped here, or getSchemaIdForObjectType() returns null for it
+            // even though its `<type>_schema` id is present in the config — which
+            // silently killed the ratings feature (`beoordeeling` was unmapped, so
+            // ReviewService/ReviewAggregateService read "not configured" forever).
+            'beoordeeling'  => 'beoordeeling_schema',
+            'dienst'        => 'dienst_schema',
+            'gebruik'       => 'gebruik_schema',
+            'contract'      => 'contract_schema',
+            'koppeling'     => 'koppeling_schema',
+            'suite'         => 'suite_schema',
+            'kwetsbaarheid' => 'kwetsbaarheid_schema',
+            'sector'        => 'sector_schema',
         ];
 
         // Only check voorzieningen config if object type exists in the key map.
@@ -1017,10 +1030,22 @@ class SettingsService
             }
         }
 
-        // Check Voorzieningen register for organisatie/organization and contactpersoon/contact.
-        $orgContactTypes = ['organisatie', 'organization', 'contactpersoon', 'contact'];
-        if ($result === null && in_array($objectType, $orgContactTypes, true) === true) {
-            $voorzieningenConfig = $this->getVoorzieningenConfig();
+        // Check Voorzieningen register for every catalog object type. All catalog
+        // schemas (organisatie, contactpersoon, module, gebruik, contract,
+        // koppeling, beoordeeling, suite, kwetsbaarheid, sector, …) live in the one
+        // voorzieningen register, but this method previously mapped it only for
+        // organisatie/contactpersoon — so a caller resolving e.g. `beoordeeling`
+        // got null and the feature read as "not configured" (ratings submit,
+        // aggregate and moderation were all dead this way). Mirror the schema-side
+        // key map: any type with a `<type>_schema` in the voorzieningen config
+        // belongs to the voorzieningen register.
+        $voorzieningenConfig = $this->getVoorzieningenConfig();
+        $isVoorzieningenType = in_array($objectType, ['organisatie', 'organization', 'contactpersoon', 'contact'], true);
+        if ($isVoorzieningenType === false) {
+            $isVoorzieningenType = isset($voorzieningenConfig[$objectType.'_schema']);
+        }
+
+        if ($result === null && $isVoorzieningenType === true) {
             if (isset($voorzieningenConfig['register']) === true && empty($voorzieningenConfig['register']) === false) {
                 $result = (int) $voorzieningenConfig['register'];
             }

--- a/tests/Unit/Service/SettingsServiceCatalogTypeResolutionTest.php
+++ b/tests/Unit/Service/SettingsServiceCatalogTypeResolutionTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Regression tests for catalog object-type register/schema resolution (#375).
+ *
+ * @category Test
+ * @package  OCA\SoftwareCatalog\Tests\Unit\Service
+ *
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @link      https://codeberg.org/Conduction/SoftwareCatalog
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Tests\Unit\Service;
+
+use OCA\SoftwareCatalog\Service\SettingsService;
+use OCP\App\IAppManager;
+use OCP\IAppConfig;
+use OCP\IGroupManager;
+use OCP\IL10N;
+use OCP\IRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Locks the resolution of every catalog object type to the voorzieningen
+ * register + its `<type>_schema`.
+ *
+ * Regression for #375: `beoordeeling` (and several sibling catalog types) were
+ * absent from getSchemaIdForObjectType()'s key map, and getRegisterIdForObjectType()
+ * only mapped the voorzieningen register for organisatie/contactpersoon — so the
+ * whole ratings feature (submit, aggregate AND moderation, which all resolve the
+ * beoordeeling target through these two methods) read "register/schema not
+ * configured" on every call.
+ */
+class SettingsServiceCatalogTypeResolutionTest extends TestCase
+{
+
+    /**
+     * Build a SettingsService whose voorzieningen_config carries the register
+     * and a `<type>_schema` id for each catalog type.
+     *
+     * @return SettingsService
+     */
+    private function makeService(): SettingsService
+    {
+        $voorzieningenConfig = json_encode(
+            [
+                'register'             => '11',
+                'organisatie_schema'   => '39',
+                'contactpersoon_schema' => '38',
+                'module_schema'        => '50',
+                'compliancy_schema'    => '51',
+                'moduleVersie_schema'  => '52',
+                'dienst_schema'        => '36',
+                'gebruik_schema'       => '40',
+                'contract_schema'      => '41',
+                'koppeling_schema'     => '42',
+                'suite_schema'         => '35',
+                'kwetsbaarheid_schema' => '37',
+                'sector_schema'        => '34',
+                'beoordeeling_schema'  => '43',
+            ]
+        );
+
+        $config = $this->createMock(IAppConfig::class);
+        $config->method('getValueString')->willReturnCallback(
+            function (string $app, string $key, string $default = '') use ($voorzieningenConfig): string {
+                if ($key === 'voorzieningen_config') {
+                    return $voorzieningenConfig;
+                }
+
+                return $default;
+            }
+        );
+        $config->method('hasKey')->willReturn(true);
+
+        // The unknown-type path falls through to the resolver, which probes the
+        // installed-apps list; mock it so that probe does not hit a null haystack.
+        $appManager = $this->createMock(IAppManager::class);
+        $appManager->method('getInstalledApps')->willReturn([]);
+
+        return new SettingsService(
+            config: $config,
+            request: $this->createMock(IRequest::class),
+            container: $this->createMock(ContainerInterface::class),
+            appManager: $appManager,
+            logger: $this->createMock(LoggerInterface::class),
+            groupManager: $this->createMock(IGroupManager::class),
+            l10n: $this->createMock(IL10N::class)
+        );
+
+    }//end makeService()
+
+    /**
+     * `beoordeeling` — the type the ratings feature resolves — must map to
+     * schema 43 and register 11.
+     *
+     * @return void
+     */
+    public function testBeoordeelingResolvesRegisterAndSchema(): void
+    {
+        $service = $this->makeService();
+
+        $this->assertSame(43, $service->getSchemaIdForObjectType('beoordeeling'), 'schema id');
+        $this->assertSame(11, $service->getRegisterIdForObjectType('beoordeeling'), 'register id');
+
+    }//end testBeoordeelingResolvesRegisterAndSchema()
+
+    /**
+     * Every catalog type present in the config resolves to a non-null register
+     * and schema — none silently reads as "not configured".
+     *
+     * @return void
+     */
+    public function testEveryCatalogTypeResolves(): void
+    {
+        $service = $this->makeService();
+
+        $types = [
+            'module'        => 50,
+            'dienst'        => 36,
+            'gebruik'       => 40,
+            'contract'      => 41,
+            'koppeling'     => 42,
+            'suite'         => 35,
+            'kwetsbaarheid' => 37,
+            'sector'        => 34,
+            'compliancy'    => 51,
+            'moduleVersie'  => 52,
+            'beoordeeling'  => 43,
+        ];
+
+        foreach ($types as $type => $schemaId) {
+            $this->assertSame($schemaId, $service->getSchemaIdForObjectType($type), "schema for {$type}");
+            $this->assertSame(11, $service->getRegisterIdForObjectType($type), "register for {$type}");
+        }
+
+    }//end testEveryCatalogTypeResolves()
+
+    /**
+     * A type with no config key stays unresolved (no false positive).
+     *
+     * @return void
+     */
+    public function testUnknownTypeStaysNull(): void
+    {
+        $service = $this->makeService();
+
+        $this->assertNull($service->getSchemaIdForObjectType('doesNotExist'));
+        $this->assertNull($service->getRegisterIdForObjectType('doesNotExist'));
+
+    }//end testUnknownTypeStaysNull()
+
+}//end class


### PR DESCRIPTION
Found by the final live e2e pass on 8080 (#386). The catalog-ratings feature (#399) was **completely non-functional on a live instance**: every review submit, aggregate and moderation call returned `register/schema not configured`.

### Root cause (SettingsService, two halves)
- `getSchemaIdForObjectType()`'s `voorzieningenKeyMap` only listed `module`/`compliancy`/`moduleVersie`/`sbomComponent`, so it returned **null for `beoordeeling`** (and `dienst`/`gebruik`/`contract`/`koppeling`/`suite`/`kwetsbaarheid`/`sector`) even though `<type>_schema` was in the config.
- `getRegisterIdForObjectType()` mapped the voorzieningen register **only** for `organisatie`/`contactpersoon`, so every other catalog type resolved to null.

`ReviewService`, `ReviewAggregateService` and `ModerationService` all resolve the beoordeeling target through these two methods — so all three read the feature as unconfigured.

### Fix
Complete the schema key map with every catalog type, and resolve the voorzieningen register for any type that has a `<type>_schema` in the config. **One fix point** in the platform helper; no per-service workarounds.

### Verified live end-to-end (after the fix)
- `submit` → **202 pending**; client-supplied `auteur:"FORGED"` and `status:"approved"` both **ignored** — author server-stamped to the session user (`admin`), status forced `pending`.
- Pending review **excluded** from the approved-only public aggregate (fail-closed).
- Moderation queue resolves → **approve** → aggregate now shows **average 5, count 1**.
- Test review deleted afterwards.

3 new regression unit tests (beoordeeling resolves register+schema; every catalog type resolves; unknown type stays null).

Note: this fixes what #399 shipped — the feature's unit tests mocked the resolver and never exercised the real key maps, which is exactly why a live pass was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
