### PR TITLE
fix(quality): clear the psalm/phpstan quality backlog and 54 phpmd findings

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -44,6 +44,8 @@ use OCA\SoftwareCatalog\Service\ArchiMateService;
 use OCA\SoftwareCatalog\Service\ContactpersoonService;
 use OCA\SoftwareCatalog\Service\FacetService;
 use OCA\SoftwareCatalog\Service\GebruikSyncService;
+use OCA\SoftwareCatalog\Service\IntakeService;
+use OCA\SoftwareCatalog\Service\ModerationService;
 use OCA\SoftwareCatalog\Service\ModuleComplianceService;
 use OCA\SoftwareCatalog\Service\ModuleRegistrationService;
 use OCA\SoftwareCatalog\Service\MergeOrganisatieService;
@@ -51,6 +53,9 @@ use OCA\SoftwareCatalog\Service\ModuleVersionService;
 use OCA\SoftwareCatalog\Service\OrganisatieService;
 use OCA\SoftwareCatalog\Service\OrganizationSyncService;
 use OCA\SoftwareCatalog\Service\ProgressTracker;
+use OCA\SoftwareCatalog\Service\PublicationService;
+use OCA\SoftwareCatalog\Service\ReviewAggregateService;
+use OCA\SoftwareCatalog\Service\ReviewService;
 use OCA\SoftwareCatalog\Service\SbomImportService;
 use OCA\SoftwareCatalog\Service\SbomParserService;
 use OCA\SoftwareCatalog\Service\SettingsService;
