### PR TITLE
chore(quality): make check:strict pass — 24 phpmd findings suppressed at the site

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -237,6 +237,12 @@ class Application extends App implements IBootstrap
      * @return void
      *
      * @spec openspec/changes/method-decomposition/tasks.md#task-9-1
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) 498 lines of flat, branch-free DI
+     * wiring — one `registerService()` closure per domain service. The length is genuine
+     * and this method SHOULD be split into per-domain registrars the way
+     * `registerHandlerServices()` already was; that split is a deliberate follow-up and is
+     * deferred here only because it is a behaviour change, not a quality-gate change.
      */
     private function registerDomainServices(IRegistrationContext $context): void
     {

--- a/lib/BackgroundJob/OrganizationContactSyncJob.php
+++ b/lib/BackgroundJob/OrganizationContactSyncJob.php
@@ -194,6 +194,15 @@ class OrganizationContactSyncJob extends TimedJob
      * @param string  $objectType    The object type.
      *
      * @return void
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 12 (threshold 10) and NPath 217
+     * (threshold 200) are almost entirely defensive duck-typing against an OpenRegister entity
+     * whose shape is not guaranteed here (`method_exists($object, 'getObject'/'getUuid')`) plus
+     * four independent early-return guards that each mean "this record is already correct, skip
+     * it". Every branch is a flat guard clause; there is no nesting to extract.
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) See the CyclomaticComplexity note above — the 217
+     * paths are the product of those same independent guard clauses, not real logic depth.
      */
     private function refreshOne(
         object $objectService,

--- a/lib/Controller/ContactpersonenController.php
+++ b/lib/Controller/ContactpersonenController.php
@@ -273,6 +273,13 @@ class ContactpersonenController extends Controller
      *
      * @spec openspec/specs/contactpersonen-api/spec.md
      * @spec openspec/changes/method-decomposition/tasks.md#task-5
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) 187 lines (threshold 100). Most of the body
+     * is the multi-line, named-argument `JSONResponse` error payloads this codebase's phpcs rules
+     * mandate — one argument per line — for each distinct failure mode of the convert flow. The
+     * method is still longer than it should be and SHOULD be decomposed further (task 5 of
+     * `method-decomposition` already carved out the permission check); that is a deliberate
+     * follow-up rather than something to smuggle into a quality-gate-only change.
      */
     public function convertToUser(string $contactpersoonId): JSONResponse
     {

--- a/lib/Controller/GebruikController.php
+++ b/lib/Controller/GebruikController.php
@@ -214,6 +214,13 @@ class GebruikController extends Controller
      * @spec openspec/changes/method-decomposition/tasks.md#task-9-3
      * @spec openspec/specs/vendor-visibility-rbac/spec.md#requirement-aanbod-beheerder-vendor-reads-of-gebruik-koppeling-objects-must-be-scoped-to-the-vendor-s-own-offered-products-req-002
      * @spec openspec/specs/vendor-visibility-rbac/spec.md#requirement-gebruik-beheerder-reads-of-gebruik-objects-must-be-scoped-to-the-caller-s-own-organisation-req-003
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 12 (threshold 10). This method IS
+     * the RBAC decision table: one explicit branch per caller role (admin/ambtenaar bypass,
+     * aanbod-beheerder vendor scope, gebruik-beheerder organisation scope) plus the empty-scope
+     * guards that make each branch fail closed. Splitting the table across helpers would move the
+     * branches out of sight of the reader auditing that no role falls through to an unscoped
+     * query — which is exactly the bug (`discovery.md` finding 2) this method was written to fix.
      */
     private function applyAanbodScopeToOptions(array $roles, array $options): ?array
     {

--- a/lib/Controller/PublicationController.php
+++ b/lib/Controller/PublicationController.php
@@ -140,6 +140,16 @@ class PublicationController extends Controller
      * @return JSONResponse|null Error response, or null when authorized.
      *
      * @spec openspec/specs/open-data-publishing/spec.md
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 11 (threshold 10). Every branch is
+     * an independent fail-closed IDOR guard — not logged in, entry not found, entry is a
+     * federated peer mirror, caller is not admin, caller's organisation does not own the entry —
+     * each returning its own JSONResponse. Collapsing them would either merge distinct refusal
+     * reasons or hide a guard behind a helper, both of which make the authorization path harder
+     * to audit than the complexity score is worth.
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) NPath 384 (threshold 200) is the product of those
+     * same independent guard clauses; the guards are sequential and flat, not deeply nested.
      */
     private function authorizeEntry(string $objectType, string $uuid): ?JSONResponse
     {

--- a/lib/Repair/InitializeSettings.php
+++ b/lib/Repair/InitializeSettings.php
@@ -71,6 +71,14 @@ class InitializeSettings implements IRepairStep
      *
      * @return void
      * @spec   openspec/specs/repair-init/spec.md
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 11 (threshold 10). A repair step
+     * runs at install/upgrade time with no user session and must never abort the upgrade, so the
+     * body is a sequence of independent "is this piece already present / still resolvable?"
+     * checks, each with its own tolerated-failure branch that reports to `IOutput` and continues.
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) NPath 385 (threshold 200) — the product of those
+     * independent tolerated-failure checks, not nested logic.
      */
     public function run(IOutput $output): void
     {

--- a/lib/Service/ContractApprovalService.php
+++ b/lib/Service/ContractApprovalService.php
@@ -46,6 +46,13 @@ use RuntimeException;
  * Raises and projects contract approval decisions delegated to decidesk.
  *
  * @spec openspec/specs/contract-decision-delegation/spec.md
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Overall complexity 56 (threshold 50). This
+ * class is the fail-closed boundary to an optional cross-app dependency (decidesk): every
+ * delegation path has to check that the event contract exists, that the listener actually handled
+ * the request, and that a decision id came back, and refuse on each. Fail-open here would silently
+ * auto-approve contracts, so that defensive branching is the point of the class and the
+ * complexity is inherent rather than accidental.
  */
 class ContractApprovalService
 {
@@ -167,6 +174,11 @@ class ContractApprovalService
      * @throws RuntimeException When delegation is not available or the listener did not handle it.
      *
      * @spec openspec/specs/contract-decision-delegation/spec.md
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `$isRenewal` selects the `decisionType`
+     * (`contract-approval` vs `contract-renewal`) carried on the raised decidesk event; the
+     * fail-closed logic, persistence and return value are byte-for-byte identical on both paths.
+     * It is a payload discriminator, not a second responsibility.
      */
     public function submitForApproval(string $contractUuid, bool $isRenewal=false): string
     {

--- a/lib/Service/EolSyncService.php
+++ b/lib/Service/EolSyncService.php
@@ -120,6 +120,19 @@ class EolSyncService
      * @spec openspec/specs/eol-feed-integration/spec.md#requirement-eol-sync-runs-on-a-schedule-with-a-manual-trigger
      * @spec openspec/specs/eol-feed-integration/spec.md#requirement-the-feature-degrades-gracefully-when-the-feed-is-unavailable
      * @spec openspec/specs/eol-feed-integration/spec.md#requirement-softwarecatalog-performs-no-direct-http-to-the-eol-feed
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 13 (threshold 10). The spec
+     * requires this method to never throw: feature disabled, OpenRegister absent, register or
+     * schema unresolvable, and per-module match failures each have to degrade to a recorded
+     * "unavailable"/skipped outcome rather than propagate. Each of those is one flat guard.
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) NPath 896 (threshold 200) — the combinatorial
+     * product of those independent graceful-degradation guards, not nested logic.
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveMethodLength) 100 lines, exactly at the threshold. The
+     * resolve-config → resolve-register/schema → match → stamp → record-status sequence is one
+     * transaction whose steps all feed the single status array returned at the end; extracting
+     * the middle steps would mean threading that accumulator through helpers for no real gain.
      */
     public function run(): array
     {

--- a/lib/Service/FacetService.php
+++ b/lib/Service/FacetService.php
@@ -52,6 +52,14 @@ use RuntimeException;
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.TooManyMethods)
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassLength) 1095 lines (threshold 1000). This is a real
+ * smell, not a defensible shape: the class currently holds three separable concerns — candidate
+ * resolution + RBAC scoping, GEMMA dimension mapping via ArchiMate element lookups, and the
+ * disjunctive count aggregation. It SHOULD be split along those seams (the aggregation half in
+ * particular has no dependency on the OpenRegister/ArchiMate plumbing). Recorded here as a
+ * deliberate follow-up; splitting it is a behaviour-affecting refactor and is out of scope for a
+ * quality-gate-only change.
  */
 class FacetService
 {

--- a/lib/Service/Federation/FederationMerger.php
+++ b/lib/Service/Federation/FederationMerger.php
@@ -69,6 +69,16 @@ class FederationMerger
      *               existing local mirror data bag, marked withdrawn + stale.
      *
      * @spec openspec/specs/federated-catalog-sync/spec.md
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 11 (threshold 10). A three-way
+     * reconciliation (create / update / withdraw) over two collections is inherently branchy:
+     * each peer entry needs an id-presence guard, an ownership guard (never touch a locally-owned
+     * entry), and a no-op-equal check before it becomes an update, and each local mirror needs the
+     * inverse "still present at the peer?" check before it becomes a withdraw.
+     *
+     * @SuppressWarnings(PHPMD.NPathComplexity) NPath 255 (threshold 200) — the product of those
+     * per-entry guards, each of which exists to keep the plan idempotent and to keep
+     * locally-owned entries out of it.
      */
     public function plan(
         string $peerUrl,

--- a/lib/Service/Federation/FederationService.php
+++ b/lib/Service/Federation/FederationService.php
@@ -34,6 +34,13 @@ use Psr\Log\LoggerInterface;
 
 /**
  * Orchestrates federation by delegating to OpenCatalogi services.
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Overall complexity 84 (threshold 50) — the
+ * highest in the app. OpenCatalogi is an OPTIONAL runtime dependency, so every delegation point
+ * here is wrapped in an app-installed / service-resolvable / shape-of-response guard that has to
+ * degrade to a recorded "federation unavailable" instead of fatalling. Much of that guard code is
+ * repeated per delegated operation and SHOULD be collapsed behind a single resolver helper;
+ * noting that as a deliberate follow-up rather than claiming 84 is a healthy number.
  */
 class FederationService
 {

--- a/lib/Service/MergeOrganisatieService.php
+++ b/lib/Service/MergeOrganisatieService.php
@@ -79,6 +79,12 @@ use Psr\Log\LoggerInterface;
  *
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Coupling 15 (threshold 13). An organisation
+ * merge legitimately touches every system that can hold an organisation reference: OpenRegister
+ * objects, Nextcloud groups and users, the app's own organisation handler, the audit log
+ * (`CriticalActionPerformedEvent`), the event dispatcher and the progress tracker. The count is
+ * the breadth of the merge itself, not an accidental dependency tangle.
  */
 class MergeOrganisatieService
 {
@@ -365,6 +371,12 @@ class MergeOrganisatieService
      * @spec openspec/specs/organisation-merge/spec.md#requirement-execute-must-re-point-every-relation-type-while-preserving-every-unrelated-field-on-each-object
      *
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `commit` is the documented dry-run/execute parity gate.
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 10, exactly at the threshold. The
+     * branches are the two reference shapes a schema may use (a scalar organisation field and/or
+     * an array-of-uuid field, either of which may be absent on a given object), crossed with the
+     * dry-run/execute gate above. Splitting the scalar and array paths would duplicate the
+     * count-vs-write logic that must stay identical for dry-run/execute parity to hold.
      */
     private function repointByField(string $objectType, string $field, ?string $arrayField, string $source, string $target, bool $commit): int
     {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -7322,6 +7322,14 @@ class SettingsService
      *                                   case).
      *
      * @return array<mixed> The merged config.
+     *
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag) `$replaceLists` is not a caller-facing mode
+     * switch — it is the recursion state of this private static helper. Public callers always
+     * enter with the default `false`; the flag is set to `true` only by the recursive call once
+     * an `authorization` key has been crossed, and it stays true for that whole subtree. Turning
+     * it into two methods would mean duplicating the merge for the sole purpose of removing a
+     * parameter that no external caller ever passes, and would make the fail-open trap this flag
+     * exists to close (softwarecatalog#375) easier to reintroduce.
      */
     private static function deepMergeConfig(array $base, array $overlay, bool $replaceLists=false): array
     {

--- a/lib/Service/SoftwareCatalogContactSyncService.php
+++ b/lib/Service/SoftwareCatalogContactSyncService.php
@@ -42,6 +42,13 @@ use RuntimeException;
  * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  GIT: <git_id>
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Overall complexity 56 (threshold 50). The
+ * class maps several distinct softwarecatalog relationship types (organisation, contactpersoon,
+ * …) onto Nextcloud's vCard contact model, and each mapping needs per-field presence checks
+ * because the legacy identity fields are optional and inconsistently populated across records.
+ * The Contacts API is also an optional dependency, so every entry point carries an availability
+ * guard. Both are breadth of mapping rather than depth of logic.
  */
 class SoftwareCatalogContactSyncService
 {
@@ -213,6 +220,12 @@ class SoftwareCatalogContactSyncService
      * @return ?array<string, mixed> The matched contact, or null.
      *
      * @spec openspec/specs/softwarecatalog-contacts-to-nc/spec.md
+     *
+     * @SuppressWarnings(PHPMD.CyclomaticComplexity) Complexity 10, exactly at the threshold. The
+     * branches are the documented identity-match cascade: Contacts API availability, then e-mail,
+     * then — for organisations only — CBS and KvK code as fallbacks, each with an
+     * empty/absent-value guard so a blank legacy field can never match an unrelated contact. The
+     * cascade order is the specified behaviour and is clearer read top-to-bottom in one method.
      */
     public function findContactForRecord(string $objectType, array $record): ?array
     {

--- a/lib/Service/SoftwareCatalogue/GroupHandler.php
+++ b/lib/Service/SoftwareCatalogue/GroupHandler.php
@@ -44,6 +44,12 @@ use RuntimeException;
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @SuppressWarnings(PHPMD.CamelCaseParameterName)
+ *
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Overall complexity 53 (threshold 50). Group
+ * management is the app's RBAC surface: every operation has to verify the group exists, that the
+ * user exists, that the caller is allowed to change that membership, and that the derived
+ * organisation groups stay consistent — and each of those has to fail closed rather than silently
+ * no-op. The branching is authorization checking, which is exactly where it belongs in view.
  */
 class GroupHandler
 {


### PR DESCRIPTION
Replays the intent of Codeberg `Conduction/softwarecatalog` #99 onto GitHub, which is canonical. Codeberg's `development` is a **stale mirror — 121 commits behind, and diverged** (it carries 1 commit GitHub does not). The fixes were re-measured on this base and ported; the diff was **not** cherry-picked.

## What was already fixed here

Most of #99's debt does not exist on the GitHub base:
- **phpcs: clean**, **psalm: clean** (97 files, 84.4% type inference), **phpstan: clean** (`[OK] No errors`)
- **composer.json `check:strict` scripts are already un-masked**
- the 13 `ElseExpression` suppressions #99 added are **not needed here** — that finding does not occur on this base

## What actually remained

**phpmd only — 24 findings across 15 files.** All suppressed at the site with the reason recorded next to each; **136 added comment lines, zero deletions**. `phpmd.xml` and `phpmd.baseline.xml` are **untouched** — nothing was swept into a baseline, and no threshold was loosened. No behaviour changed.

The write-ups distinguish two genuinely different cases rather than defending everything equally:

**Inherent complexity** (the branching *is* the feature) — `PublicationController::authorizeEntry`, `GebruikController::applyAanbodScopeToOptions`, `ContractApprovalService`, `SettingsService::deepMergeConfig`, `EolSyncService::run`, `FederationMerger::plan`, `InitializeSettings::run`, `OrganizationContactSyncJob::refreshOne`, `MergeOrganisatieService`, `SoftwareCatalogContactSyncService`, `GroupHandler`.

**Acknowledged debt** — suppressed but written up plainly as follow-up work, *not* claimed to be healthy:
- `Application::registerDomainServices` — 498 lines of flat DI wiring; should be split into per-domain registrars
- `FacetService` — 1095 lines, three separable concerns
- `FederationService` — complexity 84, the highest in the app; the repeated optional-OpenCatalogi guards should collapse behind one resolver
- `ContactpersonenController::convertToUser` — 187 lines

Two justifications were checked against the code rather than asserted: `$isRenewal` only selects `decisionType` (both paths otherwise identical), and `deepMergeConfig`'s sole external call site uses the default while only the recursive call passes `$replaceLists` true.

## Proof

- `composer check:strict` exits **0** on **PHP 8.3**, fresh `composer install` (no copied `vendor/`)
- `test:all` **skips loudly and correctly** — the suite needs a Nextcloud runtime and guards on `../../lib/base.php`. That skip was left exactly as it is; it was not converted into a hard failure or a silent pass.
- **Positive control (run twice, on two different suppressions):** removing `FacetService`'s `ExcessiveClassLength` → phpmd exit **2**; independently, removing `FederationService`'s `ExcessiveClassComplexity` → phpmd exit **2** naming the file and the figure 84, **as the sole finding** — which also demonstrates the other 23 suppressions are live and load-bearing, not decorative. Both restored; phpmd back to **0** and `git status` clean.

## Two notes for whoever does this on the rest of the fleet

1. **A phpcs trap.** `Generic.Commenting.DocComment.TagValueIndent` aligns tag values within each blank-line-separated tag group, so two adjacent `@SuppressWarnings` tags with trailing justifications error with *"expected 6 spaces but found 1"*. Separate each into its own tag group with a blank `*` line.
2. **Three findings sit exactly at the threshold**, not above it (`repointByField` CC 10/10, `findContactForRecord` CC 10/10, `EolSyncService::run` 100/100 lines) — phpmd fires at `>=`. Those three are one small refactor away from clearing on their own.

## Unrelated, but surfaced during the push

GitHub reports **151 dependabot vulnerabilities on this repo's default branch (5 critical, 49 high)**. Not addressed here — flagging it because it is worth a separate look.