### PR TITLE
i18n(schema): author schema-level titles in English + NL l10n

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -50,7 +50,7 @@ Vrij en open source onder de EUPL-licentie.
 
 **Ondersteuning:** Voor ondersteuning, neem contact op via support@conduction.nl. Voor een Service Level Agreement (SLA), neem contact op via sales@conduction.nl.
     ]]></description>
-    <version>0.2.19</version>
+    <version>0.2.20</version>
     <licence>EUPL-1.2</licence>
     <author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
     <namespace>SoftwareCatalog</namespace>

--- a/l10n/en.js
+++ b/l10n/en.js
@@ -355,7 +355,11 @@ OC.L10N.register(
     "Could not load the approval state." : "Could not load the approval state.",
     "Contract submitted to decidesk for a decision." : "Contract submitted to decidesk for a decision.",
     "Submitting the contract failed; it remains in negotiation." : "Submitting the contract failed; it remains in negotiation.",
-    "Could not refresh the outcome." : "Could not refresh the outcome."
+    "Could not refresh the outcome." : "Could not refresh the outcome.",
+    "Vulnerability" : "Vulnerability",
+    "Connection" : "Connection",
+    "Assessment" : "Assessment",
+    "SBOM component" : "SBOM component"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/en.json
+++ b/l10n/en.json
@@ -659,6 +659,10 @@
         "Manage access to {name}": "Manage access to {name}",
         "Manage members": "Manage members",
         "No members yet.": "No members yet.",
-        "Revoke access": "Revoke access"
+        "Revoke access": "Revoke access",
+        "Vulnerability": "Vulnerability",
+        "Connection": "Connection",
+        "Assessment": "Assessment",
+        "SBOM component": "SBOM component"
     }
 }

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -533,7 +533,11 @@ OC.L10N.register(
     "Current members" : "Huidige leden",
     "No members yet." : "Nog geen leden.",
     "Revoke access" : "Toegang intrekken",
-    "Close" : "Sluiten"
+    "Close" : "Sluiten",
+    "Vulnerability" : "Kwetsbaarheid",
+    "Connection" : "Koppeling",
+    "Assessment" : "Beoordeling",
+    "SBOM component" : "SBOM-component"
 },
 "nplurals=2; plural=(n != 1);"
 );

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -699,6 +699,10 @@
         "Current members": "Huidige leden",
         "No members yet.": "Nog geen leden.",
         "Revoke access": "Toegang intrekken",
-        "Close": "Sluiten"
+        "Close": "Sluiten",
+        "Vulnerability": "Kwetsbaarheid",
+        "Connection": "Koppeling",
+        "Assessment": "Beoordeling",
+        "SBOM component": "SBOM-component"
     }
 }

--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -3,8 +3,8 @@
   "info": {
     "title": "Software Catalog Register",
     "description": "Register containing AMEF and Voorzieningen schemas for the VNG Software Catalog application. This configuration includes schemas for applications, services, organizations, and compliance tracking.",
-    "version": "2.4.2",
-    "changelog": "2.4.2: Moved SBOM provenance properties (sbomLastImportedAt, sbomFormat, sbomFileName, sbomComponents) from the organisatie schema to moduleVersie, where SBOM imports actually record them; without this the moduleVersie magic table lacked the columns so recordProvenance() writes were silently dropped and the import-status endpoint always reported 'never imported'. 2.4.1: Re-authored Dutch schema property titles to English (property keys unchanged); Dutch labels now come from the app's l10n translation files."
+    "version": "2.4.3",
+    "changelog": "2.4.3: Re-authored Dutch schema-level titles to English (dienst, kwetsbaarheid, contactpersoon, organisatie, gebruik, koppeling, beoordeeling, module, bioMaatregel, moduleVersie, sbomComponent); schema keys unchanged, Dutch labels now come from the app's l10n translation files. 2.4.2: Moved SBOM provenance properties (sbomLastImportedAt, sbomFormat, sbomFileName, sbomComponents) from the organisatie schema to moduleVersie, where SBOM imports actually record them; without this the moduleVersie magic table lacked the columns so recordProvenance() writes were silently dropped and the import-status endpoint always reported 'never imported'. 2.4.1: Re-authored Dutch schema property titles to English (property keys unchanged); Dutch labels now come from the app's l10n translation files."
   },
   "x-openregister": {
     "type": "application",
@@ -1330,7 +1330,7 @@
         "uri": null,
         "slug": "dienst",
         "x-schema-org": "schema:Service",
-        "title": "Dienst",
+        "title": "Service",
         "description": "Een specifiek aanbod van een dienst op een of meerdere applicaties door een leverancier",
         "version": "0.2.1",
         "summary": "",
@@ -1639,7 +1639,7 @@
             }
           }
         },