@@ -394,9 +399,9 @@ class Application extends App implements IBootstrap
         // Register open-data publication service (sets/clears publicatiedatum — the
         // live OR RBAC publish gate; no @self.published, no app-local flag).
         $context->registerService(
-                \OCA\SoftwareCatalog\Service\PublicationService::class,
+                PublicationService::class,
                 function ($container) {
-                    return new \OCA\SoftwareCatalog\Service\PublicationService(
+                    return new PublicationService(
                     container: $container,
                     settingsService: $container->get(SettingsService::class),
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -407,9 +412,9 @@ class Application extends App implements IBootstrap
         // Register the anonymous-registration intake service (queues submissions
         // as registratiestatus=pending, no publicatiedatum — invisible until approved).
         $context->registerService(
-                \OCA\SoftwareCatalog\Service\IntakeService::class,
+                IntakeService::class,
                 function ($container) {
-                    return new \OCA\SoftwareCatalog\Service\IntakeService(
+                    return new IntakeService(
                     container: $container,
                     settingsService: $container->get(SettingsService::class),
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -420,9 +425,9 @@ class Application extends App implements IBootstrap
         // Register the registration/review moderation/approval-queue service
         // (generalised to also moderate beoordeeling — softwarecatalog#375).
         $context->registerService(
-                \OCA\SoftwareCatalog\Service\ModerationService::class,
+                ModerationService::class,
                 function ($container) {
-                    return new \OCA\SoftwareCatalog\Service\ModerationService(
+                    return new ModerationService(
                     container: $container,
                     settingsService: $container->get(SettingsService::class),
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -434,9 +439,9 @@ class Application extends App implements IBootstrap
         // softwarecatalog#375). Author identity comes from IUserSession, never
         // from client input.
         $context->registerService(
-                \OCA\SoftwareCatalog\Service\ReviewService::class,
+                ReviewService::class,
                 function ($container) {
-                    return new \OCA\SoftwareCatalog\Service\ReviewService(
+                    return new ReviewService(
                     container: $container,
                     settingsService: $container->get(SettingsService::class),
                     userSession: $container->get(\OCP\IUserSession::class),
@@ -449,9 +454,9 @@ class Application extends App implements IBootstrap
         // (catalog-ratings, softwarecatalog#375) — split from ReviewService
         // to keep each class under the complexity budget.
         $context->registerService(
-                \OCA\SoftwareCatalog\Service\ReviewAggregateService::class,
+                ReviewAggregateService::class,
                 function ($container) {
-                    return new \OCA\SoftwareCatalog\Service\ReviewAggregateService(
+                    return new ReviewAggregateService(
                     container: $container,
                     settingsService: $container->get(SettingsService::class),
                     logger: $container->get('Psr\Log\LoggerInterface')
@@ -474,7 +479,7 @@ class Application extends App implements IBootstrap
         // Register the pure SBOM parser (no OR/HTTP dependency — ADR-008).
         $context->registerService(
                 SbomParserService::class,
-                function ($container) {
+                function () {
                     return new SbomParserService();
                 }
                 );
@@ -646,7 +651,7 @@ class Application extends App implements IBootstrap
                 );
         $context->registerService(
                 FederationMerger::class,
-                function ($container) {
+                function () {
                     return new FederationMerger();
                 }
                 );
@@ -680,7 +685,7 @@ class Application extends App implements IBootstrap
         // by design (design.md "Nextcloud Integration" — pure matching logic).
         $context->registerService(
                 EolMatcherService::class,
-                function ($container) {
+                function () {
                     return new EolMatcherService();
                 }
                 );

--- a/lib/BackgroundJob/OrganizationContactSyncJob.php
+++ b/lib/BackgroundJob/OrganizationContactSyncJob.php
@@ -164,7 +164,7 @@ class OrganizationContactSyncJob extends TimedJob
 
         foreach (['contactpersoon', 'organisatie'] as $objectType) {
             $schemaId = $this->settingsService->getSchemaIdForObjectType($objectType);
-            if ($schemaId === null || $schemaId === false) {
+            if ($schemaId === null) {
                 continue;
             }
 
@@ -225,10 +225,10 @@ class OrganizationContactSyncJob extends TimedJob
             }
 
             $data['contactsUid'] = $resolved;
+
+            $uuidArg = null;
             if ($uuid !== '') {
                 $uuidArg = $uuid;
-            } else {
-                $uuidArg = null;
             }
 
             $objectService->saveObject($data, [], $registerId, $schemaId, $uuidArg, false, false);

--- a/lib/Controller/SbomController.php
+++ b/lib/Controller/SbomController.php
@@ -219,8 +219,13 @@ class SbomController extends Controller
 
         // JSON-only gate BEFORE the parser is invoked (semantic bomFormat/
         // specVersion validation happens inside SbomParserService).
-        json_decode($contents);
-        if (json_last_error() !== JSON_ERROR_NONE) {
+        // json_validate() (PHP 8.3+) replaces the older
+        // `json_decode($contents); json_last_error()` side-effect idiom: it
+        // populates the same global error state — so json_last_error_msg()
+        // below is unchanged — without materialising a decoded value that is
+        // immediately discarded, and without the peak-memory cost of decoding
+        // an SBOM that is about to be re-parsed by SbomParserService anyway.
+        if (json_validate($contents) === false) {
             return new JSONResponse(
                 data: [
                     'message' => 'Uploaded file is not valid JSON: '.json_last_error_msg(),

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -179,7 +179,7 @@ class SettingsController extends Controller
     }//end getRedactedParams()
 
     /**
-     * Builds the canonical "config endpoint failed" JSONResponse.
+     * Build the 500 response for a failed config READ.
      *
      * Centralises the error-log emission + the
      * `{success: false, message: "Failed to <op>: <exception>"}` shape that
@@ -187,10 +187,53 @@ class SettingsController extends Controller
      * `updateGeneralConfig()`, `getSyncConfig()`, `updateSyncConfig()`, and
      * `getGeneralConfig()` as part of task 3.X.
      *
-     * @param string     $operationLabel "update sync config" / "get general config" / …
+     * A read failure logs no request params — the read endpoints take none.
+     *
+     * @param string     $operationLabel "get sync config" / "get general config" / …
      * @param \Exception $exception      The caught exception.
-     * @param bool       $includeParams  Attach the redacted request params to the
-     *                                   log payload (the "update" endpoints want this).
+     *
+     * @return JSONResponse
+     *
+     * @spec openspec/changes/method-decomposition/tasks.md#task-3
+     */
+    private function buildConfigReadErrorResponse(string $operationLabel, \Exception $exception): JSONResponse
+    {
+        return $this->buildConfigErrorResponse(
+            operationLabel: $operationLabel,
+            exception: $exception,
+            context: ['exception' => $exception->getMessage()]
+        );
+    }//end buildConfigReadErrorResponse()
+
+    /**
+     * Build the 500 response for a failed config WRITE, attaching the redacted
+     * request params to the log payload so a rejected update can be diagnosed.
+     *
+     * @param string     $operationLabel "update sync config" / "update general config" / …
+     * @param \Exception $exception      The caught exception.
+     *
+     * @return JSONResponse
+     *
+     * @spec openspec/changes/method-decomposition/tasks.md#task-3
+     */
+    private function buildConfigWriteErrorResponse(string $operationLabel, \Exception $exception): JSONResponse
+    {
+        return $this->buildConfigErrorResponse(
+            operationLabel: $operationLabel,
+            exception: $exception,
+            context: [
+                'exception'   => $exception->getMessage(),
+                'requestData' => $this->getRedactedParams(),
+            ]
+        );
+    }//end buildConfigWriteErrorResponse()
+
+    /**
+     * Log the failure and build the shared 500 config-error response body.
+     *
+     * @param string               $operationLabel "update sync config" / "get general config" / …
+     * @param \Exception           $exception      The caught exception.
+     * @param array<string, mixed> $context        The log context payload.
      *
      * @return JSONResponse
      *
@@ -199,13 +242,8 @@ class SettingsController extends Controller
     private function buildConfigErrorResponse(
         string $operationLabel,
         \Exception $exception,
-        bool $includeParams=false
+        array $context
     ): JSONResponse {
-        $context = ['exception' => $exception->getMessage()];
-        if ($includeParams === true) {
-            $context['requestData'] = $this->getRedactedParams();
-        }
-
         $this->logger->error('Failed to '.$operationLabel, $context);
 
         return new JSONResponse(
@@ -406,7 +444,7 @@ class SettingsController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'get general config', exception: $e, includeParams: false);
+            return $this->buildConfigReadErrorResponse(operationLabel: 'get general config', exception: $e);
         }//end try
     }//end getGeneralConfig()
 
@@ -438,7 +476,7 @@ class SettingsController extends Controller
                 ]
             );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'update general config', exception: $e, includeParams: true);
+            return $this->buildConfigWriteErrorResponse(operationLabel: 'update general config', exception: $e);
         }//end try
     }//end updateGeneralConfig()
 
@@ -465,7 +503,7 @@ class SettingsController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'get sync config', exception: $e, includeParams: false);
+            return $this->buildConfigReadErrorResponse(operationLabel: 'get sync config', exception: $e);
         }//end try
     }//end getSyncConfig()
 
@@ -497,7 +535,7 @@ class SettingsController extends Controller
                     ]
                     );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'update sync config', exception: $e, includeParams: true);
+            return $this->buildConfigWriteErrorResponse(operationLabel: 'update sync config', exception: $e);
         }//end try
     }//end updateSyncConfig()
 
@@ -3699,7 +3737,7 @@ class SettingsController extends Controller
                 ]
             );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'get EOL sync config', exception: $e, includeParams: false);
+            return $this->buildConfigReadErrorResponse(operationLabel: 'get EOL sync config', exception: $e);
         }
     }//end getEolSyncConfig()
 
@@ -3718,7 +3756,7 @@ class SettingsController extends Controller
             $data = $this->request->getParams();
             return new JSONResponse($this->eolSyncService->updateConfig($data));
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'update EOL sync config', exception: $e, includeParams: true);
+            return $this->buildConfigWriteErrorResponse(operationLabel: 'update EOL sync config', exception: $e);
         }
     }//end updateEolSyncConfig()
 
@@ -3775,7 +3813,7 @@ class SettingsController extends Controller
                 ]
             );
         } catch (\Exception $e) {
-            return $this->buildConfigErrorResponse(operationLabel: 'get EOL sync status', exception: $e, includeParams: false);
+            return $this->buildConfigReadErrorResponse(operationLabel: 'get EOL sync status', exception: $e);
         }
     }//end getEolSyncStatus()
 }//end class

--- a/lib/EventListener/OpenRegisterEventsDebugListener.php
+++ b/lib/EventListener/OpenRegisterEventsDebugListener.php
@@ -226,13 +226,9 @@ class OpenRegisterEventsDebugListener implements IEventListener
         }
 
         if ($event instanceof ObjectUpdatedEvent) {
-            $newObject = $event->getNewObject();
-            $oldObject = $event->getOldObject();
-            if ($oldObject !== null) {
-                $oldObjectData = $oldObject->getObject();
-            } else {
-                $oldObjectData = null;
-            }
+            $newObject     = $event->getNewObject();
+            $oldObject     = $event->getOldObject();
+            $oldObjectData = $oldObject?->getObject();
 
             return [
                 'eventType'     => 'ObjectUpdated',

--- a/lib/EventListener/SoftwareCatalogEventListener.php
+++ b/lib/EventListener/SoftwareCatalogEventListener.php
@@ -441,10 +441,11 @@ class SoftwareCatalogEventListener implements IEventListener
         );
 
         // Get configuration for different object types.
-        $organisatieSchemaId = $settingsService->getSchemaIdForObjectType(objectType: 'organisatie');
-        $contactSchemaId     = $settingsService->getSchemaIdForObjectType(objectType: 'contactpersoon');
-        $contactInfoSchemaId = $settingsService->getSchemaIdForObjectType(objectType: 'contactgegevens');
-        $gebruikSchemaId     = $settingsService->getSchemaIdForObjectType(objectType: 'gebruik');
+        $catalogSchemaIds    = $this->resolveCatalogSchemaIds(settingsService: $settingsService);
+        $organisatieSchemaId = $catalogSchemaIds['organisatie'];
+        $contactSchemaId     = $catalogSchemaIds['contactpersoon'];
+        $contactInfoSchemaId = $catalogSchemaIds['contactgegevens'];
+        $gebruikSchemaId     = $catalogSchemaIds['gebruik'];
 
         $logger->debug(
             'SoftwareCatalog: Configuration lookup results',
@@ -458,12 +459,12 @@ class SoftwareCatalogEventListener implements IEventListener
         );
 
         // Check if this is an organization object.
-        if ($organisatieSchemaId !== null && $objectSchemaIdInt === (int) $organisatieSchemaId) {
+        if ($this->matchesSchema(objectSchemaIdInt: $objectSchemaIdInt, configured: $organisatieSchemaId) === true) {
             $objectData = $object->getObject();
             $status     = strtolower($objectData['status'] ?? '');
 
             // Only process active organizations.
-            if (in_array(needle: $status, haystack: ['actief', 'active']) !== true) {
+            if ($this->isActiveStatus(status: $status) === false) {
                 $logger->debug(
                         'SoftwareCatalog: Skipping non-active organization creation',
                         [
@@ -487,21 +488,21 @@ class SoftwareCatalogEventListener implements IEventListener
         }//end if
 
         // Check if this is a contactpersoon object.
-        if ($contactSchemaId !== null && $objectSchemaIdInt === (int) $contactSchemaId) {
+        if ($this->matchesSchema(objectSchemaIdInt: $objectSchemaIdInt, configured: $contactSchemaId) === true) {
             $logger->info('SoftwareCatalog: Processing contactpersoon creation', ['objectId' => $objectId]);
             $contactSvc->processContactpersoon($object);
             return;
         }
 
         // Check if this is a contactgegevens object (deprecated - use contactpersoon instead).
-        if ($contactInfoSchemaId !== null && $objectSchemaIdInt === (int) $contactInfoSchemaId) {
+        if ($this->matchesSchema(objectSchemaIdInt: $objectSchemaIdInt, configured: $contactInfoSchemaId) === true) {
             $logger->info('SoftwareCatalog: Processing contactgegevens creation (deprecated)', ['objectId' => $objectId]);
             // Contactgegevens is deprecated, use contactpersoon instead.
             return;
         }
 
         // Check if this is a gebruik object.
-        if ($gebruikSchemaId !== null && $objectSchemaIdInt === (int) $gebruikSchemaId) {
+        if ($this->matchesSchema(objectSchemaIdInt: $objectSchemaIdInt, configured: $gebruikSchemaId) === true) {
             $logger->info('SoftwareCatalog: Processing gebruik creation', ['objectId' => $objectId]);
             $this->runGebruikSync(object: $object, phase: 'creation', logger: $logger);
             return;
@@ -615,14 +616,14 @@ class SoftwareCatalogEventListener implements IEventListener
                         'status'        => $status,
                         'oldStatus'     => $oldStatus,
                         'statusChanged' => ($status !== $oldStatus),
-                        'isActief'      => in_array(needle: $status, haystack: ['actief', 'active']),
-                        'willProcess'   => (in_array(needle: $status, haystack: ['actief', 'active']) === true
+                        'isActief'      => $this->isActiveStatus(status: $status),
+                        'willProcess'   => ($this->isActiveStatus(status: $status) === true
                             && $status !== $oldStatus),
                     ]
                     );
 
             // Only process active organizations.
-            if (in_array(needle: $status, haystack: ['actief', 'active']) === true && $status !== $oldStatus) {
+            if ($this->isActiveStatus(status: $status) === true && $status !== $oldStatus) {
                 $logger->info(
                         'SoftwareCatalog: Processing active organization update',
                         [
@@ -642,7 +643,7 @@ class SoftwareCatalogEventListener implements IEventListener
                 }
             }//end if
 
-            if (in_array(needle: $status, haystack: ['actief', 'active']) !== true || $status === $oldStatus) {
+            if ($this->isActiveStatus(status: $status) === false || $status === $oldStatus) {
                 $logger->debug(
                         'SoftwareCatalog: Skipping non-active organization update',
                         [

--- a/lib/Repair/MigrateContactsToNc.php
+++ b/lib/Repair/MigrateContactsToNc.php
@@ -38,7 +38,6 @@ use OCP\App\IAppManager;
 use OCP\IAppConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
-use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -70,7 +69,6 @@ class MigrateContactsToNc implements IRepairStep
      * Constructor.
      *
      * @param IAppManager                       $appManager      The app manager.
-     * @param ContainerInterface                $container       The DI container.
      * @param SettingsService                   $settingsService The settings service (register/schema id resolution).
      * @param SoftwareCatalogContactSyncService $contactSync     The contacts bridge.
      * @param IAppConfig                        $appConfig       The app config (convergence marker).
@@ -80,7 +78,6 @@ class MigrateContactsToNc implements IRepairStep
      */
     public function __construct(
         private readonly IAppManager $appManager,
-        private readonly ContainerInterface $container,
         private readonly SettingsService $settingsService,
         private readonly SoftwareCatalogContactSyncService $contactSync,
         private readonly IAppConfig $appConfig,
@@ -199,7 +196,7 @@ class MigrateContactsToNc implements IRepairStep
         ];
 
         $schemaId = $this->settingsService->getSchemaIdForObjectType($objectType);
-        if ($schemaId === null || $schemaId === false) {
+        if ($schemaId === null) {
             $output->warning(sprintf('Schema id for "%s" not configured — skipping', $objectType));
             return $stats;
         }
@@ -220,11 +217,7 @@ class MigrateContactsToNc implements IRepairStep
                     ->findAll([], false, false);
             };
 
-            if (method_exists($objectService, 'runAsSystem') === true) {
-                $objects = $objectService->runAsSystem($readObjects);
-            } else {
-                $objects = $readObjects();
-            }
+            $objects = $this->runElevated(objectService: $objectService, work: $readObjects);
         } catch (\Throwable $e) {
             $output->warning(sprintf('Could not read "%s" objects: %s', $objectType, $e->getMessage()));
             $this->logger->error(
@@ -318,17 +311,14 @@ class MigrateContactsToNc implements IRepairStep
                 );
             };
 
-            if (method_exists($objectService, 'runAsSystem') === true) {
-                $objectService->runAsSystem($saveObject);
-            } else {
-                $saveObject();
+            $this->runElevated(objectService: $objectService, work: $saveObject);
+
+            $statKey = 'created';
+            if ($alreadyExisted === true) {
+                $statKey = 'linked';
             }
 
-            if ($alreadyExisted === true) {
-                $stats['linked']++;
-            } else {
-                $stats['created']++;
-            }
+            $stats[$statKey]++;
         } catch (\Throwable $e) {
             // Fail-safe per-object: never abort the whole migration, never drop data.
             $stats['failed']++;
@@ -338,6 +328,30 @@ class MigrateContactsToNc implements IRepairStep
             );
         }//end try
     }//end migrateOne()
+
+    /**
+     * Run a unit of OpenRegister work with system elevation when available.
+     *
+     * Repair steps run user-less, so without elevation OpenRegister RBAC denies
+     * the read/write as 'Anonymous'. `runAsSystem()` was added to OpenRegister's
+     * ObjectService later than this repair step, so the capability is probed
+     * rather than assumed and the work is executed directly on older installs.
+     *
+     * @param object   $objectService The OpenRegister ObjectService handle.
+     * @param callable $work          The unit of work to execute.
+     *
+     * @return mixed Whatever the unit of work returns.
+     *
+     * @spec exclude system-context adoption
+     */
+    private function runElevated(object $objectService, callable $work): mixed
+    {
+        if (method_exists($objectService, 'runAsSystem') === true) {
+            return $objectService->runAsSystem($work);
+        }
+
+        return $work();
+    }//end runElevated()
 
     /**
      * Extract the object data array from an OpenRegister entity or array.

--- a/lib/Service/ContractApprovalService.php
+++ b/lib/Service/ContractApprovalService.php
@@ -40,6 +40,7 @@ use OCA\OpenRegister\Service\ObjectService;
 use OCP\EventDispatcher\IEventDispatcher;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 /**
  * Raises and projects contract approval decisions delegated to decidesk.
@@ -163,7 +164,7 @@ class ContractApprovalService
      *
      * @return string The decidesk decision id.
      *
-     * @throws \RuntimeException When delegation is not available or the listener did not handle it.
+     * @throws RuntimeException When delegation is not available or the listener did not handle it.
      *
      * @spec openspec/specs/contract-decision-delegation/spec.md
      */
@@ -171,12 +172,12 @@ class ContractApprovalService
     {
         if ($this->isDelegationConfigured() === false) {
             // Fail closed — never auto-approve when decidesk is not installed.
-            throw new \RuntimeException('Contract approval delegation is not available (decidesk event contract not installed).');
+            throw new RuntimeException('Contract approval delegation is not available (decidesk event contract not installed).');
         }
 
         $contract = $this->loadContract(contractUuid: $contractUuid);
         if ($contract === null) {
-            throw new \RuntimeException('Contract not found: '.$contractUuid);
+            throw new RuntimeException('Contract not found: '.$contractUuid);
         }
 
         $data = $contract->getObject();
@@ -208,16 +209,16 @@ class ContractApprovalService
                 'ContractApprovalService: dispatching decidesk decision request failed — contract left in negotiation',
                 ['contractUuid' => $contractUuid, 'error' => $e->getMessage()]
             );
-            throw new \RuntimeException('Failed to raise the approval decision in decidesk.', 0, $e);
+            throw new RuntimeException('Failed to raise the approval decision in decidesk.', 0, $e);
         }//end try
 
         if ($event->isHandled() === false) {
-            throw new \RuntimeException('decidesk did not handle the approval request; contract left in negotiation.');
+            throw new RuntimeException('decidesk did not handle the approval request; contract left in negotiation.');
         }
 
         $decisionId = (string) ($event->getDecisionId() ?? '');
         if ($decisionId === '') {
-            throw new \RuntimeException('decidesk did not return a decision id; contract left in negotiation.');
+            throw new RuntimeException('decidesk did not return a decision id; contract left in negotiation.');
         }
 
         $data['approvalDecisionId'] = $decisionId;

--- a/lib/Service/ContractStatusService.php
+++ b/lib/Service/ContractStatusService.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\SoftwareCatalog\Service;
 
+use DateTimeImmutable;
 use OCA\OpenRegister\Service\ObjectService;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -66,14 +67,14 @@ class ContractStatusService
      * (other status, missing/blank/unparseable end date, future end date)
      * returns false — the transition is never applied.
      *
-     * @param array              $contractData The contract object data bag.
-     * @param \DateTimeImmutable $now          Logical "now".
+     * @param array             $contractData The contract object data bag.
+     * @param DateTimeImmutable $now          Logical "now".
      *
      * @return bool True when the contract must be expired.
      *
      * @spec openspec/specs/contract-administration/spec.md
      */
-    public function shouldExpire(array $contractData, \DateTimeImmutable $now): bool
+    public function shouldExpire(array $contractData, DateTimeImmutable $now): bool
     {
         $status = $contractData['status'] ?? null;
         if ($status !== self::STATUS_ACTIVE) {
@@ -86,7 +87,7 @@ class ContractStatusService
         }
 
         try {
-            $end = new \DateTimeImmutable($eindDatum);
+            $end = new DateTimeImmutable($eindDatum);
         } catch (\Exception $e) {
             // Fail-closed: an unparseable end date never triggers a transition.
             $this->logger->debug(
@@ -105,15 +106,15 @@ class ContractStatusService
      * Returns the number of contracts transitioned. Degrades to 0 (no error)
      * when OpenRegister is unavailable or the contract schema is not configured.
      *
-     * @param \DateTimeImmutable|null $now Logical "now" (defaults to current time).
+     * @param DateTimeImmutable|null $now Logical "now" (defaults to current time).
      *
      * @return int The number of contracts transitioned to Verlopen.
      *
      * @spec openspec/specs/contract-administration/spec.md
      */
-    public function expirePastContracts(?\DateTimeImmutable $now=null): int
+    public function expirePastContracts(?DateTimeImmutable $now=null): int
     {
-        $now = ($now ?? new \DateTimeImmutable());
+        $now = ($now ?? new DateTimeImmutable());
 
         $objectService = $this->getObjectService();
         if ($objectService === null) {

--- a/lib/Service/EolMatcherService.php
+++ b/lib/Service/EolMatcherService.php
@@ -121,13 +121,21 @@ class EolMatcherService
      */
     private function matchDepth(string $versie, string $cycle): ?int
     {
+        // Reject empty input. `explode()` never returns an empty array, so the
+        // segment count below is always >= 1 and a `$depth === 0` test could
+        // never fire — the degenerate case is an empty STRING: explode('.', '')
+        // yields [''], which would let two empty inputs "match" at depth 1 and
+        // produce an EOL stamp from no version information at all. matchVersion()
+        // already rejects both empty inputs upstream, so this is defence in depth
+        // for any future caller.
+        if ($versie === '' || $cycle === '') {
+            return null;
+        }
+
         $versieSegments = explode('.', $versie);
         $cycleSegments  = explode('.', $cycle);
 
         $depth = min(count($versieSegments), count($cycleSegments));
-        if ($depth === 0) {
-            return null;
-        }
 
         for ($i = 0; $i < $depth; $i++) {
             if ($versieSegments[$i] !== $cycleSegments[$i]) {

--- a/lib/Service/FacetService.php
+++ b/lib/Service/FacetService.php
@@ -254,15 +254,15 @@ class FacetService
             baseObjects: $baseObjects
         );
 
-        $dimensionValuesByObjectId = $this->buildDimensionValueMap(modulesByObjectId: $modulesByObjectId);
+        $dimValsByObjId = $this->buildDimensionValueMap(modulesByObjectId: $modulesByObjectId);
 
         $facets = $this->computeFacets(
-            dimensionValuesByObjectId: $dimensionValuesByObjectId,
+            dimValsByObjId: $dimValsByObjId,
             selectedFilters: $normalizedFilters
         );
 
         $matchedObjectIds = $this->filterObjectIds(
-            dimensionValuesByObjectId: $dimensionValuesByObjectId,
+            dimValsByObjId: $dimValsByObjId,
             selectedFilters: $normalizedFilters,
             excludeDimension: null
         );
@@ -437,7 +437,7 @@ class FacetService
             $pagedQuery['_page']  = $page;
 
             $paginated  = $objectService->searchObjectsPaginated($pagedQuery);
-            $results    = array_map([$this, 'normalizeObject'], $paginated['results'] ?? []);
+            $results    = array_map(fn (mixed $entry): array => $this->normalizeObject(object: $entry), ($paginated['results'] ?? []));
             $allObjects = array_merge($allObjects, $results);
 
             $totalPages = (int) ($paginated['pages'] ?? 1);
@@ -622,7 +622,7 @@ class FacetService
         }
 
         $byId = [];
-        foreach (array_map([$this, 'normalizeObject'], $results) as $module) {
+        foreach (array_map(fn (mixed $entry): array => $this->normalizeObject(object: $entry), $results) as $module) {
             $key        = $this->objectIdentifier(object: $module);
             $byId[$key] = $module;
         }
@@ -646,9 +646,9 @@ class FacetService
     private function buildDimensionValueMap(array $modulesByObjectId): array
     {
         // Pass 1: direct fields (referentiecomponent identifiers + standaard identifiers).
-        $referentiecomponentIdsByObjectId = [];
-        $standaardValuesByObjectId        = [];
-        $allReferentiecomponentIds        = [];
+        $refCompIdsByObjId = [];
+        $stdValsByObjId    = [];
+        $allRefCompIds     = [];
 
         foreach ($modulesByObjectId as $objectId => $modules) {
             $refCompIds  = [];
@@ -662,32 +662,32 @@ class FacetService
             $refCompIds  = array_values(array_unique($refCompIds));
             $standaarden = array_values(array_unique(array_filter($standaarden)));
 
-            $referentiecomponentIdsByObjectId[$objectId] = $refCompIds;
-            $standaardValuesByObjectId[$objectId]        = $standaarden;
-            $allReferentiecomponentIds = array_merge($allReferentiecomponentIds, $refCompIds);
+            $refCompIdsByObjId[$objectId] = $refCompIds;
+            $stdValsByObjId[$objectId]    = $standaarden;
+            $allRefCompIds = array_merge($allRefCompIds, $refCompIds);
         }
 
-        $allReferentiecomponentIds = array_values(array_unique($allReferentiecomponentIds));
+        $allRefCompIds = array_values(array_unique($allRefCompIds));
 
         // Pass 2: resolve referentiecomponent elements themselves (for the
         // referentiecomponent facet's display value + the `domein` field).
-        $elementsById = $this->resolveElementsByIdentifier(identifiers: $allReferentiecomponentIds);
+        $elementsById = $this->resolveElementsByIdentifier(identifiers: $allRefCompIds);
 
         // Pass 3: resolve applicatieservice elements reachable via a `relation`
         // touching one of the referentiecomponent elements.
-        $applicatieserviceNamesByReferentiecomponentId = $this->resolveApplicatieservicesForReferentiecomponenten(
-            referentiecomponentIds: $allReferentiecomponentIds
+        $appSvcNmByRefComp = $this->resolveApplicatieservicesForReferentiecomponenten(
+            refCompIds: $allRefCompIds
         );
 
         // Assemble the final per-object dimension map.
-        $dimensionValuesByObjectId = [];
+        $dimValsByObjId = [];
 
         foreach ($modulesByObjectId as $objectId => $modules) {
-            $refCompIds = $referentiecomponentIdsByObjectId[$objectId] ?? [];
+            $refCompIds = $refCompIdsByObjId[$objectId] ?? [];
 
-            $referentiecomponentNames = [];
-            $domeinValues            = [];
-            $applicatieserviceValues = [];
+            $refCompNames = [];
+            $domeinValues = [];
+            $appSvcValues = [];
 
             foreach ($refCompIds as $refCompId) {
                 $element = $elementsById[$refCompId] ?? null;
@@ -695,7 +695,7 @@ class FacetService
                 // `elementDisplayName()` itself falls back to `$refCompId` when
                 // `$element` carries no usable `name` — pass an empty element
                 // array when unresolved so the same call covers both cases.
-                $referentiecomponentNames[] = $this->elementDisplayName(
+                $refCompNames[] = $this->elementDisplayName(
                     element: $element ?? [],
                     fallbackIdentifier: $refCompId
                 );
@@ -705,20 +705,20 @@ class FacetService
                     $domeinValues[] = trim($domein);
                 }
 
-                foreach (($applicatieserviceNamesByReferentiecomponentId[$refCompId] ?? []) as $applicatieserviceName) {
-                    $applicatieserviceValues[] = $applicatieserviceName;
+                foreach (($appSvcNmByRefComp[$refCompId] ?? []) as $appSvcName) {
+                    $appSvcValues[] = $appSvcName;
                 }
             }
 
-            $dimensionValuesByObjectId[$objectId] = [
-                'referentiecomponent' => array_values(array_unique($referentiecomponentNames)),
-                'standaard'           => $standaardValuesByObjectId[$objectId] ?? [],
+            $dimValsByObjId[$objectId] = [
+                'referentiecomponent' => array_values(array_unique($refCompNames)),
+                'standaard'           => $stdValsByObjId[$objectId] ?? [],
                 'domein'              => array_values(array_unique($domeinValues)),
-                'applicatieservice'   => array_values(array_unique($applicatieserviceValues)),
+                'applicatieservice'   => array_values(array_unique($appSvcValues)),
             ];
         }//end foreach
 
-        return $dimensionValuesByObjectId;
+        return $dimValsByObjId;
 
     }//end buildDimensionValueMap()
 
@@ -774,16 +774,16 @@ class FacetService
      * relationship-resolution pattern `ViewService`/`ArchiMateService` already
      * perform for referentiecomponent overlays (design.md trade-offs).
      *
-     * @param array $referentiecomponentIds Distinct referentiecomponent element identifiers.
+     * @param array $refCompIds Distinct referentiecomponent element identifiers.
      *
      * @return array<string,string[]> Referentiecomponent identifier => applicatieservice names.
      *
      * @spec openspec/specs/gemma-faceted-search/spec.md#requirement-facet-aggregation-endpoint-returns-gemma-dimension-counts
      * @spec openspec/specs/gemma-faceted-search/spec.md#requirement-facet-aggregation-queries-must-be-bounded
      */
-    private function resolveApplicatieservicesForReferentiecomponenten(array $referentiecomponentIds): array
+    private function resolveApplicatieservicesForReferentiecomponenten(array $refCompIds): array
     {
-        if (empty($referentiecomponentIds) === true) {
+        if (empty($refCompIds) === true) {
             return [];
         }
 
@@ -801,20 +801,20 @@ class FacetService
             return [];
         }
 
-        $otherEndpointsByRefCompId = $this->collectRelationEndpoints(
+        $otherEpsByRefComp = $this->collectRelationEndpoints(
             relations: $relations,
-            referentiecomponentIds: $referentiecomponentIds
+            refCompIds: $refCompIds
         );
 
-        if (empty($otherEndpointsByRefCompId) === true) {
+        if (empty($otherEpsByRefComp) === true) {
             return [];
         }
 
-        $allOtherIds  = array_values(array_unique(array_merge(...array_values($otherEndpointsByRefCompId))));
+        $allOtherIds  = array_values(array_unique(array_merge(...array_values($otherEpsByRefComp))));
         $elementsById = $this->resolveElementsByIdentifier(identifiers: $allOtherIds);
 
         return $this->mapEndpointsToApplicatieserviceNames(
-            otherEndpointsByRefCompId: $otherEndpointsByRefCompId,
+            otherEpsByRefComp: $otherEpsByRefComp,
             elementsById: $elementsById
         );
 
@@ -826,15 +826,15 @@ class FacetService
      * relations are undirected for this lookup's purposes (either endpoint
      * order counts).
      *
-     * @param array $relations              Bounded relation objects.
-     * @param array $referentiecomponentIds Distinct referentiecomponent element identifiers.
+     * @param array $relations  Bounded relation objects.
+     * @param array $refCompIds Distinct referentiecomponent element identifiers.
      *
      * @return array<string,string[]> Referentiecomponent identifier => other-endpoint identifiers.
      */
-    private function collectRelationEndpoints(array $relations, array $referentiecomponentIds): array
+    private function collectRelationEndpoints(array $relations, array $refCompIds): array
     {
-        $refCompLookup = array_flip($referentiecomponentIds);
-        $otherEndpointsByRefCompId = [];
+        $refCompLookup     = array_flip($refCompIds);
+        $otherEpsByRefComp = [];
 
         foreach ($relations as $relation) {
             $source = $relation['source'] ?? null;
@@ -844,15 +844,15 @@ class FacetService
             }
 
             if (isset($refCompLookup[$source]) === true) {
-                $otherEndpointsByRefCompId[$source][] = $target;
+                $otherEpsByRefComp[$source][] = $target;
             }
 
             if (isset($refCompLookup[$target]) === true) {
-                $otherEndpointsByRefCompId[$target][] = $source;
+                $otherEpsByRefComp[$target][] = $source;
             }
         }
 
-        return $otherEndpointsByRefCompId;
+        return $otherEpsByRefComp;
 
     }//end collectRelationEndpoints()
 
@@ -860,16 +860,16 @@ class FacetService
      * Filter each referentiecomponent's other-endpoint identifiers down to
      * `Applicatieservice`-typed elements and resolve their display names.
      *
-     * @param array $otherEndpointsByRefCompId Referentiecomponent identifier => other-endpoint identifiers.
-     * @param array $elementsById              Resolved element identifier => element object.
+     * @param array $otherEpsByRefComp Referentiecomponent identifier => other-endpoint identifiers.
+     * @param array $elementsById      Resolved element identifier => element object.
      *
      * @return array<string,string[]> Referentiecomponent identifier => applicatieservice names.
      */
-    private function mapEndpointsToApplicatieserviceNames(array $otherEndpointsByRefCompId, array $elementsById): array
+    private function mapEndpointsToApplicatieserviceNames(array $otherEpsByRefComp, array $elementsById): array
     {
         $result = [];
 
-        foreach ($otherEndpointsByRefCompId as $refCompId => $otherIds) {
+        foreach ($otherEpsByRefComp as $refCompId => $otherIds) {
             $names = [];
             foreach (array_unique($otherIds) as $otherId) {
                 $element = $elementsById[$otherId] ?? null;
@@ -895,27 +895,27 @@ class FacetService
      * dimension (not its own selection) — "self-count is not narrowed by its
      * own selection" per the spec scenario.
      *
-     * @param array $dimensionValuesByObjectId Object id => dimension => values.
-     * @param array $selectedFilters           Normalized selected filters.
+     * @param array $dimValsByObjId  Object id => dimension => values.
+     * @param array $selectedFilters Normalized selected filters.
      *
      * @return array<string,array<int,array{value:string,label:string,count:int}>>
      *
      * @spec openspec/specs/gemma-faceted-search/spec.md#requirement-facet-counts-reflect-the-currently-filtered-set-not-the-unfiltered-universe
      */
-    private function computeFacets(array $dimensionValuesByObjectId, array $selectedFilters): array
+    private function computeFacets(array $dimValsByObjId, array $selectedFilters): array
     {
         $facets = [];
 
         foreach (self::DIMENSIONS as $dimension) {
             $narrowedObjectIds = $this->filterObjectIds(
-                dimensionValuesByObjectId: $dimensionValuesByObjectId,
+                dimValsByObjId: $dimValsByObjId,
                 selectedFilters: $selectedFilters,
                 excludeDimension: $dimension
             );
 
             $counts = [];
             foreach ($narrowedObjectIds as $objectId) {
-                $values = $dimensionValuesByObjectId[$objectId][$dimension] ?? [];
+                $values = $dimValsByObjId[$objectId][$dimension] ?? [];
                 foreach ($values as $value) {
                     $counts[$value] = ($counts[$value] ?? 0) + 1;
                 }
@@ -946,19 +946,19 @@ class FacetService
      * applying that one dimension's own filter (used when computing that
      * dimension's own disjunctive counts).
      *
-     * @param array       $dimensionValuesByObjectId Object id => dimension => values.
-     * @param array       $selectedFilters           Normalized selected filters.
-     * @param string|null $excludeDimension          Dimension to skip filtering on, or null.
+     * @param array       $dimValsByObjId   Object id => dimension => values.
+     * @param array       $selectedFilters  Normalized selected filters.
+     * @param string|null $excludeDimension Dimension to skip filtering on, or null.
      *
      * @return string[] Matching object ids.
      *
      * @spec openspec/specs/gemma-faceted-search/spec.md#requirement-facet-counts-reflect-the-currently-filtered-set-not-the-unfiltered-universe
      */
-    private function filterObjectIds(array $dimensionValuesByObjectId, array $selectedFilters, ?string $excludeDimension): array
+    private function filterObjectIds(array $dimValsByObjId, array $selectedFilters, ?string $excludeDimension): array
     {
         $matched = [];
 
-        foreach ($dimensionValuesByObjectId as $objectId => $dimensionValues) {
+        foreach ($dimValsByObjId as $objectId => $dimensionValues) {
             $isMatch = true;
 
             foreach ($selectedFilters as $dimension => $selectedValues) {

--- a/lib/Service/Federation/FederationConfig.php
+++ b/lib/Service/Federation/FederationConfig.php
@@ -197,9 +197,10 @@ class FederationConfig
             $decoded = [];
         }
 
-        if ($failures <= 0) {
-            unset($decoded[$peerUrl]);
-        } else {
+        // A non-positive failure count clears the entry entirely, so drop it
+        // first and only re-add it when there is a positive count to record.
+        unset($decoded[$peerUrl]);
+        if ($failures > 0) {
             $decoded[$peerUrl] = $failures;
         }
 

--- a/lib/Service/Federation/FederationMerger.php
+++ b/lib/Service/Federation/FederationMerger.php
@@ -157,10 +157,9 @@ class FederationMerger
      */
     public function isStale(int $consecutiveFailures, ?int $threshold=null): bool
     {
+        $limit = self::DEFAULT_STALE_AFTER_FAILURES;
         if ($threshold !== null && $threshold > 0) {
             $limit = $threshold;
-        } else {
-            $limit = self::DEFAULT_STALE_AFTER_FAILURES;
         }
 
         return $consecutiveFailures >= $limit;
@@ -178,10 +177,9 @@ class FederationMerger
      */
     public function applyStale(array $mirror, bool $stale): array
     {
+        $source = [];
         if (is_array($mirror['_source'] ?? null) === true) {
             $source = $mirror['_source'];
-        } else {
-            $source = [];
         }
 
         $source['stale']   = $stale;
@@ -250,10 +248,9 @@ class FederationMerger
      */
     private function markWithdrawn(array $mirror, string $syncedAt): array
     {
+        $source = [];
         if (is_array($mirror['_source'] ?? null) === true) {
             $source = $mirror['_source'];
-        } else {
-            $source = [];
         }
 
         $source['withdrawn']   = true;

--- a/lib/Service/Federation/FederationService.php
+++ b/lib/Service/Federation/FederationService.php
@@ -114,10 +114,9 @@ class FederationService
             ];
         }
 
+        $message = 'Federation unavailable — requires OpenCatalogi';
         if ($available === true) {
             $message = 'Federation available';
-        } else {
-            $message = 'Federation unavailable — requires OpenCatalogi';
         }
 
         return [
@@ -176,7 +175,7 @@ class FederationService
     {
         $peerUrl  = trim($peerUrl);
         $peers    = $this->config->getPeers();
-        $filtered = array_values(array_filter($peers, static fn (string $p): bool => $p !== $peerUrl));
+        $filtered = array_values(array_filter($peers, static fn (string $peer): bool => $peer !== $peerUrl));
         if (count($filtered) === count($peers)) {
             return ['ok' => false, 'reason' => 'peer not found'];
         }
@@ -509,10 +508,9 @@ class FederationService
             return [];
         }
 
+        $items = [];
         if (is_array($objects) === true) {
             $items = $objects;
-        } else {
-            $items = [];
         }
 
         $mirrors = [];
@@ -542,10 +540,9 @@ class FederationService
     {
         $count = 0;
         foreach ($mirrors as $mirror) {
+            $uuid = '';
             if ($uuidKey !== null) {
                 $uuid = (string) ($mirror[$uuidKey] ?? '');
-            } else {
-                $uuid = '';
             }
 
             try {
@@ -743,10 +740,10 @@ class FederationService
             return false;
         }
 
-        $ip = filter_var($host, FILTER_VALIDATE_IP);
-        if ($ip !== false) {
+        $ipAddress = filter_var($host, FILTER_VALIDATE_IP);
+        if ($ipAddress !== false) {
             $public = filter_var(
-                $ip,
+                $ipAddress,
                 FILTER_VALIDATE_IP,
                 (FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
             );

--- a/lib/Service/MergeOrganisatieService.php
+++ b/lib/Service/MergeOrganisatieService.php
@@ -92,7 +92,11 @@ class MergeOrganisatieService
     /**
      * Relation types re-pointed via a business-level object field (scalar and/or array).
      *
-     * @var array<string, array{field: string, arrayField: string|null}>
+     * The optional `schema` key overrides the OpenRegister schema slug when it
+     * differs from the relation-type key (`aanbod` lives on the `koppeling`
+     * schema); `walkRelations()` falls back to the key via `?? $type`.
+     *
+     * @var array<string, array{field: string, arrayField: string|null, schema?: string}>
      */
     private const FIELD_RELATION_TYPES = [
         'gebruik'        => ['field' => 'afnemer', 'arrayField' => 'deelnemers'],
@@ -241,7 +245,7 @@ class MergeOrganisatieService
             context: ['sourceUuid' => $sourceUuid, 'targetUuid' => $targetUuid, 'actor' => $actorUid, 'operationId' => $operationId]
         );
 
-        $counts = $this->walkRelations(sourceUuid: $sourceUuid, targetUuid: $targetUuid, commit: true, operationId: $operationId);
+        $counts = $this->walkRelations(sourceUuid: $sourceUuid, targetUuid: $targetUuid, commit: true);
         $counts['groupMembers'] = $this->migrateGroupMembership(sourceUuid: $sourceUuid, targetUuid: $targetUuid);
 
         $this->tombstoneSource(sourceUuid: $sourceUuid, targetUuid: $targetUuid);
@@ -286,10 +290,9 @@ class MergeOrganisatieService
      * enumerates AND re-points. Both callers run the identical per-type
      * logic below, which is what guarantees dry-run/execute parity.
      *
-     * @param string      $sourceUuid  The source organisation UUID.
-     * @param string      $targetUuid  The target organisation UUID.
-     * @param bool        $commit      Whether to write (true) or only count (false).
-     * @param string|null $operationId Progress-tracking operation id (execute only).
+     * @param string $sourceUuid The source organisation UUID.
+     * @param string $targetUuid The target organisation UUID.
+     * @param bool   $commit     Whether to write (true) or only count (false).
      *
      * @return array<string, int> Per-relation-type counts.
      *
@@ -297,7 +300,7 @@ class MergeOrganisatieService
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `commit` is the documented dry-run/execute parity gate, not a generic flag.
      */
-    private function walkRelations(string $sourceUuid, string $targetUuid, bool $commit, ?string $operationId=null): array
+    private function walkRelations(string $sourceUuid, string $targetUuid, bool $commit): array
     {
         $counts = $this->emptyCounts();
 
@@ -381,12 +384,13 @@ class MergeOrganisatieService
                 $arrayMatched = false;
                 $newArray     = [];
                 foreach ($data[$arrayField] as $entry) {
+                    $replacement = $entry;
                     if ($entry === $source) {
                         $arrayMatched = true;
-                        $newArray[]   = $target;
-                    } else {
-                        $newArray[] = $entry;
+                        $replacement  = $target;
                     }
+
+                    $newArray[] = $replacement;
                 }
 
                 if ($arrayMatched === true) {

--- a/lib/Service/OrganisatieService.php
+++ b/lib/Service/OrganisatieService.php
@@ -292,7 +292,7 @@ class OrganisatieService
     ): \OCA\OpenRegister\Db\Organisation {
         // Resolve the active organisation as the parent for the new (child)
         // organisation, restoring the hierarchy the hotfix disabled.
-        $parentOrganisationUuid = $this->getActiveOrganisationUuid(organisationService: $organisationService);
+        $parentOrgUuid = $this->getActiveOrganisationUuid(organisationService: $organisationService);
 
         $this->logger->info(
                 'OrganisatieService: Creating organisation entity',
@@ -300,7 +300,7 @@ class OrganisatieService
                     'uuid'               => $organizationUuid,
                     'name'               => $mappedData['naam'],
                     'active'             => $mappedData['active'],
-                    'parentOrganisation' => $parentOrganisationUuid,
+                    'parentOrganisation' => $parentOrgUuid,
                 ]
                 );
 
@@ -319,13 +319,13 @@ class OrganisatieService
         // already uses in addUsersToOrganization()); a link failure is logged
         // and swallowed so the organisation is still returned (flat) rather
         // than lost — matching the pre-hotfix "org always created" guarantee.
-        if ($parentOrganisationUuid !== null
-            && $parentOrganisationUuid !== ''
-            && $parentOrganisationUuid !== $organisationEntity->getUuid()
+        if ($parentOrgUuid !== null
+            && $parentOrgUuid !== ''
+            && $parentOrgUuid !== $organisationEntity->getUuid()
         ) {
             $organisationEntity = $this->linkParentOrganisation(
                 organisationEntity: $organisationEntity,
-                parentOrganisationUuid: $parentOrganisationUuid
+                parentOrgUuid: $parentOrgUuid
             );
         }
 
@@ -351,8 +351,8 @@ class OrganisatieService
      * entity is returned unchanged so organisation creation never fails
      * outright over a hierarchy link.
      *
-     * @param \OCA\OpenRegister\Db\Organisation $organisationEntity     The created organisation entity.
-     * @param string                            $parentOrganisationUuid The parent organisation UUID to link.
+     * @param \OCA\OpenRegister\Db\Organisation $organisationEntity The created organisation entity.
+     * @param string                            $parentOrgUuid      The parent organisation UUID to link.
      *
      * @return \OCA\OpenRegister\Db\Organisation The entity with the parent set (or the original on failure).
      *
@@ -360,19 +360,19 @@ class OrganisatieService
      */
     private function linkParentOrganisation(
         \OCA\OpenRegister\Db\Organisation $organisationEntity,
-        string $parentOrganisationUuid
+        string $parentOrgUuid
     ): \OCA\OpenRegister\Db\Organisation {
         try {
             $organisationMapper = $this->container->get('OCA\OpenRegister\Db\OrganisationMapper');
 
-            $organisationEntity->setParent($parentOrganisationUuid);
+            $organisationEntity->setParent($parentOrgUuid);
             $saved = $organisationMapper->save($organisationEntity);
 
             $this->logger->info(
                     'OrganisatieService: Linked organisation to parent',
                     [
                         'uuid'   => $organisationEntity->getUuid(),
-                        'parent' => $parentOrganisationUuid,
+                        'parent' => $parentOrgUuid,
                     ]
                     );
 
@@ -382,7 +382,7 @@ class OrganisatieService
                     'OrganisatieService: Failed to link organisation to parent, leaving it flat',
                     [
                         'uuid'   => $organisationEntity->getUuid(),
-                        'parent' => $parentOrganisationUuid,
+                        'parent' => $parentOrgUuid,
                         'error'  => $e->getMessage(),
                     ]
                     );

--- a/lib/Service/PublicationService.php
+++ b/lib/Service/PublicationService.php
@@ -273,12 +273,12 @@ class PublicationService
             return null;
         }
 
-        $ts = strtotime($when);
-        if ($ts === false) {
+        $timestamp = strtotime($when);
+        if ($timestamp === false) {
             return null;
         }
 
-        return gmdate('Y-m-d\TH:i:sP', $ts);
+        return gmdate('Y-m-d\TH:i:sP', $timestamp);
     }//end normaliseDate()
 
     /**

--- a/lib/Service/SoftwareCatalogContactSyncService.php
+++ b/lib/Service/SoftwareCatalogContactSyncService.php
@@ -299,39 +299,9 @@ class SoftwareCatalogContactSyncService
      */
     private function recordToVCard(string $objectType, array $record): array
     {
-        $properties = [];
-
-        if ($objectType === 'organisatie') {
-            $name = trim((string) ($record['naam'] ?? ''));
-            $properties['FN']   = $name;
-            $properties['ORG']  = $name;
-            $properties['KIND'] = 'org';
-
-            $cbsCode = trim((string) ($record['cbsCode'] ?? ''));
-            if ($cbsCode !== '') {
-                $properties['X-KVK']    = $cbsCode;
-                $properties['NICKNAME'] = $cbsCode;
-            }
-
-            $website = trim((string) ($record['website'] ?? ''));
-            if ($website !== '') {
-                $properties['URL'] = $website;
-            }
-        } else {
-            $voornaam      = trim((string) ($record['voornaam'] ?? ''));
-            $tussenvoegsel = trim((string) ($record['tussenvoegsel'] ?? ''));
-            $achternaam    = trim((string) ($record['achternaam'] ?? ''));
-            $family        = trim(trim($tussenvoegsel.' '.$achternaam));
-
-            $properties['FN'] = trim($voornaam.' '.$family);
-            // N = Family;Given;Additional;Prefix;Suffix.
-            $properties['N'] = $family.';'.$voornaam.';;;';
-
-            $functie = trim((string) ($record['functie'] ?? ''));
-            if ($functie !== '') {
-                $properties['TITLE'] = $functie;
-            }
-        }//end if
+        // The identity block differs per kind; the contact channels below are
+        // shared by both.
+        $properties = $this->identityProperties(objectType: $objectType, record: $record);
 
         $email = trim((string) ($record['e-mailadres'] ?? $record['email'] ?? ''));
         if ($email !== '') {
@@ -345,6 +315,81 @@ class SoftwareCatalogContactSyncService
 
         return $properties;
     }//end recordToVCard()
+
+    /**
+     * Select and build the kind-specific vCard identity properties.
+     *
+     * @param string               $objectType The relationship type.
+     * @param array<string, mixed> $record     The relationship record.
+     *
+     * @return array<string, mixed> The identity property set.
+     */
+    private function identityProperties(string $objectType, array $record): array
+    {
+        if ($objectType === 'organisatie') {
+            return $this->organisationIdentityProperties(record: $record);
+        }
+
+        return $this->personIdentityProperties(record: $record);
+    }//end identityProperties()
+
+    /**
+     * Build the organisation-kind vCard identity properties.
+     *
+     * @param array<string, mixed> $record The relationship record.
+     *
+     * @return array<string, mixed> The identity property set.
+     */
+    private function organisationIdentityProperties(array $record): array
+    {
+        $name       = trim((string) ($record['naam'] ?? ''));
+        $properties = [
+            'FN'   => $name,
+            'ORG'  => $name,
+            'KIND' => 'org',
+        ];
+
+        $cbsCode = trim((string) ($record['cbsCode'] ?? ''));
+        if ($cbsCode !== '') {
+            $properties['X-KVK']    = $cbsCode;
+            $properties['NICKNAME'] = $cbsCode;
+        }
+
+        $website = trim((string) ($record['website'] ?? ''));
+        if ($website !== '') {
+            $properties['URL'] = $website;
+        }
+
+        return $properties;
+    }//end organisationIdentityProperties()
+
+    /**
+     * Build the person-kind vCard identity properties.
+     *
+     * @param array<string, mixed> $record The relationship record.
+     *
+     * @return array<string, mixed> The identity property set.
+     */
+    private function personIdentityProperties(array $record): array
+    {
+        $voornaam      = trim((string) ($record['voornaam'] ?? ''));
+        $tussenvoegsel = trim((string) ($record['tussenvoegsel'] ?? ''));
+        $achternaam    = trim((string) ($record['achternaam'] ?? ''));
+        $family        = trim(trim($tussenvoegsel.' '.$achternaam));
+
+        $properties = [
+            'FN' => trim($voornaam.' '.$family),
+            // N = Family;Given;Additional;Prefix;Suffix.
+            'N'  => $family.';'.$voornaam.';;;',
+        ];
+
+        $functie = trim((string) ($record['functie'] ?? ''));
+        if ($functie !== '') {
+            $properties['TITLE'] = $functie;
+        }
+
+        return $properties;
+    }//end personIdentityProperties()
 
     /**
      * Return the key of the first writable addressbook, or null when none is

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -439,7 +439,7 @@ class ViewService
         }
 
         if ($this->shouldIncludeGebruik(options: $options) === true) {
-            $gebruikData = $this->getGebruikData(options: $options);
+            $gebruikData = $this->getGebruikData();
         }
 
         if ($this->shouldIncludeDeelnamesGebruik(options: $options) === true) {
@@ -804,13 +804,14 @@ class ViewService
      * Retrieves only organisation-owned gebruik via standard RBAC filtering.
      * Deelnames gebruik is retrieved separately via getDeelnamesGebruikData().
      *
-     * @param array $options Query options (unused, kept for signature compatibility).
+     * The register/schema and organisation scope are resolved from settings and
+     * the current session, so this needs no caller-supplied query options.
      *
      * @return array Gebruik data indexed by elementRef.
      *
      * @spec openspec/changes/deelnames-gebruik/tasks.md#task-2
      */
-    private function getGebruikData(array $options=[]): array
+    private function getGebruikData(): array
     {
         $this->logger->debug(message: 'Getting regular gebruik data for view enrichment');
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,6 +17,16 @@ parameters:
         - lib/Resources/template
     scanDirectories:
         - vendor/nextcloud/ocp
+    scanFiles:
+        # decidesk decision-event contract (DecisionRequestedEvent +
+        # DecisionConcludedEvent). decidesk is a sibling Nextcloud app, not a
+        # Composer dependency, so it is genuinely absent from the CI analysis
+        # path. The stub mirrors the real signatures in decidesk/lib/Event/ and
+        # supplies real type information rather than silencing the diagnostic —
+        # that is what also resolves the six `Call to method X() on an unknown
+        # class` errors that a bare ignore pattern cannot fix. Analysis-only;
+        # never loaded at runtime or by PHPUnit.
+        - tests/analysis-stubs/decidesk-events.stub.php
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,18 @@
     </projectFiles>
     <stubs>
         <file name="vendor/nextcloud/ocp/OCP/Capabilities/ICapability.php" preloadClasses="true" />
+        <!-- decidesk decision-event contract (DecisionRequestedEvent +
+             DecisionConcludedEvent). decidesk is a sibling Nextcloud app, not a
+             Composer dependency, so it is absent from the analysis path. The
+             stub mirrors the real signatures in decidesk/lib/Event/ and supplies
+             real type information instead of silencing the diagnostic — which is
+             what also resolves the isHandled()/getDecisionId() calls on the
+             dispatched event. Analysis-only; never loaded at runtime. -->
+        <file name="tests/analysis-stubs/decidesk-events.stub.php" preloadClasses="true" />
+        <!-- OpenRegister RegisterResolverService. Same cross-app situation; this
+             stub already existed for PHPUnit mock generation and mirrors the real
+             signature in openregister/lib/Service/RegisterResolverService.php. -->
+        <file name="tests/Stubs/Service/RegisterResolverService.php" preloadClasses="true" />
     </stubs>
     <issueHandlers>
         <UndefinedDocblockClass errorLevel="suppress"/>

--- a/tests/Unit/Controller/SettingsControllerDecompositionTest.php
+++ b/tests/Unit/Controller/SettingsControllerDecompositionTest.php
@@ -15,8 +15,13 @@ use ReflectionClass;
 use ReflectionMethod;
 
 /**
- * Unit tests for the W30 SettingsController decomposition helper
- * (buildConfigErrorResponse).
+ * Unit tests for the W30 SettingsController decomposition helpers
+ * (buildConfigReadErrorResponse / buildConfigWriteErrorResponse).
+ *
+ * These target the two intent-named entry points the controller actually
+ * calls, rather than the shared private core — the read/write distinction
+ * (whether the redacted request params reach the log) is the behaviour under
+ * test, and it now lives in the choice of entry point.
  *
  * @spec openspec/changes/method-decomposition/tasks.md#task-3
  */
@@ -35,11 +40,11 @@ class SettingsControllerDecompositionTest extends TestCase
         return $controller;
     }
 
-    private function call(SettingsController $controller, string $label, \Exception $e, bool $includeParams)
+    private function call(SettingsController $controller, string $method, string $label, \Exception $e)
     {
-        $ref = new ReflectionMethod($controller, 'buildConfigErrorResponse');
+        $ref = new ReflectionMethod($controller, $method);
         $ref->setAccessible(true);
-        return $ref->invokeArgs($controller, [$label, $e, $includeParams]);
+        return $ref->invokeArgs($controller, [$label, $e]);
     }
 
     public function testErrorResponseReturnsStatus500AndCanonicalShape(): void
@@ -51,7 +56,12 @@ class SettingsControllerDecompositionTest extends TestCase
         );
 
         $controller = $this->makeController($logger);
-        $response = $this->call($controller, 'get sync config', new \RuntimeException('boom'), false);
+        $response = $this->call(
+            $controller,
+            'buildConfigReadErrorResponse',
+            'get sync config',
+            new \RuntimeException('boom')
+        );
 
         $this->assertSame(500, $response->getStatus());
         $data = $response->getData();
@@ -81,9 +91,9 @@ class SettingsControllerDecompositionTest extends TestCase
         $reqProp->setAccessible(true);
         $reqProp->setValue($controller, $request);
 
-        $ref = new ReflectionMethod($controller, 'buildConfigErrorResponse');
+        $ref = new ReflectionMethod($controller, 'buildConfigWriteErrorResponse');
         $ref->setAccessible(true);
-        $response = $ref->invokeArgs($controller, ['update general config', new \LogicException('nope'), true]);
+        $response = $ref->invokeArgs($controller, ['update general config', new \LogicException('nope')]);
 
         $this->assertSame(500, $response->getStatus());
         $this->assertSame(

--- a/tests/analysis-stubs/decidesk-events.stub.php
+++ b/tests/analysis-stubs/decidesk-events.stub.php
@@ -1,0 +1,463 @@
+<?php
+
+/**
+ * Static-analysis stubs for the decidesk decision-event contract.
+ *
+ * ANALYSIS-ONLY — referenced from phpstan.neon `scanFiles` and psalm.xml
+ * `<stubs>`, and NEVER loaded at runtime or during PHPUnit.
+ *
+ * Why this lives in `tests/analysis-stubs/` and NOT in `tests/Stubs/`:
+ * `tests/bootstrap.php` `require_once`s every file matching
+ * `tests/Stubs/{,**\/}*.php` BEFORE Nextcloud's app bootstrap, deliberately
+ * letting those stubs win over the real classes for mock generation. Doing
+ * that to the decidesk event classes would shadow the REAL events that
+ * ContractApprovalService dispatches through IEventDispatcher on any
+ * instance where decidesk is installed. These declarations must therefore
+ * stay out of that glob.
+ *
+ * The real classes live in the sibling `decidesk` app
+ * (decidesk/lib/Event/DecisionConcludedEvent.php and
+ * DecisionRequestedEvent.php). decidesk is a Nextcloud app, not a Composer
+ * dependency, so it is genuinely absent from the CI analysis path. The
+ * signatures below mirror the real ones exactly; they supply real type
+ * information rather than silencing the diagnostic, which is what also
+ * resolves the `Call to method X() on an unknown class` errors that a bare
+ * ignore pattern cannot fix.
+ *
+ * @category Test
+ * @package  OCA\Decidesk\Event
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Decidesk\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Analysis-only mirror of decidesk's DecisionConcludedEvent.
+ *
+ * Dispatched by decidesk when a Decision reaches a terminal outcome; consumed
+ * by SoftwareCatalog's DecisionConcludedListener.
+ */
+class DecisionConcludedEvent extends Event
+{
+
+    /**
+     * Construct the conclusion event.
+     *
+     * @param string            $decisionId        The concluded Decision id.
+     * @param string            $decisionType      The Decision type.
+     * @param string            $status            Derived outcome status.
+     * @param string            $outcome           Raw decision outcome.
+     * @param bool              $signed            Whether a signature stage resolved.
+     * @param string|null       $signingReference  Signing reference, when signed.
+     * @param array<int, mixed> $signers           Resolved signers list.
+     * @param string|null       $decidedAt         When the decision concluded.
+     * @param string            $sourceApp         Consumer app that raised the decision.
+     * @param string|null       $subjectRegister   OpenRegister register of the origin object.
+     * @param string|null       $subjectSchema     OpenRegister schema of the origin object.
+     * @param string|null       $subjectId         OpenRegister id of the origin object.
+     * @param string            $externalReference Consumer's own reference.
+     * @param string            $correlationId     Correlation id from the request event.
+     */
+    public function __construct(
+        private readonly string $decisionId,
+        private readonly string $decisionType,
+        private readonly string $status,
+        private readonly string $outcome,
+        private readonly bool $signed,
+        private readonly ?string $signingReference,
+        private readonly array $signers,
+        private readonly ?string $decidedAt,
+        private readonly string $sourceApp,
+        private readonly ?string $subjectRegister,
+        private readonly ?string $subjectSchema,
+        private readonly ?string $subjectId,
+        private readonly string $externalReference='',
+        private readonly string $correlationId='',
+    ) {
+        parent::__construct();
+    }//end __construct()
+
+
+    /**
+     * Get the concluded Decision id.
+     *
+     * @return string
+     */
+    public function getDecisionId(): string
+    {
+        return $this->decisionId;
+    }//end getDecisionId()
+
+
+    /**
+     * Get the Decision type.
+     *
+     * @return string
+     */
+    public function getDecisionType(): string
+    {
+        return $this->decisionType;
+    }//end getDecisionType()
+
+
+    /**
+     * Get the derived outcome status.
+     *
+     * @return string
+     */
+    public function getStatus(): string
+    {
+        return $this->status;
+    }//end getStatus()
+
+
+    /**
+     * Get the raw decision outcome.
+     *
+     * @return string
+     */
+    public function getOutcome(): string
+    {
+        return $this->outcome;
+    }//end getOutcome()
+
+
+    /**
+     * Whether a signature stage resolved.
+     *
+     * @return bool
+     */
+    public function isSigned(): bool
+    {
+        return $this->signed;
+    }//end isSigned()
+
+
+    /**
+     * Get the signing reference, when signed.
+     *
+     * @return string|null
+     */
+    public function getSigningReference(): ?string
+    {
+        return $this->signingReference;
+    }//end getSigningReference()
+
+
+    /**
+     * Get the resolved signers list.
+     *
+     * @return array<int, mixed>
+     */
+    public function getSigners(): array
+    {
+        return $this->signers;
+    }//end getSigners()
+
+
+    /**
+     * Get when the decision concluded.
+     *
+     * @return string|null
+     */
+    public function getDecidedAt(): ?string
+    {
+        return $this->decidedAt;
+    }//end getDecidedAt()
+
+
+    /**
+     * Get the consumer app that raised the decision.
+     *
+     * @return string
+     */
+    public function getSourceApp(): string
+    {
+        return $this->sourceApp;
+    }//end getSourceApp()
+
+
+    /**
+     * Get the OpenRegister register of the originating object.
+     *
+     * @return string|null
+     */
+    public function getSubjectRegister(): ?string
+    {
+        return $this->subjectRegister;
+    }//end getSubjectRegister()
+
+
+    /**
+     * Get the OpenRegister schema of the originating object.
+     *
+     * @return string|null
+     */
+    public function getSubjectSchema(): ?string
+    {
+        return $this->subjectSchema;
+    }//end getSubjectSchema()
+
+
+    /**
+     * Get the OpenRegister id of the originating object.
+     *
+     * @return string|null
+     */
+    public function getSubjectId(): ?string
+    {
+        return $this->subjectId;
+    }//end getSubjectId()
+
+
+    /**
+     * Get the consumer's own reference.
+     *
+     * @return string
+     */
+    public function getExternalReference(): string
+    {
+        return $this->externalReference;
+    }//end getExternalReference()
+
+
+    /**
+     * Get the correlation id from the request event.
+     *
+     * @return string
+     */
+    public function getCorrelationId(): string
+    {
+        return $this->correlationId;
+    }//end getCorrelationId()
+
+
+}//end class
+
+
+/**
+ * Analysis-only mirror of decidesk's DecisionRequestedEvent.
+ *
+ * Dispatched by SoftwareCatalog's ContractApprovalService to ask decidesk to
+ * open a Decision; decidesk's listener fills the `decisionId` / `handled`
+ * result slots before the dispatch call returns.
+ */
+class DecisionRequestedEvent extends Event
+{
+
+    /**
+     * The id of the Decision decidesk created or matched (result slot).
+     *
+     * @var string|null
+     */
+    private ?string $decisionId = null;
+
+    /**
+     * Whether decidesk's listener handled this request (result slot).
+     *
+     * @var boolean
+     */
+    private bool $handled = false;
+
+
+    /**
+     * Construct the request event.
+     *
+     * @param string               $sourceApp         The consumer app raising the decision.
+     * @param string               $subjectRegister   OpenRegister register of the origin object.
+     * @param string               $subjectSchema     OpenRegister schema of the origin object.
+     * @param string               $subjectId         OpenRegister id of the origin object.
+     * @param string               $subjectLabel      Human display label for the subject.
+     * @param string               $decisionType      Decision type.
+     * @param string               $actorId           Nextcloud UID of the requesting user.
+     * @param array<string, mixed> $payload           Additional decision body fields.
+     * @param string               $externalReference Consumer's own reference.
+     * @param string               $correlationId     Correlation id echoed on the conclusion event.
+     */
+    public function __construct(
+        private readonly string $sourceApp,
+        private readonly string $subjectRegister,
+        private readonly string $subjectSchema,
+        private readonly string $subjectId,
+        private readonly string $subjectLabel='',
+        private readonly string $decisionType='contract',
+        private readonly string $actorId='',
+        private readonly array $payload=[],
+        private readonly string $externalReference='',
+        private readonly string $correlationId='',
+    ) {
+        parent::__construct();
+    }//end __construct()
+
+
+    /**
+     * Get the consumer app that raised the decision.
+     *
+     * @return string
+     */
+    public function getSourceApp(): string
+    {
+        return $this->sourceApp;
+    }//end getSourceApp()
+
+
+    /**
+     * Get the OpenRegister register of the originating object.
+     *
+     * @return string
+     */
+    public function getSubjectRegister(): string
+    {
+        return $this->subjectRegister;
+    }//end getSubjectRegister()
+
+
+    /**
+     * Get the OpenRegister schema of the originating object.
+     *
+     * @return string
+     */
+    public function getSubjectSchema(): string
+    {
+        return $this->subjectSchema;
+    }//end getSubjectSchema()
+
+
+    /**
+     * Get the OpenRegister id of the originating object.
+     *
+     * @return string
+     */
+    public function getSubjectId(): string
+    {
+        return $this->subjectId;
+    }//end getSubjectId()
+
+
+    /**
+     * Get the human display label for the subject.
+     *
+     * @return string
+     */
+    public function getSubjectLabel(): string
+    {
+        return $this->subjectLabel;
+    }//end getSubjectLabel()
+
+
+    /**
+     * Get the decision type.
+     *
+     * @return string
+     */
+    public function getDecisionType(): string
+    {
+        return $this->decisionType;
+    }//end getDecisionType()
+
+
+    /**
+     * Get the Nextcloud UID of the requesting user.
+     *
+     * @return string
+     */
+    public function getActorId(): string
+    {
+        return $this->actorId;
+    }//end getActorId()
+
+
+    /**
+     * Get the additional decision body fields.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }//end getPayload()
+
+
+    /**
+     * Get the consumer's own reference.
+     *
+     * @return string
+     */
+    public function getExternalReference(): string
+    {
+        return $this->externalReference;
+    }//end getExternalReference()
+
+
+    /**
+     * Get the correlation id echoed on the conclusion event.
+     *
+     * @return string
+     */
+    public function getCorrelationId(): string
+    {
+        return $this->correlationId;
+    }//end getCorrelationId()
+
+
+    /**
+     * Get the id of the Decision decidesk created or matched.
+     *
+     * @return string|null
+     */
+    public function getDecisionId(): ?string
+    {
+        return $this->decisionId;
+    }//end getDecisionId()
+
+
+    /**
+     * Record the id of the Decision decidesk created or matched.
+     *
+     * @param string $decisionId The Decision id.
+     *
+     * @return void
+     */
+    public function setDecisionId(string $decisionId): void
+    {
+        $this->decisionId = $decisionId;
+    }//end setDecisionId()
+
+
+    /**
+     * Whether decidesk's listener handled this request.
+     *
+     * @return bool
+     */
+    public function isHandled(): bool
+    {
+        return $this->handled;
+    }//end isHandled()
+
+
+    /**
+     * Record whether decidesk's listener handled this request.
+     *
+     * @param bool $handled Whether the request was handled.
+     *
+     * @return void
+     */
+    public function setHandled(bool $handled): void
+    {
+        $this->handled = $handled;
+    }//end setHandled()
+
+
+}//end class


### PR DESCRIPTION
Clears the pre-existing RED `quality` jobs on `development` (run 30816462792) **without suppressing anything**: no new baseline entries, no `@SuppressWarnings`, no `@psalm-suppress`, no `phpcs:ignore`, no phpstan `ignoreErrors` for our own code. `phpmd.baseline.xml` is byte-identical.

## Results

| Job | Before | After |
|---|---|---|
| PHP Quality (psalm) | 15 | **0** |
| PHP Quality (phpstan) | 16 | **0** |
| PHP Quality (phpmd) | 78 | **24** (structural only) |
| phpcs (was green) | 0 errors | 0 errors |
| phpunit (was green) | 480 / 0 fail | 480 / 0 fail |

All three "before" counts were reproduced locally against a pristine `origin/development` checkout before any code changed, and each tool was positive-controlled after the fixes (deliberate violation injected, confirmed still reported, reverted).

## Genuine bugs found and fixed

**Three dead branches** phpstan flagged as always-false:
- `OrganizationContactSyncJob` / `MigrateContactsToNc` — `$schemaId === false` can never hold; `getSchemaIdForObjectType()` returns `?int`.
- `EolMatcherService::matchDepth()` — `$depth === 0` was unreachable because `explode()` never returns an empty array. The degenerate case the guard was *reaching* for is an empty **input**: `explode('.', '')` yields `['']`, so two empty strings would "match" at depth 1 and stamp an EOL date from no version information at all. Replaced with an explicit empty-input guard (currently masked by upstream guards in `matchVersion()`, so this is defence in depth).

**Three orphaned listener methods.** `resolveCatalogSchemaIds`, `isActiveStatus` and `matchesSchema` were extracted by an earlier decomposition change but the callers were never switched over — the inline duplicates were still live at 9 call sites. Wired them up rather than deleting working code.

**One phpmd false positive, deliberately not "fixed" by deletion.** `FacetService::normalizeObject` is reported unused but *is* called — via `[$this, 'normalizeObject']` callable arrays that pdepend cannot resolve (phpstan, which does resolve them, never flagged it). Its docblock records that it had already shipped dead once. Made the reference statically visible instead of removing the boundary.

`SbomController`'s discarded `json_decode` turned out **not** to be a dropped call — it was the old side-effect idiom for `json_last_error()`. Replaced with `json_validate()` (PHP 8.3+), same error message, no wasted decode.

## Cross-app stubs (the one sanctioned exception)

`decidesk` and `OpenRegister` are sibling Nextcloud apps, not Composer deps, so they are genuinely absent from the CI analysis path. Both referenced `decidesk` event classes were verified to exist upstream (they are not phantoms).

`tests/analysis-stubs/decidesk-events.stub.php` mirrors the real signatures in `decidesk/lib/Event/`. A stub was preferred over an ignore pattern because it supplies real type information — and it is what resolves the six `Call to method X() on an unknown class` errors and the `isHandled()` / `getDecisionId()` calls that an ignore pattern cannot reach. It deliberately lives **outside** `tests/Stubs/`, because `tests/bootstrap.php` `require_once`s that whole tree before the Nextcloud bootstrap and would otherwise shadow the real events at runtime.

psalm additionally consumes the pre-existing `tests/Stubs/Service/RegisterResolverService.php`.

## Still RED: phpmd, 24 findings

All 54 mechanical findings are fixed (MissingImport 12, LongVariable 18, ElseExpression 14, ShortVariable 3, UnusedPrivateMethod 4, UnusedFormalParameter 2, BooleanArgumentFlag 1). The remaining 24 need real refactors and are left visible rather than baselined:

| Rule | Count |
|---|---|
| CyclomaticComplexity | 8 |
| NPathComplexity | 5 |
| ExcessiveClassComplexity | 4 |
| ExcessiveMethodLength | 3 |
| BooleanArgumentFlag | 2 |
| ExcessiveClassLength | 1 |
| CouplingBetweenObjects | 1 |

The 2 remaining boolean flags are `ContractApprovalService::submitForApproval($isRenewal)` and `SettingsService::deepMergeConfig($replaceLists)` — the latter is a recursion-carried mode flag guarding security-relevant `authorization` merge semantics, where a split would duplicate the recursion.

Note `SoftwareCatalogContactSyncService`'s class complexity moved 53 → 56: extracting the vCard identity builders removes an `ElseExpression` but adds per-method base complexity. Same single finding, worse number.

## Testing note

The worktree's `vendor/` was a symlink, which made Composer's autoloader resolve `OCA\SoftwareCatalog\` to the **main checkout** — so an early "identical 480/0" test run was measuring the wrong tree entirely. Re-running with a real `vendor/` surfaced 2 genuine `TypeError`s that the boolean-flag split had introduced in `SettingsControllerDecompositionTest`. That test now targets the two new intent-named entry points, and the before/after test sets are identical by name with 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)