### PR TITLE
chore(deps): @conduction/nextcloud-vue ^1.0.0-beta.221 — activate schema-label translation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,7 +50,7 @@ Vrij en open source onder de EUPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.18</version>
+    <version>0.2.19</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>SoftwareCatalog</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@codemirror/lang-json": "^6.0.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.221",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/axios": "^2.5.0",
@@ -2084,9 +2084,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "1.0.0-beta.213",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.213.tgz",
-      "integrity": "sha512-L3E7kT3AvVb8HvxRWc2nSA6aYXbuMOj9f7HiGiJQOJ9om6ImCrdreMqACB4pEbHGy49FeRnmX5aHI1qt8o1SaQ==",
+      "version": "1.0.0-beta.221",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.221.tgz",
+      "integrity": "sha512-2sNPtUYlQNrFg3yVqXHvOwOHeXiOHsjmWhHPc3WCsAq8hpJj1v/T+XeGKFBmUEi4mJ/9UtR+NrrT8Zke0FKcug==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@babel/core": "^7.29.0",
     "@codemirror/lang-json": "^6.0.0",
-    "@conduction/nextcloud-vue": "^1.0.0-beta.213",
+    "@conduction/nextcloud-vue": "^1.0.0-beta.221",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/axios": "^2.5.0",


### PR DESCRIPTION
## Summary
- Bump `@conduction/nextcloud-vue` to `^1.0.0-beta.221` (exact lock: `1.0.0-beta.221`), which carries the cnTranslate display-layer translation for schema property titles.
- Rebuild not committed — this app gitignores `/js/`; CI builds the bundle at release time. Verified locally that `npm run build` succeeds and `cnTranslate` lands in `softwarecatalog-shared-nc-vue.js`.
- Patch-bump `appinfo/info.xml` version 0.2.18 → 0.2.19 so NC's `?v=` cache-buster serves the new bundle once released.

## Test plan
- [x] `npm ci` clean install
- [x] `npm install @conduction/nextcloud-vue@1.0.0-beta.221 --save` — package-lock pinned to exact `1.0.0-beta.221`
- [x] `USE_LOCAL_LIB=false npm run build` exits 0 (only the 2 pre-existing asset-size warnings)
- [x] `grep -rl cnTranslate js/` → `softwarecatalog-shared-nc-vue.js`