-        "title": "Kwetsbaarheid",
+        "title": "Vulnerability",
         "description": "Schema voor kwetsbaarheden. Dit schema is onderdeel van het vastgestelde datamodel maar wordt niet daadwerkelijk in de applicatie gebruikt.",
         "version": "1.0.20",
         "summary": "",
@@ -1792,7 +1792,7 @@
         "uri": null,
         "slug": "contactpersoon",
         "x-schema-org": "schema:Person",
-        "title": "Contactpersoon",
+        "title": "Contact person",
         "description": "Contactgegevens van een persoon",
         "version": "0.0.27",
         "summary": "",
@@ -2026,7 +2026,7 @@
         "uri": null,
         "slug": "organisatie",
         "x-schema-org": "schema:Organization",
-        "title": "Organisatie",
+        "title": "Organisation",
         "description": "Een organisatie die voorzieningen aanbiedt",
         "version": "0.5.0",
         "summary": "",
@@ -2546,7 +2546,7 @@
       "gebruik": {
         "uri": null,
         "slug": "gebruik",
-        "title": "Gebruik",
+        "title": "Usage",
         "description": "Het gebruik van applicaties, diensten en koppelingen door afnemers",
         "version": "1.4.0",
         "summary": "",
@@ -3440,7 +3440,7 @@
       "koppeling": {
         "uri": null,
         "slug": "koppeling",
-        "title": "Koppeling",
+        "title": "Connection",
         "description": "Schema voor koppelingen tussen applicaties en systemen. ApplicatieB is voor koppelingen met andere applicaties. BuitengemeentelijkVoorziening is voor koppelingen met externe voorzieningen.",
         "version": "0.3.0",
         "summary": "",
@@ -3851,7 +3851,7 @@
             }
           }
         },
-        "title": "Beoordeeling",
+        "title": "Assessment",
         "description": "Schema voor beoordelingen en waarderingen van applicaties en diensten. Dit schema is onderdeel van het vastgestelde datamodel maar wordt niet daadwerkelijk in de applicatie gebruikt.",
         "version": "0.1.3",
         "summary": "",
@@ -6808,7 +6808,7 @@
             }
           }
         },
-        "title": "Applicatie",
+        "title": "Application",
         "description": "Een applicatie is een softwarecomponent (applicatie of systeemsoftware)",
         "version": "0.3.2",
         "summary": "",
@@ -7539,7 +7539,7 @@
       "bioMaatregel": {
         "uri": null,
         "slug": "bioMaatregel",
-        "title": "BIO-maatregel",
+        "title": "BIO measure",
         "description": "Een BIO 2.0 (Baseline Informatiebeveiliging Overheid) maatregel uit de gepubliceerde maatregelenlijst. Wordt gebruikt als selectiebron voor compliance-registraties (compliancy.bioMaatregel) en het BIO-dekkingsrapport.",
         "version": "0.0.1",
         "summary": "",
@@ -7693,7 +7693,7 @@
             }
           }
         },
-        "title": "Applicatieversie",
+        "title": "Application version",
         "description": "Schema voor applicatieversies",
         "version": "0.1.3",
         "summary": "",
@@ -7936,7 +7936,7 @@
       "sbomComponent": {
         "uri": null,
         "slug": "sbomComponent",
-        "title": "SBOM-component",
+        "title": "SBOM component",
         "description": "Schema voor componenten die zijn geïmporteerd uit een SBOM (Software Bill of Materials, CycloneDX of SPDX) voor een applicatieversie.",
         "version": "0.0.1",
         "summary": "",


### PR DESCRIPTION
## Summary
- Rewrites Dutch schema-level `title` fields in `lib/Settings/softwarecatalogus_register.json` to idiomatic English (schema keys, property titles, enums, descriptions untouched): dienst→Service, kwetsbaarheid→Vulnerability, contactpersoon→Contact person, organisatie→Organisation, gebruik→Usage, koppeling→Connection, beoordeeling→Assessment, module→Application, bioMaatregel→BIO measure, moduleVersie→Application version, sbomComponent→SBOM component.
- Adds missing l10n identity/translation keys (Vulnerability, Connection, Assessment, SBOM component) to en/nl `.json`+`.js`; the other 7 titles already had keys from the earlier property-title work.
- Bumps register `info.version` 2.4.2→2.4.3 and `appinfo/info.xml` 0.2.19→0.2.20.

## Test plan
- [x] `git diff` of the register shows only schema-level `title` values + version/changelog line changed
- [x] Scripted check: property-key set per schema identical to merge-base
- [x] `python3 -m json.tool` valid for register + en/nl `.json`
- [x] `node -c` valid for en/nl `.js`
- [x] No files under `Softwarecatalogus/` touched