### PR TITLE
feat(icons): adopt the ADR-077 semantic icon vocabulary

### DIFF
--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -2550,7 +2550,7 @@
         "description": "Het gebruik van applicaties, diensten en koppelingen door afnemers",
         "version": "1.4.0",
         "summary": "",
-        "icon": "Usage",
+        "icon": "Gauge",
         "x-openregister-notifications": {
           "phaseout-approaching": {
             "trigger": {"type": "scheduled", "intervalSec": 86400, "filter": {"startDatumUitTeFaseren": {"operator": "withinNext", "value": "P180D"}}},
@@ -6148,7 +6148,7 @@
         "description": "AMEF Property Definition - Definitie van eigenschappen voor ArchiMate elementen",
         "version": "0.0.8",
         "summary": "",
-        "icon": "Settings",
+        "icon": "CogOutline",
         "required": [
           "identifier",
           "type"

--- a/src/icons.js
+++ b/src/icons.js
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Icon registry for softwarecatalog (ADR-077 semantic icon vocabulary).
+//
+// CnAppNav, CnIcon, CnIndexPage / CnDetailPage headers and empty states resolve
+// an `icon` by PascalCase name through the registry that `registerIcons()`
+// populates. A name that is not registered renders NO icon in the navigation —
+// not a fallback glyph — so this file must cover every `icon` the manifests and
+// register files name. Keep it in sync when you add a menu entry.
+//
+// Generated from the app's own manifests; every name is verified to exist in
+// vue-material-design-icons.
+
+import AccountBoxOutline from 'vue-material-design-icons/AccountBoxOutline.vue'
+import AccountGroup from 'vue-material-design-icons/AccountGroup.vue'
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import AlertCircle from 'vue-material-design-icons/AlertCircle.vue'
+import ApplicationOutline from 'vue-material-design-icons/ApplicationOutline.vue'
+import ArrowRight from 'vue-material-design-icons/ArrowRight.vue'
+import BookOpenVariantOutline from 'vue-material-design-icons/BookOpenVariantOutline.vue'
+import BriefcaseOutline from 'vue-material-design-icons/BriefcaseOutline.vue'
+import ChartBar from 'vue-material-design-icons/ChartBar.vue'
+import ChartBoxOutline from 'vue-material-design-icons/ChartBoxOutline.vue'
+import ChartLine from 'vue-material-design-icons/ChartLine.vue'
+import CheckCircle from 'vue-material-design-icons/CheckCircle.vue'
+import ClipboardCheckOutline from 'vue-material-design-icons/ClipboardCheckOutline.vue'
+import CogOutline from 'vue-material-design-icons/CogOutline.vue'
+import CommentOutline from 'vue-material-design-icons/CommentOutline.vue'
+import Cube from 'vue-material-design-icons/Cube.vue'
+import CurrencyEur from 'vue-material-design-icons/CurrencyEur.vue'
+import Database from 'vue-material-design-icons/Database.vue'
+import Domain from 'vue-material-design-icons/Domain.vue'
+import Eye from 'vue-material-design-icons/Eye.vue'
+import FileDocumentEdit from 'vue-material-design-icons/FileDocumentEdit.vue'
+import FileSign from 'vue-material-design-icons/FileSign.vue'
+import FolderOutline from 'vue-material-design-icons/FolderOutline.vue'
+import Gauge from 'vue-material-design-icons/Gauge.vue'
+import Gavel from 'vue-material-design-icons/Gavel.vue'
+import Handshake from 'vue-material-design-icons/Handshake.vue'
+import HandshakeOutline from 'vue-material-design-icons/HandshakeOutline.vue'
+import History from 'vue-material-design-icons/History.vue'
+import Link from 'vue-material-design-icons/Link.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import MapMarkerPath from 'vue-material-design-icons/MapMarkerPath.vue'
+import MapOutline from 'vue-material-design-icons/MapOutline.vue'
+import NoteTextOutline from 'vue-material-design-icons/NoteTextOutline.vue'
+import OfficeBuilding from 'vue-material-design-icons/OfficeBuilding.vue'
+import OfficeBuildingOutline from 'vue-material-design-icons/OfficeBuildingOutline.vue'
+import Package from 'vue-material-design-icons/Package.vue'
+import PackageVariant from 'vue-material-design-icons/PackageVariant.vue'
+import PackageVariantClosed from 'vue-material-design-icons/PackageVariantClosed.vue'
+import PuzzleOutline from 'vue-material-design-icons/PuzzleOutline.vue'
+import ShieldAlert from 'vue-material-design-icons/ShieldAlert.vue'
+import ShieldAlertOutline from 'vue-material-design-icons/ShieldAlertOutline.vue'
+import ShieldCheckOutline from 'vue-material-design-icons/ShieldCheckOutline.vue'
+import ShieldLockOutline from 'vue-material-design-icons/ShieldLockOutline.vue'
+import ShieldOutline from 'vue-material-design-icons/ShieldOutline.vue'
+import Star from 'vue-material-design-icons/Star.vue'
+import ViewDashboardOutline from 'vue-material-design-icons/ViewDashboardOutline.vue'
+import ViewGridOutline from 'vue-material-design-icons/ViewGridOutline.vue'
+import ViewModule from 'vue-material-design-icons/ViewModule.vue'
+
+export default {
+	AccountBoxOutline,
+	AccountGroup,
+	AccountMultiple,
+	AlertCircle,
+	ApplicationOutline,
+	ArrowRight,
+	BookOpenVariantOutline,
+	BriefcaseOutline,
+	ChartBar,
+	ChartBoxOutline,
+	ChartLine,
+	CheckCircle,
+	ClipboardCheckOutline,
+	CogOutline,
+	CommentOutline,
+	Cube,
+	CurrencyEur,
+	Database,
+	Domain,
+	Eye,
+	FileDocumentEdit,
+	FileSign,
+	FolderOutline,
+	Gauge,
+	Gavel,
+	Handshake,
+	HandshakeOutline,
+	History,
+	Link,
+	LinkVariant,
+	MapMarkerPath,
+	MapOutline,
+	NoteTextOutline,
+	OfficeBuilding,
+	OfficeBuildingOutline,
+	Package,
+	PackageVariant,
+	PackageVariantClosed,
+	PuzzleOutline,
+	ShieldAlert,
+	ShieldAlertOutline,
+	ShieldCheckOutline,
+	ShieldLockOutline,
+	ShieldOutline,
+	Star,
+	ViewDashboardOutline,
+	ViewGridOutline,
+	ViewModule,
+}

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ import bundledManifest from './manifest.json'
 import menuLayout from './menu-layout.json'
 import customComponents from './customComponents.js'
 import registry from './registry.js'
+import appIcons from './icons.js'
 import { routesFromManifest } from './router.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
@@ -45,7 +46,7 @@ Vue.use(PiniaVuePlugin)
 Vue.use(VueRouter)
 
 // Register library-side icon set + lib translations once at bootstrap.
-registerIcons()
+registerIcons(appIcons)
 try {
 	registerTranslations()
 } catch (e) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,125 +27,125 @@
 		{
 			"id": "Dashboard",
 			"label": "Dashboard",
-			"icon": "icon-category-dashboard",
+			"icon": "ViewDashboardOutline",
 			"route": "Dashboard",
 			"order": 10
 		},
 		{
 			"id": "Organisaties",
 			"label": "Organisations",
-			"icon": "icon-category-organization",
+			"icon": "OfficeBuildingOutline",
 			"route": "Organisaties",
 			"order": 20
 		},
 		{
 			"id": "Modules",
 			"label": "Applications",
-			"icon": "icon-category-app-bundles",
+			"icon": "ApplicationOutline",
 			"route": "Modules",
 			"order": 25
 		},
 		{
 			"id": "Suites",
 			"label": "Suites",
-			"icon": "icon-category-app-bundles",
+			"icon": "ViewGridOutline",
 			"route": "Suites",
 			"order": 27
 		},
 		{
 			"id": "Diensten",
 			"label": "Services",
-			"icon": "icon-category-organization",
+			"icon": "Domain",
 			"route": "Diensten",
 			"order": 30
 		},
 		{
 			"id": "Contracten",
 			"label": "Contracts",
-			"icon": "icon-file",
+			"icon": "FileSign",
 			"route": "Contracten",
 			"order": 40
 		},
 		{
 			"id": "Standaarden",
 			"label": "Standards",
-			"icon": "icon-checkmark",
+			"icon": "ClipboardCheckOutline",
 			"route": "Standaarden",
 			"order": 50
 		},
 		{
 			"id": "BioMaatregelen",
 			"label": "BIO measures",
-			"icon": "icon-category-security",
+			"icon": "ShieldOutline",
 			"route": "BioMaatregelen",
 			"order": 55
 		},
 		{
 			"id": "Reviews",
 			"label": "Reviews",
-			"icon": "icon-comment",
+			"icon": "CommentOutline",
 			"route": "Reviews",
 			"order": 60
 		},
 		{
 			"id": "Komplianties",
 			"label": "Compliance",
-			"icon": "icon-checkmark",
+			"icon": "ClipboardCheckOutline",
 			"route": "Komplianties",
 			"order": 70
 		},
 		{
 			"id": "ComplianceMatrix",
 			"label": "Compliance matrix",
-			"icon": "icon-category-monitoring",
+			"icon": "ClipboardCheckOutline",
 			"route": "ComplianceMatrix",
 			"order": 75
 		},
 		{
 			"id": "ReportsCompliance",
 			"label": "Reports & Compliance",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartBoxOutline",
 			"order": 78
 		},
 		{
 			"id": "Moduleversies",
 			"label": "Module versions",
-			"icon": "icon-files",
+			"icon": "PuzzleOutline",
 			"route": "Moduleversies",
 			"order": 80
 		},
 		{
 			"id": "Kwetsbaarheden",
 			"label": "Vulnerabilities",
-			"icon": "icon-category-security",
+			"icon": "ShieldAlertOutline",
 			"route": "Kwetsbaarheden",
 			"order": 82
 		},
 		{
 			"id": "LifecycleRoadmap",
 			"label": "Portfolio roadmap",
-			"icon": "icon-category-organization",
+			"icon": "MapOutline",
 			"route": "LifecycleRoadmap",
 			"order": 85
 		},
 		{
 			"id": "LicensePosture",
 			"label": "License posture",
-			"icon": "icon-category-monitoring",
+			"icon": "ChartLine",
 			"route": "LicensePosture",
 			"order": 86
 		},
 		{
 			"id": "PortfolioReport",
 			"label": "Portfolio rationalization",
-			"icon": "icon-category-monitoring",
+			"icon": "BriefcaseOutline",
 			"route": "PortfolioReport",
 			"order": 87
 		},
 		{
 			"id": "Documentation",
 			"label": "Documentation",
-			"icon": "icon-info",
+			"icon": "BookOpenVariantOutline",
 			"href": "https://softwarecatalog.conduction.nl",
 			"section": "footer",
 			"order": 90
@@ -153,7 +153,7 @@
 		{
 			"id": "FeaturesRoadmapMenu",
 			"label": "Features & roadmap",
-			"icon": "icon-toggle",
+			"icon": "MapMarkerPath",
 			"route": "FeaturesRoadmap",
 			"section": "footer",
 			"order": 95
@@ -161,7 +161,7 @@
 		{
 			"id": "SettingsMenu",
 			"label": "Settings",
-			"icon": "icon-settings",
+			"icon": "CogOutline",
 			"route": "Settings",
 			"section": "settings",
 			"order": 99


### PR DESCRIPTION
## Why

Menu icons across the fleet had drifted into meaninglessness. A scan of all 21 manifest-shipping apps (366 menu entries) found **120 distinct icons for 262 distinct labels**:

| Icon | distinct concepts it stood for |
|---|---|
| `icon-category-monitoring` | 18 |
| `icon-comment` | 17 |
| `icon-category-organization` | 15 (incl. **Store**, Cases, Contracts, Pipeline) |

…and the same concept drawn differently per app — **Store** was `icon-category-integration` in hermiq and `icon-category-organization` in openbuild; Dashboard had three glyphs, Documentation three.

## What

Moves this app onto the shared vocabulary defined in **ADR-077**: MDI PascalCase names, one concept to one icon. Tier A entries (Dashboard, Documentation, Settings, Store, Features & roadmap) now match every other Conduction app — which is the point: a glyph should mean the same thing wherever a user meets it.

Two defect classes fixed along the way:

- **Icon names that do not exist in `vue-material-design-icons` at all** (`LedgerOutline`, `FileSignOutline`, `GavelOutline`, `BankTransferOutline`, …). They could never resolve — a help-circle at best, nothing in the navigation.
- **Menu entries that rendered with NO icon.** `CnAppNav` resolves an MDI name only through the registry `registerIcons()` populates, with no fallback and no CSS class for non-`icon-*` values. Apps that relied on legacy `icon-*` registered nothing at all and were fine right up until the first MDI name appeared. Live-verified on hrmq before this change: **29 of 72 nav entries rendered blank**.

`src/icons.js` is generated from this app’s own manifests and register files, so every referenced name is registered and the migration **stands on its own against the currently released `@conduction/nextcloud-vue`** — it does not wait on the library-side vocabulary (ConductionNL/nextcloud-vue#563).

## Verification

- **0** menu entries render without an icon (was 51 fleet-wide).
- Every icon import resolves against this app’s own `node_modules` (1,247 checked fleet-wide, 0 unresolvable).
- hydra **gate-60 `icon-vocabulary`** passes: 0 failures, 0 warnings.
- ESLint clean on every changed file.

Spec: ADR-077 — ConductionNL/hydra#408.