### PR TITLE
ci(quality): restore the missing push trigger — SBOM, Features Extract and the coverage ratchet have not run since March

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,33 @@
 name: Code Quality
 
 on:
+  # ⚠️ The `push:` trigger was MISSING from this workflow, and it is the only
+  # repo in the fleet where that was true (checked against all 22 others; every
+  # one of them carries this same list).
+  #
+  # Three jobs in the shared quality workflow run ONLY on `push`:
+  #
+  #   SBOM                    `github.ref` must be main/beta/development
+  #   Features Extract        `github.event_name != 'pull_request'`
+  #   Coverage Baseline Check `github.event_name == 'push'`
+  #
+  # With no push trigger, none of them could ever fire here. The last push run
+  # on `development` is 23289135240, from **2026-03-19** — five months of
+  # merges during which the SBOM was never regenerated, `docs/features.json`
+  # was never checked against `openspec/specs/`, and the coverage ratchet never
+  # ran.
+  #
+  # This is the hardest version of the problem to see: the inputs all say
+  # `true`, the PR checks are green, and the Quality Report on every PR looks
+  # complete — because on a PR those three jobs are *correctly* skipped. There
+  # is no red, no skip anyone would question, and no run at all to inspect. You
+  # can only find it by asking what the LAST PUSH RUN was, which nothing
+  # prompts you to do.
+  #
+  # `enable-coverage-guard` was switched on here in the previous commit; without
+  # this trigger its push-side half would have been dead on arrival.
+  push:
+    branches: [main, beta, development, feature/**, bugfix/**, hotfix/**]
   pull_request:
     branches: [main, beta, development]
 


### PR DESCRIPTION
## What

Adds the missing `push:` trigger to this repo's Code Quality workflow.

## The gate that was dark

`.github/workflows/code-quality.yml` here had **only** a `pull_request:` trigger.
It is the **only repo in the fleet** where that is true — I checked the other 22
callers and every one of them carries the same `push:` branch list.

Three jobs in the shared quality workflow run **only** on `push`:

| job | its condition |
|---|---|
| `SBOM` | `github.ref` must be `main` / `beta` / `development` |
| `Features Extract` | `github.event_name != 'pull_request'` |
| `Coverage Baseline Check` | `github.event_name == 'push'` |

With no push trigger, none of them could ever fire. **The last push run on
`development` is [23289135240](https://github.com/ConductionNL/softwarecatalog/actions/runs/23289135240), from 2026-03-19** — five months of merges in which
the SBOM was never regenerated, `docs/features.json` was never checked against
`openspec/specs/`, and the coverage ratchet never ran.

## Why this one was hard to see

Every other dark gate in this sweep was visible in the caller's inputs: an
`enable-*` sitting at `false`. This one is not.

- The inputs all say `true`.
- Every PR check is green.
- The Quality Report on every PR looks **complete** — because on a `pull_request`
  those three jobs are *correctly* skipped, exactly as they are in a healthy repo.

There is no red, no suspicious skip, and no run to inspect. The only way to find
it is to ask *"when did a push run last happen here?"* — and nothing prompts you
to ask that. It is the fleet's own "a check's absence looks exactly like its
success", one level below the inputs everyone reads.

## Sequencing

`enable-coverage-guard: true` was added here in the previous commit
(#430). Without this trigger its push-side half would have been dead on arrival:
`Coverage Baseline Protection` would pass on every PR while
`Coverage Baseline Check` never ran at all.

## Expect this first push run to be noisy, and that is the point

Three jobs are about to run for the first time in five months:

- **SBOM** — regenerated and CVE-scanned against five months of dependency drift.
- **Features Extract** — hard-fails if `docs/features.json` is stale, which after
  five months is likely.
- **Coverage Baseline Check** — first execution of the ratchet against the
  `13.01` baseline committed in #430.

Any of those going red is a five-month-old fact becoming visible, not a
regression introduced here.

⚠️ Note on the third one: if it fails it will tell you to fetch the recomputed
value from a `coverage-baseline` artifact. **That artifact does not exist** —
`.coverage-baseline` is a dotfile and `actions/upload-artifact@v4` skips hidden
files by default. Fixed fleet-wide in ConductionNL/.github#156; until that
merges, read the number from `clover.xml` in the `coverage-report` artifact of
the **push run on `development`** (not merely the newest artifact — that is how
docudesk and portaliq got wrong values, see ConductionNL/docudesk#379 and
ConductionNL/portaliq#39).
