### PR TITLE
fix(ci): make composer check:strict able to fail on tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"psalm": "if [ -f vendor/bin/psalm ]; then ./vendor/bin/psalm --threads=1 --no-cache; else echo 'Psalm not installed, skipping...'; fi",
 		"phpstan": "if [ -f vendor/bin/phpstan ]; then ./vendor/bin/phpstan analyse --memory-limit=1G; else echo 'PHPStan not installed, skipping...'; fi",
 		"test:unit": "phpunit tests -c tests/phpunit.xml --colors=always --fail-on-warning --fail-on-risky",
-		"test:all": "./vendor/bin/phpunit --colors=always || echo 'Tests require Nextcloud environment, skipping...'",
+		"test:all": "if [ ! -f vendor/bin/phpunit ]; then echo 'SKIPPED: phpunit not installed - run composer install'; elif [ ! -f ../../lib/base.php ]; then echo 'SKIPPED: tests/bootstrap.php requires a Nextcloud server tree (../../lib/base.php not found) - run from inside a Nextcloud checkout or in CI'; else ./vendor/bin/phpunit --colors=always; fi",
 		"check": "E=0; for CMD in lint phpcs psalm test:unit; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"check:full": "E=0; for CMD in lint phpcs psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",
 		"check:strict": "E=0; for CMD in lint phpcs phpmd psalm phpstan test:all; do echo; echo \"=== $CMD ===\"; composer $CMD || E=1; done; echo; if [ $E -eq 0 ]; then echo \"ALL CHECKS PASSED\"; else echo \"SOME CHECKS FAILED (see above)\"; fi; exit $E",


### PR DESCRIPTION
## Problem

`test:unit` and `test:all` ended in:

```
./vendor/bin/phpunit --colors=always || echo 'Tests require Nextcloud environment, skipping...'
```

phpunit's exit status was discarded **unconditionally**, so `composer check:strict` could never fail on a test failure.

Unlike most repos in the fleet, **the excuse in that message is actually true here**: `tests/bootstrap.php` calls `\OC_App::loadApps()`, so the suite genuinely needs a Nextcloud server tree above the app. Running `composer test:all` in a bare checkout dies with `Class "OC_App" not found`.

But the mask was never *conditional* on that. Inside CI — where the Nextcloud tree **is** present (`enable-phpunit: true`, `nextcloud-test-refs` in `code-quality.yml`) — a genuine test failure looked exactly like "no Nextcloud here" and vanished.

## Change

`composer.json` only. Replace the blanket mask with the **actual precondition**, so a skip is a stated, checkable fact and phpunit's exit status propagates whenever the suite can really run:

```
if [ ! -f vendor/bin/phpunit ]; then echo 'SKIPPED: phpunit not installed - run composer install';
elif [ ! -f ../../lib/base.php ]; then echo 'SKIPPED: tests/bootstrap.php requires a Nextcloud server tree (../../lib/base.php not found) - run from inside a Nextcloud checkout or in CI';
else ./vendor/bin/phpunit --colors=always; fi
```

Note this deliberately does **not** use the plain `if [ -f vendor/bin/phpunit ]` guard used elsewhere in the fleet: in this repo that guard would turn an honest-if-crude skip into a permanent **false red** every time anyone runs `check:strict` outside a Nextcloud tree, which is the fastest way to get a gate ignored again.

## Positive control — measured on this tree

PHP 8.3.32 container, app mounted at `/nc/apps-extra/softwarecatalog` so that `../../lib/base.php` is under my control:

| state | result |
|---|---|
| no server tree, no injected test | loud `SKIPPED: tests/bootstrap.php requires a Nextcloud server tree`; `test:all` **not** named |
| server tree present + one deliberately failing test in `tests/Unit/` | phpunit runs the suite; `check:strict` fails **naming `test:all`** |
| **old** `composer.json`, same failure | `test:all` never named — swallowed by `\|\| echo` |

(The "server tree" in the middle row is a minimal stand-in defining `OC_App`/`OC_Hook`, enough to get past `tests/bootstrap.php`. It proves the guard's mechanism; real test outcomes still need a real Nextcloud, which CI provides. The control test and the stand-in are **not** part of this PR — the diff is `composer.json` only.)

## Policy / state after this PR

**Tooling only — no findings are fixed here.** `check:strict` is red on this branch for **pre-existing reasons unrelated to this change**:

- `phpmd` — 78 violations
- `psalm` — 16 errors
- `phpstan` — `Found 16 errors`
- `lint`, `phpcs` — pass
- `test:all` — skips loudly (no Nextcloud tree in the measurement environment)
