### PR TITLE
feat(schema): mark the GEMMA AMEF Element reference component shareable for federated config sharing

### DIFF
--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -3985,7 +3985,7 @@
         "slug": "element",
         "title": "Element",
         "description": "AMEF Element - Architectuur elementen uit het ArchiMate model",
-        "version": "0.0.10",
+        "version": "0.0.11",
         "summary": "",
         "icon": "Cube",
         "required": [
@@ -5145,7 +5145,8 @@
         "configuration": {
           "objectNameField": "name",
           "objectSummaryField": "summary",
-          "objectDescriptionField": "documentation"
+          "objectDescriptionField": "documentation",
+          "x-openregister-shareable": true
         }
       },
       "view": {


### PR DESCRIPTION
**Rescued from Codeberg before the remote is removed.**

Landed on `codeberg.org/Conduction/softwarecatalog` as `5f728a11` (PR #98, 2026-07-26); never reached GitHub. Part of the 2026-07-26 *federated-config-sharing* wave, which six repos merged only on Codeberg.

Absence on GitHub verified across all 122 `origin` refs, not just `development`:

    git grep -l 'x-openregister-shareable' <gh_dev> --   ->  (empty)

## Only the hunk, not the file — and this repo shows why

GitHub's register is at `info.version` **2.4.3**; Codeberg is still on **2.4.2** and still carries the pre-English schema titles (`"Dienst"`, `"Kwetsbaarheid"`) that GitHub already re-authored. Taking the Codeberg file wholesale would have reverted the whole 2.4.3 title pass — a silent regression dressed as a rescue.

    gh 0.0.11 {..., 'x-openregister-shareable': True}
    cb 0.0.11 {..., 'x-openregister-shareable': True}
    MATCH
    shareable schemas: gh 1  cb 1
    register version preserved (gh newer): 2.4.3 vs cb 2.4.2