### PR TITLE
ci(quality): move hydra-gates-ref v1.0.1 -> v1.3.0, which is what is failing CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -141,5 +141,33 @@ jobs:
       # cannot move this repo's verdict without a commit here.
       # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
       # serious/critical violations from core's own UI.
+      #
+      # v1.0.1 -> v1.3.0 (ConductionNL/.github#159). Two defects, one bump.
+      #
+      # 1. STALE. v1.0.1 is `f4d9756` (2026-08-03) and predates three gate
+      #    fixes, so every Hydra Gates run this repo has ever made executed a
+      #    script in which 16 gates reported PASS when their helper never ran
+      #    (#147), gate-33 had no axe report to read and never said so (#148),
+      #    and gates 6 and 7 reported PASS on an EMPTY scope (#149). A gate
+      #    that reports PASS without running emits a tick identical to a real
+      #    one, which is why nothing in this repo's history shows it.
+      #
+      # 2. RED. quality.yml is referenced `@main` while this package is
+      #    PINNED, so the two can desync — and on 2026-08-05 they did. #164
+      #    flipped `hydra-gates-require-full-coverage` to default TRUE, but
+      #    the accounting that makes that flag survivable (NOT APPLICABLE, as
+      #    distinct from a structural or a wiring gap) ships in the PACKAGE.
+      #    So every pin older than `f7eaf2a` now fails the coverage assertion
+      #    for gates it has no subject matter for. Measured diff-scoped,
+      #    exactly as CI scopes it:
+      #      v1.0.1  exit 98  FAIL — "GATES THAT DID NOT RUN: 24 33"
+      #      v1.3.0  exit 0   PASS — those gates named NOT APPLICABLE
+      #    The old pin was not merely stale, it was failing this repo's CI for
+      #    a reason that had nothing to do with this repo — and it is what is
+      #    currently blocking #434.
+      #
+      # v1.3.0 is `f7eaf2a` = .github@main, tagged so the ref stays
+      # reproducible and a later gate change cannot move this repo's verdict
+      # without a commit here.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.0.1
+      hydra-gates-ref: v1.3.0


### PR DESCRIPTION
One line: `hydra-gates-ref: v1.0.1` -> `v1.3.0`.

## This repo's CI is red right now, and it is not this repo's fault

At **2026-08-05T13:52Z**, `ConductionNL/.github` commit `f7eaf2a` (#164) flipped `hydra-gates-require-full-coverage` to **default `true`** in the shared `quality.yml`. Every repo references that workflow at `@main`, so the flip went live everywhere at once. But the flag requires a gate to **declare itself** not-applicable — and that vocabulary ships in the **pinned package**:

| | `_skip` calls |
|---|---|
| `v1.0.1` (this repo's pin) | **0** |
| `v1.3.0` | **36** |

A pin with no `_skip` calls cannot say "not applicable". So every gate without subject matter here — 4 (composer-audit, correctly diff-scoped out per ADR-020), 24 (integration-parity), 33 (axe-core, whose producer `enable-axe` is deliberately off) — became `DID NOT RUN` and failed the job.

**The red is fleet-wide, dated, and caused by a shared-workflow flag meeting a pinned script that predates the vocabulary it needs.** It is not a code defect and not anything a PR author did. The control that settles it: decidesk#407 is PHPMD-only with zero npm changes and shows the identical failure, and it *passed* on pre-13:52Z base runs — the base is a different vintage of the shared workflow, not of the code.

## The pin was also four fixes stale

`v1.0.1` is `f4d9756` (2026-08-03). Every Hydra Gates run this repo has ever made executed a script in which:

| PR | what it fixed | in `v1.0.1`? |
|---|---|---|
| [#147](https://github.com/ConductionNL/.github/pull/147) | **16 gates reported PASS when their helper never ran** | ❌ |
| [#148](https://github.com/ConductionNL/.github/pull/148) | gate-33 had no axe report to read, and never said so | ❌ |
| [#149](https://github.com/ConductionNL/.github/pull/149) | gates 6 and 7 reported PASS on an **empty scope** | ❌ |
| [#162](https://github.com/ConductionNL/.github/pull/162) | gate-5 reported a resolution failure as a security finding | ❌ |

A gate that reports PASS without running emits a tick identical to a real one, which is why nothing in this repo's history shows the difference. Tracked in [.github#159](https://github.com/ConductionNL/.github/issues/159).

## Measured before opening this PR

Diff-scoped against `origin/development`, exactly as CI scopes it. Each run in its **own mount namespace with a private tmpfs** — the runner writes ~50 detail logs to hardcoded `/tmp/hydra-gate-<name>.log` paths and reads its verdicts back out of them, so two concurrent runs on one host silently corrupt each other's counts ([.github#158](https://github.com/ConductionNL/.github/issues/158) item 6). Another agent was running the gates unisolated on the same host during this work, so that is not hypothetical.

```
v1.0.1   exit 98   FAIL — "GATES THAT DID NOT RUN: 24 33"
v1.3.0   exit 0    PASS — ALL 58 APPLICABLE GATES PASSED, and all 58 ran
                          NOT APPLICABLE: 4 6 7 24 33 — each with a reason
```

Verified not merely that the job is green but that gates 4, 24 and 33 each **name themselves** not-applicable and say why. A green that came from somewhere else would not be the fix landing.

Independently confirmed end-to-end by [doriath#160](https://github.com/ConductionNL/doriath/pull/160), which changed this same single line and nothing else: Hydra Gates went **failure -> success**.

`v1.3.0` is `f7eaf2a` = `.github@main` at the time it was cut.

Refs ConductionNL/.github#159
