### PR TITLE
ci: bound all 16 unbounded workflow jobs on main with timeout-minutes

### DIFF
--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout Code

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,6 +12,11 @@ jobs:
   php-checks:
     name: ${{ matrix.check.name }}
     runs-on: ubuntu-latest
+    # One job-level bound covers every matrix leg, so it must clear the
+    # SLOWEST leg. Lint/PHPCS/PHPMD/Psalm/PHPStan run ~4 min, but the PHPUnit
+    # leg has been observed at 18.9 min while SUCCEEDING — a 20 bound would
+    # leave ~6% headroom and turn a slow-but-healthy run into a red check.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +54,8 @@ jobs:
   frontend-quality:
     name: Frontend Quality
     runs-on: ubuntu-latest
+    # Observed max 5.3 min across 49 fleet runs; 20 leaves ample headroom.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ jobs:
   deploy:
     name: Deploy Documentation
     runs-on: ubuntu-latest
+    # Observed max 2.5 min across 23 fleet runs; 20 leaves ample headroom.
+    timeout-minutes: 20
     if: github.event_name == 'push'
     permissions:
       contents: write

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    # Observed max 0.1 min across 123 fleet runs; 10 leaves ample headroom.
+    timeout-minutes: 10
     steps:
       - name: Check branch
         run: |

--- a/.github/workflows/pull-request-from-branch-check.yaml
+++ b/.github/workflows/pull-request-from-branch-check.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   check-branch:
     runs-on: ubuntu-latest
+    # Observed max 0.1 min across 123 fleet runs; 10 leaves ample headroom.
+    timeout-minutes: 10
     steps:
       - name: Check branch
         run: |

--- a/.github/workflows/pull-request-lint-check.yaml
+++ b/.github/workflows/pull-request-lint-check.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint-check:
     runs-on: ubuntu-latest
+    # Observed max 1.4 min across 176 fleet runs; 15 leaves ample headroom.
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/push-development-to-beta.yaml
+++ b/.github/workflows/push-development-to-beta.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   create-pr:
     runs-on: ubuntu-latest
+    # Observed max 5.6 min across 152 fleet runs; 20 leaves ample headroom.
+    timeout-minutes: 20
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/release-beta.yaml
+++ b/.github/workflows/release-beta.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -14,6 +14,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -149,6 +152,8 @@ jobs:
 
   update-changelog:
     runs-on: ubuntu-latest
+    # Observed ~0.2 min; 15 leaves ample headroom.
+    timeout-minutes: 15
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/release-unstable.yaml
+++ b/.github/workflows/release-unstable.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
     
       - name: Checkout Code

--- a/.github/workflows/sync-beta.yaml
+++ b/.github/workflows/sync-beta.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   sync-to-beta-release:
     runs-on: ubuntu-latest
+    # Branch-sync job; fleet sync jobs run well under a minute. 20 is generous.
+    timeout-minutes: 20
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/sync-dev.yaml
+++ b/.github/workflows/sync-dev.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   sync-to-development-release:
     runs-on: ubuntu-latest
+    # Branch-sync job; fleet sync jobs run well under a minute. 20 is generous.
+    timeout-minutes: 20
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/unstable-release.yaml
+++ b/.github/workflows/unstable-release.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-management:
     runs-on: ubuntu-latest
+    # Observed max 0.7 min across 26 fleet runs; 45 matches the shared release
+    # jobs — a spurious release failure is expensive, so keep this loose.
+    timeout-minutes: 45
     steps:
 
       - name: Checkout Code


### PR DESCRIPTION
## What

Adds `timeout-minutes` to all **16** jobs on the `main` branch. Every one of them was unbounded, so a hang burned a runner for GitHub's 6-hour default.

## Why `main` specifically

`development` now calls the shared reusable workflows in `ConductionNL/.github`, which are bounded at source. `main` still carries the older inline layout, and those files are live:

- `release-workflow.yaml` has recent runs on `main`.
- The PR-triggered jobs (`php-checks` matrix, `frontend-quality`, `lint-check`, and both `check-branch` duplicates) fire on **every PR into `main`** — i.e. on every release.

## Bounds

| file | job | timeout |
|---|---|---|
| `pull-request-lint-check.yaml` | `lint-check` | 15 |
| `pull-request-from-branch-check.yaml` | `check-branch` | 10 |
| `pr-check.yaml` | `check-branch` | 10 |
| `push-development-to-beta.yaml` | `create-pr` | 20 |
| `code-quality.yml` | `php-checks` | 30 |
| `code-quality.yml` | `frontend-quality` | 20 |
| `documentation.yml` | `deploy` | 20 |
| `sync-beta.yaml` | `sync-to-beta-release` | 20 |
| `sync-dev.yaml` | `sync-to-development-release` | 20 |
| `release-stable.yaml` | `update-changelog` | 15 |
| `release-stable.yaml` | `release-management` | 45 |
| `beta-release.yaml` | `release-management` | 45 |
| `unstable-release.yaml` | `release-management` | 45 |
| `release-workflow.yaml` | `release-management` | 45 |
| `release-beta.yaml` | `release-management` | 45 |
| `release-unstable.yaml` | `release-management` | 45 |

Derived from measured fleet-wide durations (successful + failed executions, skipped excluded) and deliberately loose — **a timeout that fires under normal contention is worse than no timeout**, because it converts a slow run into a phantom defect.

### One deviation from the rollout table: `php-checks` is 30, not 20

A single job-level bound covers all six matrix legs, so it must clear the *slowest* leg. Lint/PHPCS/PHPMD/Psalm/PHPStan run ~4 min, but the **PHPUnit leg has been observed at 18.9 min while succeeding**. A 20 bound would leave ~6% headroom over a known-good run.

## Notes

- **No job here is a `uses:` reusable-workflow caller**, so `timeout-minutes` is valid on all 16 (a `uses:` job that carries it makes the whole file `startup_failure`). Nothing was skipped.
- `l10n.yml` **does not exist on `main`** — it is a `development`-only file. The `main` job count is therefore 16 without it.
- `pr-check.yaml` and `pull-request-from-branch-check.yaml` are byte-identical duplicate Branch Protection workflows; both were bounded. Deduplicating them is out of scope here.

## Verification

- Every touched file re-parsed with `yaml.safe_load`; job set asserted unchanged vs `origin/main` and each job asserted to carry its exact expected value — 16/16.
- **Negative control**: the same probe run against the unedited `origin/main` blobs reports `None` for all 16, so the probe genuinely distinguishes bounded from unbounded.
- Diff is **additions-only** (41 insertions, 0 deletions) and touches `.github/workflows/` only. No step, trigger, or job was modified.