### PR TITLE
feat(icons): extend ADR-077 to page, widget and action icons

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -292,7 +292,7 @@
 				"_note": "bio-compliance-assessment: catalog archetype (an offered application). Body: application data 8-wide top-left (naam, descriptions, website, contactpersoon, hosting/licence fields, then the new BBN level and DPIA status/dates/document-reference/verwerkingsregister fields) with a Documentation files panel 4-wide top-right. Below, a Related panel surfaces the vendor (aanbieder) and linked services/couplings, then two object-lists: compliance claims (compliancy records — both GEMMA standards and, since this change, BIO measures — filtered by module=@objectId) and application versions (moduleVersie filtered by module=@objectId). An application does not communicate, so per the comms hard-rule NO Emails/Meetings widgets appear. Audit trail stays a sidebar tab.",
 				"widgets": [
 					{ "id": "md-data", "type": "data", "title": "Application", "icon": "Package", "content": { "columns": 2, "include": [ "naam", "beschrijvingKort", "beschrijvingLang", "website", "aanbieder", "contactpersoon", "cloudDienstverleningsmodel", "hostingJurisdictie", "hostingLocatie", "licentietype", "licentie", "bbnLevel", "dpiaStatus", "dpiaDate", "dpiaVolgendeBeoordeling", "dpiaDocumentRef", "verwerkingsregisterRef" ] } },
-					{ "id": "md-files", "type": "integration", "integrationId": "files", "title": "Documentation", "icon": "FolderOutline" },
+					{ "id": "md-files", "type": "integration", "integrationId": "files", "title": "Documentation", "icon": "BookOpenVariantOutline" },
 					{ "id": "md-related", "type": "related", "title": "Vendor & services", "icon": "LinkVariant" },
 					{ "id": "md-compliance", "type": "object-list", "title": "Compliance claims", "icon": "ClipboardCheckOutline", "content": { "register": "@resolve:voorzieningen_register", "schema": "compliancy", "filter": { "module": "@objectId" }, "columns": [ { "key": "standaardversie", "label": "Standard" }, { "key": "bioMaatregel", "label": "BIO measure" }, { "key": "url", "label": "Evidence" } ], "limit": 50, "rowRoute": "KompliantieDetail", "allowCreate": false, "emptyText": "No compliance claims yet" } },
 					{ "id": "md-versions", "type": "object-list", "title": "Application versions", "icon": "ViewModule", "content": { "register": "@resolve:voorzieningen_register", "schema": "moduleVersie", "filter": { "module": "@objectId" }, "columns": [ { "key": "versie", "label": "Version" }, { "key": "status", "label": "Status" } ], "limit": 25, "rowRoute": "ModuleversieDetail", "allowCreate": false, "emptyText": "No versions registered yet" } }
@@ -788,8 +788,8 @@
 					"enabled": true,
 					"showMetadata": true,
 					"tabs": [
-						{ "id": "exposure", "label": "Exposure", "icon": "icon-category-security", "component": "VulnerabilityExposurePanel" },
-						{ "id": "audit", "label": "Audit trail", "icon": "icon-history", "widgets": [ { "type": "audit" } ] }
+						{ "id": "exposure", "label": "Exposure", "icon": "ShieldOutline", "component": "VulnerabilityExposurePanel" },
+						{ "id": "audit", "label": "Audit trail", "icon": "History", "widgets": [ { "type": "audit" } ] }
 					]
 				},
 				"documentationUrl": "https://softwarecatalog.conduction.nl"


### PR DESCRIPTION
## Why

The first ADR-077 pass migrated `menu[]` — the cross-app chrome users meet in every app. Everything else kept its legacy `icon-*` classes: page and tab icons, widget headers, and the `actions[]` / `headerActions[]` entries.

Those render through the same CnIcon registry and carry the same hazard: a legacy name with no `CSS_ICON_TO_MDI` bridge entry falls through to the raw Nextcloud class, and on NC34+ light themes several of those ship a baked white `background-image` — **an invisible glyph, wherever it appears**, not just in the nav.

## What

Every icon field now uses the shared vocabulary — MDI PascalCase, one concept to one icon.

Action icons name a **verb** rather than a domain noun, so the vocabulary gained an actions family (view / create / edit / delete / run / test / publish / upload / download / refresh / …). Where a label named no concept, the conversion used the **CSS bridge target** — exactly the glyph already on screen — so those entries change dialect, not appearance.

`src/icons.js` is regenerated so every name the manifests reference is registered.

## Verification

- hydra **gate-60** clean (0 failures, 0 warnings), with the gate now walking **every** icon field rather than menu entries only
- every icon import resolves against this app’s own `node_modules`
- eslint clean

Spec: ADR-077 — ConductionNL/hydra#416.