### PR TITLE
chore(deps): repin @conduction/nextcloud-vue to 2.2.0-vue3.3 (3.0.0-vue3.6 was unpublished)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@codemirror/lang-json": "^6.0.0",
-        "@conduction/nextcloud-vue": "3.0.0-vue3.6",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.3",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/auth": "^2.6.0",
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "3.0.0-vue3.6",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-3.0.0-vue3.6.tgz",
-      "integrity": "sha512-6x8VapVLF22eCQB+CdoC1OkB3oLiIM31OceexDrvu/L++8Z5HYV2X3Xcgl8ZGy29jcqbtrjDNaZ5WbaDrzm8fA==",
+      "version": "2.2.0-vue3.3",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
+      "integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.29.0",
     "@codemirror/lang-json": "^6.0.0",
-    "@conduction/nextcloud-vue": "3.0.0-vue3.6",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.3",
     "@fortawesome/fontawesome-svg-core": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@nextcloud/auth": "^2.6.0",


### PR DESCRIPTION
## Why

`@conduction/nextcloud-vue` `3.0.0-vue3.1` … `3.0.0-vue3.6` were **unpublished from npm**, and npm never permits reuse of an unpublished version number — so the old pin is permanently dead:

```
$ npm view @conduction/nextcloud-vue@3.0.0-vue3.6 version
npm error code E404 — No match found for version 3.0.0-vue3.6
```

`npm ci` therefore **cannot succeed on `development`**. Fleet-blocking.

## What

| | |
|---|---|
| Old pin | `3.0.0-vue3.6` — **dead (E404)** |
| New pin | `2.2.0-vue3.3` — live, current `vue3` dist-tag |
| Dead refs in `package-lock.json` | 3 → **0** |

Pinned exactly (no caret), per fleet convention.

## Verification

- **Lockfile regenerated with npm 10.8.2**, not local npm 11. CI runs node 20 / npm 10; an npm-11-written lockfile prunes platform-inapplicable optional entries, making CI's `npm ci` fail `Missing: … from lock file` while a *local* `npm ci` still passes. Using npm 10 avoids that false green.
- **Cold `npm ci`** (fresh isolated cache, npm 10.8.2): **exit 0**, zero `Missing:` lines.
- **Build** `USE_LOCAL_LIB=false npm run build`: **exit 0**, 0 `Module not found`, 0 `export … was not found`. (`USE_LOCAL_LIB=false` matters — `webpack.config.js` aliases the package to a sibling `../nextcloud-vue/src` checkout when present, so a plain build can compile the sibling and prove nothing about the pin.)
- **Unit tests** — both suites in this repo:
  - `npm run test:unit` (vitest): **18 files / 210 tests passing**
  - `npm test` (jest): **9 suites / 120 tests passing**
  A "before" run is **impossible** — `npm ci` cannot install the dead pin, so no baseline number exists to compare against.
- **UI-surface check**: all **27** identifiers `src/` imports from `@conduction/nextcloud-vue` resolve against the installed 2.2.0-vue3.3 (574 exports, counting the `export * from '@nextcloud/vue'` re-export in nc-vue's ESM entry). Run with a sentinel positive control to confirm the checker can actually report a miss. The 2.x line is a **renumbering of the same lineage**, so the surface is a superset — nothing lost.

## Scope

Only `package.json` + `package-lock.json`. The bundle is gitignored here (no tracked `js/`/`dist/`). E2E (`playwright`) not run — needs a live Nextcloud instance.