### PR TITLE
chore: normalise all licence declarations to EUPL-1.2

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @package  OCA\SoftwareCatalog
  * @version  1.0.0
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  */
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <!--

--- a/src/components/AlwaysVisibleSection.vue
+++ b/src/components/AlwaysVisibleSection.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -107,7 +107,7 @@ import Information from 'vue-material-design-icons/Information.vue'
  * Always shows content without toggle functionality
  *
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  */
 export default defineComponent({

--- a/src/components/CollapsibleSection.vue
+++ b/src/components/CollapsibleSection.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -128,7 +128,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/components/SelectedObjectsList.vue
+++ b/src/components/SelectedObjectsList.vue
@@ -3,7 +3,7 @@
  * @module Components
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/components/StandardTabs.vue
+++ b/src/components/StandardTabs.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -45,7 +45,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/components/cards/OrganisatieCard.vue
+++ b/src/components/cards/OrganisatieCard.vue
@@ -5,7 +5,7 @@
  * @package softwarecatalog
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  * @link https://github.com/opencatalogi/softwarecatalog
  */

--- a/src/components/contracts/ContractApprovalPanel.vue
+++ b/src/components/contracts/ContractApprovalPanel.vue
@@ -1,6 +1,6 @@
 <!--
   - SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
-  - SPDX-License-Identifier: AGPL-3.0-or-later
+  - SPDX-License-Identifier: EUPL-1.2
   -->
 <template>
 	<CnWidgetWrapper
@@ -78,7 +78,7 @@ import Autorenew from 'vue-material-design-icons/Autorenew.vue'
  * @class ContractApprovalPanel
  * @module Components/Contracts
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * Read-only Approval panel for the ContractDetail page sidebar. It surfaces the
  * `approvalState` PROJECTION of the decidesk outcome and offers the

--- a/src/components/organisations/OrganisationSwitcher.vue
+++ b/src/components/organisations/OrganisationSwitcher.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <!--

--- a/src/components/organisations/organisationSwitcher.js
+++ b/src/components/organisations/organisationSwitcher.js
@@ -6,7 +6,7 @@
  * @module components/organisations/organisationSwitcher
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/multi-org-membership/spec.md#requirement-the-organisation-switcher-must-list-only-the-authenticated-user-s-own-organisations-req-003
  */

--- a/src/components/reviews/ReviewsPanel.vue
+++ b/src/components/reviews/ReviewsPanel.vue
@@ -1,6 +1,6 @@
 <!--
   - SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
-  - SPDX-License-Identifier: AGPL-3.0-or-later
+  - SPDX-License-Identifier: EUPL-1.2
   -
   - Ratings & reviews body widget (softwarecatalog#375) — registered via
   - src/customComponents.js and placed on ModuleDetail's `bodyWidgets`

--- a/src/composables/orClient.js
+++ b/src/composables/orClient.js
@@ -23,7 +23,7 @@
  * @module composables/orClient
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/changes/softwarecatalog-adopt-or-abstractions/tasks.md#3.1
  */

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 
 /**

--- a/src/modals/AddContactpersoonModal.vue
+++ b/src/modals/AddContactpersoonModal.vue
@@ -6,7 +6,7 @@ Modal component for adding new contactpersoon to an organisation
 @package softwarecatalog
 @author Ruben Linde
 @copyright 2024
-@license AGPL-3.0-or-later
+@license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
 @version 1.0.0
 @link https://github.com/opencatalogi/softwarecatalog
 -->

--- a/src/modals/BulkSyncDialog.vue
+++ b/src/modals/BulkSyncDialog.vue
@@ -143,7 +143,7 @@ import {
  *
  * @author   Conduction b.v. <info@conduction.nl>
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  */
 export default defineComponent({

--- a/src/modals/GrantOrganisationAccessModal.vue
+++ b/src/modals/GrantOrganisationAccessModal.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <!--

--- a/src/modals/SubmitReviewModal.vue
+++ b/src/modals/SubmitReviewModal.vue
@@ -1,6 +1,6 @@
 <!--
   - SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
-  - SPDX-License-Identifier: AGPL-3.0-or-later
+  - SPDX-License-Identifier: EUPL-1.2
   -
   - Submit-a-review modal (softwarecatalog#375). Own file per ADR-012
   - (modals live in their own component). Collects a title, a 1-10 rating,

--- a/src/modals/grantOrganisationAccess.js
+++ b/src/modals/grantOrganisationAccess.js
@@ -7,7 +7,7 @@
  * @module modals/grantOrganisationAccess
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/multi-org-membership/spec.md#requirement-granting-access-must-only-target-an-existing-nextcloud-user-req-005
  */

--- a/src/modals/object/ChangeOrganisatieStatusDialog.vue
+++ b/src/modals/object/ChangeOrganisatieStatusDialog.vue
@@ -5,7 +5,7 @@
  * @package softwarecatalog
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  * @link https://github.com/opencatalogi/softwarecatalog
  */

--- a/src/modals/object/MassDeleteObject.vue
+++ b/src/modals/object/MassDeleteObject.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassDepublishObjects.vue
+++ b/src/modals/object/MassDepublishObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassLockObjects.vue
+++ b/src/modals/object/MassLockObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassPublishObjects.vue
+++ b/src/modals/object/MassPublishObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassUnlockObjects.vue
+++ b/src/modals/object/MassUnlockObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/MassValidateObjects.vue
+++ b/src/modals/object/MassValidateObjects.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/modals/object/ViewObject.vue
+++ b/src/modals/object/ViewObject.vue
@@ -3,7 +3,7 @@
  * @module Modals/Object
  * @author Your Name
  * @copyright 2024 Your Organization
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version 1.0.0
  */
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
 // 5-kind component registry for v2 manifest (per hydra ADR-036).

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
 // Router builder for softwarecatalog's manifest-driven app shell.

--- a/src/store/modules/object.js
+++ b/src/store/modules/object.js
@@ -11,7 +11,7 @@
  * @module Store
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 2.0.0
  * @see {@link https://github.com/opencatalogi/softwarecatalog}
  *

--- a/src/store/modules/organisatie.js
+++ b/src/store/modules/organisatie.js
@@ -6,7 +6,7 @@
  * @package
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  * @see https://github.com/opencatalogi/softwarecatalog
  */

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -12,7 +12,7 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
  * - Register and schema management
  *
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  */
 export const useSettingsStore = defineStore('settings', {

--- a/src/store/plugins/softwarecatalogPlugin.js
+++ b/src/store/plugins/softwarecatalogPlugin.js
@@ -8,7 +8,7 @@
  * @module softwarecatalogPlugin
  * @author Ruben Linde
  * @copyright 2024
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/softwarecatalog-store-migration/spec.md#requirement-plugin-shape-for-app-specific-extensions
  */

--- a/src/utils/adminApi.js
+++ b/src/utils/adminApi.js
@@ -13,7 +13,7 @@
  * @spec openspec/specs/open-data-publishing/spec.md
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 const API_BASE = '/index.php/apps/softwarecatalog/api'

--- a/src/utils/complianceMatrix.js
+++ b/src/utils/complianceMatrix.js
@@ -36,7 +36,7 @@
  * @module utils/complianceMatrix
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/module-compliance-assessment/spec.md
  * @spec openspec/specs/bio-compliance-assessment/spec.md

--- a/src/utils/contractCost.js
+++ b/src/utils/contractCost.js
@@ -16,7 +16,7 @@
  * @module utils/contractCost
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/contract-administration/spec.md
  */

--- a/src/utils/heartbeat.js
+++ b/src/utils/heartbeat.js
@@ -5,7 +5,7 @@
  * keep-alive requests during long operations.
  *
  * @author Conduction B.V. <info@conduction.nl>
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/utils/lifecyclePhase.js
+++ b/src/utils/lifecyclePhase.js
@@ -19,7 +19,7 @@
  * @module utils/lifecyclePhase
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/application-lifecycle-tracking/spec.md
  */

--- a/src/utils/moderationItem.js
+++ b/src/utils/moderationItem.js
@@ -10,7 +10,7 @@
  * @spec openspec/specs/open-data-publishing/spec.md
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 const TITLE_FIELDS = ['naam', 'name', 'titel', 'title', 'organisatie', 'organisation']

--- a/src/utils/openDataProjection.js
+++ b/src/utils/openDataProjection.js
@@ -22,7 +22,7 @@
  * @module utils/openDataProjection
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/specs/open-data-publishing/spec.md
  */

--- a/src/utils/reviewAggregate.js
+++ b/src/utils/reviewAggregate.js
@@ -8,7 +8,7 @@
  * @spec openspec/specs/catalog-ratings/spec.md#requirement-module-and-dienst-detail-pages-must-display-an-aggregate-rating-computed-only-from-approved-reviews
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 /**

--- a/src/utils/reviewForm.js
+++ b/src/utils/reviewForm.js
@@ -11,7 +11,7 @@
  * @spec openspec/specs/catalog-ratings/spec.md#requirement-the-submitting-users-identity-must-be-bound-server-side-and-must-not-be-accepted-from-client-input
  *
  * SPDX-FileCopyrightText: 2026 Conduction B.V. <info@conduction.nl>
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  */
 
 /**

--- a/src/utils/translationBadge.js
+++ b/src/utils/translationBadge.js
@@ -14,7 +14,7 @@
  * @module utils/translationBadge
  * @author Ruben Linde
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * @spec openspec/changes/softwarecatalog-adopt-or-abstractions/tasks.md#3.5
  */

--- a/src/views/ComplianceMatrixView.vue
+++ b/src/views/ComplianceMatrixView.vue
@@ -174,7 +174,7 @@ import CheckboxMarkedCircleOutline from 'vue-material-design-icons/CheckboxMarke
  * @class ComplianceMatrixView
  * @module Views
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * Filter-first compliance matrix: modules × a selected column source
  * (GEMMA standard versions, or — since bio-compliance-assessment — BIO 2.0

--- a/src/views/LifecycleRoadmapView.vue
+++ b/src/views/LifecycleRoadmapView.vue
@@ -106,7 +106,7 @@ const EOL_WINDOW_DAYS = 180
  * @class LifecycleRoadmapView
  * @module Views
  * @copyright 2026 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  *
  * Per-organisation portfolio roadmap: the organisation's gebruiken grouped by
  * derived lifecycle phase (incl. Onbekend, rendered first), ordered within a

--- a/src/views/organisaties/OrganisatieIndex.vue
+++ b/src/views/organisaties/OrganisatieIndex.vue
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
 <!-- Copyright (C) 2026 Conduction B.V. -->
 
 <!--

--- a/src/views/settings/SoftwareCatalogSettings.vue
+++ b/src/views/settings/SoftwareCatalogSettings.vue
@@ -140,7 +140,7 @@ import AlwaysVisibleSection from '../../components/AlwaysVisibleSection.vue'
  * Software Catalog Settings component
  *
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  */
 export default defineComponent({

--- a/src/views/settings/sections/ArchiMateImportExport.vue
+++ b/src/views/settings/sections/ArchiMateImportExport.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
 -->
 
 <template>
@@ -418,7 +418,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 2.0.0
  */
 

--- a/src/views/settings/sections/CronjobConfiguration.vue
+++ b/src/views/settings/sections/CronjobConfiguration.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2024 Conduction B.V. <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -134,7 +134,7 @@
  *
  * @author Conduction B.V. <info@conduction.nl>
  * @copyright 2024 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/views/settings/sections/EmailConfiguration.vue
+++ b/src/views/settings/sections/EmailConfiguration.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -413,7 +413,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/views/settings/sections/EolSyncSettings.vue
+++ b/src/views/settings/sections/EolSyncSettings.vue
@@ -1,6 +1,6 @@
 <!--
  - @copyright Copyright (c) 2026 Conduction B.V. <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
  - EOL feed sync admin section: configure the register/schema names the
  - matcher reads `eolProduct`/`eolCycle` from (provisioned by the sibling

--- a/src/views/settings/sections/FederationSettings.vue
+++ b/src/views/settings/sections/FederationSettings.vue
@@ -1,6 +1,6 @@
 <!--
  - @copyright Copyright (c) 2026 Conduction B.V. <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
  - Federation settings admin section: view federation availability + the
  - configured peers, add/remove a peer (subject to the server-side SSRF

--- a/src/views/settings/sections/ModerationQueue.vue
+++ b/src/views/settings/sections/ModerationQueue.vue
@@ -1,6 +1,6 @@
 <!--
  - @copyright Copyright (c) 2026 Conduction B.V. <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
  - Moderation queue admin section: lists entries of `type` awaiting moderation
  - (organisatie: registratiestatus=pending, default; beoordeeling:

--- a/src/views/settings/sections/OpenRegisterIntegration.vue
+++ b/src/views/settings/sections/OpenRegisterIntegration.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -167,7 +167,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/views/settings/sections/OrganizationSynchronization.vue
+++ b/src/views/settings/sections/OrganizationSynchronization.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -341,7 +341,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/views/settings/sections/StatisticsOverview.vue
+++ b/src/views/settings/sections/StatisticsOverview.vue
@@ -126,7 +126,7 @@ import SyncIcon from 'vue-material-design-icons/Sync.vue'
  * Displays object counts for all configured registers
  *
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2
  * @version  1.0.0
  */
 export default defineComponent({

--- a/src/views/settings/sections/UserGroupsConfiguration.vue
+++ b/src/views/settings/sections/UserGroupsConfiguration.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -278,7 +278,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/src/views/settings/sections/VersionInformation.vue
+++ b/src/views/settings/sections/VersionInformation.vue
@@ -1,19 +1,19 @@
 <!--
  - @copyright Copyright (c) 2023 Ruben Linde <info@conduction.nl>
- - @license AGPL-3.0-or-later
+ - @license EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - This program is free software: you can redistribute it and/or modify
- - it under the terms of the GNU Affero General Public License as
- - published by the Free Software Foundation, either version 3 of the
- - License, or (at your option) any later version.
+ - Licensed under the EUPL, Version 1.2 or – as soon they will be approved by
+ - the European Commission – subsequent versions of the EUPL (the "Licence");
+ - You may not use this work except in compliance with the Licence.
+ - You may obtain a copy of the Licence at:
  -
- - This program is distributed in the hope that it will be useful,
- - but WITHOUT ANY WARRANTY; without even the implied warranty of
- - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- - GNU Affero General Public License for more details.
+ - https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  -
- - You should have received a copy of the GNU Affero General Public License
- - along with this program. If not, see <http://www.gnu.org/licenses/>.
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the Licence is distributed on an "AS IS" basis,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the Licence for the specific language governing permissions and
+ - limitations under the Licence.
  -->
 
 <template>
@@ -222,7 +222,7 @@
  *
  * @author Ruben Linde <info@conduction.nl>
  * @copyright 2023 Conduction B.V.
- * @license AGPL-3.0-or-later
+ * @license EUPL-1.2
  * @version 1.0.0
  */
 

--- a/tests/OrganizationSyncTest.php
+++ b/tests/OrganizationSyncTest.php
@@ -8,7 +8,7 @@
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  */
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  */

--- a/tests/Stubs/Db/ObjectEntity.php
+++ b/tests/Stubs/Db/ObjectEntity.php
@@ -8,7 +8,7 @@
  * stub declares the getters/setters the unit tests stub explicitly. Resolved
  * via the `OCA\OpenRegister\ => tests/Stubs/` autoload-dev mapping.
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests\Stubs\Db

--- a/tests/Stubs/Db/Organisation.php
+++ b/tests/Stubs/Db/Organisation.php
@@ -7,7 +7,7 @@
  * partly magic. This stub declares the concrete surface the SoftwareCatalog
  * unit tests exercise (uuid + parent + a couple of read accessors).
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests\Stubs\Db

--- a/tests/Stubs/Db/OrganisationMapper.php
+++ b/tests/Stubs/Db/OrganisationMapper.php
@@ -7,7 +7,7 @@
  * (findByUuid + save), so PHPUnit can create mocks without the real
  * OpenRegister mapper being autoloadable.
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests\Stubs\Db

--- a/tests/Unit/Controller/ContractApprovalControllerTest.php
+++ b/tests/Unit/Controller/ContractApprovalControllerTest.php
@@ -12,7 +12,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Controller
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/contract-approval-ownership-guard/specs/contract-decision-delegation/spec.md

--- a/tests/Unit/EventListener/SoftwareCatalogEventListenerTest.php
+++ b/tests/Unit/EventListener/SoftwareCatalogEventListenerTest.php
@@ -26,7 +26,7 @@ use Psr\Log\LoggerInterface;
  * @category Tests
  * @package  OCA\SoftwareCatalog\Tests\Unit\EventListener
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  * @version  1.0.0
  */

--- a/tests/Unit/OrganisationUserWorkflowTest.php
+++ b/tests/Unit/OrganisationUserWorkflowTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests\Unit
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  */
@@ -45,7 +45,7 @@ use Psr\Log\LoggerInterface;
  * @category Test
  * @package  OCA\SoftwareCatalog\Tests\Unit
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @version  1.0.0
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  */

--- a/tests/Unit/Service/BioComplianceRegisterShapeTest.php
+++ b/tests/Unit/Service/BioComplianceRegisterShapeTest.php
@@ -14,7 +14,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/specs/bio-compliance-assessment/spec.md

--- a/tests/Unit/Service/ContactPersonHandlerTest.php
+++ b/tests/Unit/Service/ContactPersonHandlerTest.php
@@ -31,7 +31,7 @@ use ReflectionMethod;
  * @category Tests
  * @package  OCA\SoftwareCatalog\Tests\Unit\Service
  * @author   Conduction b.v. <info@conduction.nl>
- * @license  AGPL-3.0-or-later
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link     https://codeberg.org/Conduction/SoftwareCatalog
  * @version  1.0.0
  */

--- a/tests/Unit/Service/ContractApprovalServiceTest.php
+++ b/tests/Unit/Service/ContractApprovalServiceTest.php
@@ -14,7 +14,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/softwarecatalog-delegation-via-events/specs/contract-decision-delegation/spec.md

--- a/tests/Unit/Service/ContractStatusServiceTest.php
+++ b/tests/Unit/Service/ContractStatusServiceTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/contract-administration/specs/contract-administration/spec.md

--- a/tests/Unit/Service/DeepMergeAuthorizationTest.php
+++ b/tests/Unit/Service/DeepMergeAuthorizationTest.php
@@ -17,7 +17,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/specs/catalog-ratings/spec.md#requirement-the-register-fragment-merge-must-replace-authorization-rule-lists-not-concatenate-them

--- a/tests/Unit/Service/FederationMergerTest.php
+++ b/tests/Unit/Service/FederationMergerTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/federated-catalog-sync/specs/federated-catalog-sync/spec.md

--- a/tests/Unit/Service/FederationServiceTest.php
+++ b/tests/Unit/Service/FederationServiceTest.php
@@ -10,7 +10,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/federated-catalog-sync/specs/federated-catalog-sync/spec.md

--- a/tests/Unit/Service/IntakeModerationTest.php
+++ b/tests/Unit/Service/IntakeModerationTest.php
@@ -19,7 +19,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/open-data-publishing/specs/open-data-publishing/spec.md

--- a/tests/Unit/Service/LifecycleRegisterShapeTest.php
+++ b/tests/Unit/Service/LifecycleRegisterShapeTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/application-lifecycle-tracking/specs/application-lifecycle-tracking/spec.md

--- a/tests/Unit/Service/ModuleComplianceServiceTest.php
+++ b/tests/Unit/Service/ModuleComplianceServiceTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/module-compliance-assessment/specs/module-compliance-assessment/spec.md

--- a/tests/Unit/Service/OpenDataRegisterShapeTest.php
+++ b/tests/Unit/Service/OpenDataRegisterShapeTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/open-data-publishing/specs/open-data-publishing/spec.md

--- a/tests/Unit/Service/OrganisatieServiceParentHierarchyTest.php
+++ b/tests/Unit/Service/OrganisatieServiceParentHierarchyTest.php
@@ -13,7 +13,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/organisation-parent-hierarchy-rbac-fix/specs/organisatie-service/spec.md

--- a/tests/Unit/Service/PublicationServiceTest.php
+++ b/tests/Unit/Service/PublicationServiceTest.php
@@ -13,7 +13,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/open-data-publishing/specs/open-data-publishing/spec.md

--- a/tests/Unit/Service/PublishGateRbacTest.php
+++ b/tests/Unit/Service/PublishGateRbacTest.php
@@ -16,7 +16,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/changes/open-data-publishing/specs/open-data-publishing/spec.md

--- a/tests/Unit/Service/ReviewAggregateServiceTest.php
+++ b/tests/Unit/Service/ReviewAggregateServiceTest.php
@@ -11,7 +11,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/specs/catalog-ratings/spec.md#requirement-module-and-dienst-detail-pages-must-display-an-aggregate-rating-computed-only-from-approved-reviews

--- a/tests/Unit/Service/ReviewServiceTest.php
+++ b/tests/Unit/Service/ReviewServiceTest.php
@@ -16,7 +16,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/specs/catalog-ratings/spec.md

--- a/tests/Unit/Service/SbomRegisterShapeTest.php
+++ b/tests/Unit/Service/SbomRegisterShapeTest.php
@@ -17,7 +17,7 @@
  * @package   OCA\SoftwareCatalog\Tests\Unit\Service
  * @author    Conduction b.v. <info@conduction.nl>
  * @copyright 2026 Conduction B.V.
- * @license   AGPL-3.0-or-later https://www.gnu.org/licenses/agpl-3.0.html
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  * @link      https://codeberg.org/Conduction/SoftwareCatalog
  *
  * @spec openspec/specs/sbom-import/spec.md

--- a/tests/e2e/visual/_visual-helpers.ts
+++ b/tests/e2e/visual/_visual-helpers.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: EUPL-1.2
  *
  * Shared helpers for the visual-regression layer (GAP-5).
  *

--- a/tests/validate-manifest.js
+++ b/tests/validate-manifest.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: EUPL-1.2
 // Copyright (C) 2026 Conduction B.V.
 //
 // validate-manifest.js — schema-validates src/manifest.json against the


### PR DESCRIPTION
The repo already declares **EUPL-1.2** in `composer.json`, `package.json`, `appinfo/info.xml` and `LICENSE` — and `openspec/specs/licence-declaration/spec.md` already requires it ("No location SHALL declare AGPL or any licence other than EUPL-1.2"). 83 source files outside `lib/` still declared AGPL-3.0. This closes that gap.

## What changed

| Category | Files |
|---|---|
| `@license AGPL-3.0-or-later …` → EUPL-1.2 | 60 |
| `SPDX-License-Identifier: AGPL-3.0-or-later` → `EUPL-1.2` | 19 |
| ...of which also carried the **full GNU AGPL grant paragraph** | 10 |
| **Total files** | **83** (196 lines) |

The 10 files with the full grant paragraph ("This program is free software… GNU Affero General Public License…") had it replaced with the official **EUPL-1.2 boilerplate**. Swapping only the tag would have left a file whose header said EUPL above four paragraphs of AGPL prose — worse than either.

### Two tag shapes, deliberately

- **PHP / PHPDoc** — the fleet shape `@license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12`
- **JSDoc in `src/`** — the bare `@license EUPL-1.2`

The bare form is what this repo’’s existing frontend headers already use, and it is what `eslint`’’s `jsdoc/check-values` requires — a URL-suffixed value is not a valid SPDX expression. Using the URL form everywhere added **29 new eslint warnings**; the bare form returns the count to exactly the baseline.

## Scope discipline

- Only `@license` / `SPDX-License-Identifier` lines (and the AGPL grant paragraphs) were touched. **Zero** `@copyright` / `SPDX-FileCopyrightText` lines appear in the diff — mechanically verified.
- All copyright holders on the touched files are ours: Conduction B.V., Ruben Linde, and the `2024 Your Organization` template placeholder. No third-party file was relicensed.
- `tests/Stubs/Db/{ObjectEntity,Organisation,OrganisationMapper}.php` are **hand-written test doubles** of OpenRegister classes (they declare only the narrow surface our tests mock), not copied upstream source — ours to relicense.

## Verification — header-only, so nothing may move

| | before | after |
|---|---|---|
| phpunit (`phpunit-unit.xml`) | 480 tests, 1564 assertions | 480 tests, 1564 assertions |
| vitest | 18 files, 210 tests passed | 18 files, 210 tests passed |
| eslint `src` | 355 warnings, 0 errors | 355 warnings, 0 errors |
| **gate-28** (license-triangle) | PASS | PASS |

gate-28 was **already green** here — it only inspects `lib/**/*.php`, and all 97 of those files were already EUPL-1.2. (Verified with a positive control: temporarily flipping one `lib/` header to AGPL made the gate FAIL, confirming it is live and not silently passing.) The AGPL declarations this PR fixes are all in `src/` and `tests/`, which that gate never looks at.

phpunit runs in `php:8.4-cli` — host PHP is 8.2 and the lockfile requires ≥ 8.3.

## Noted, not changed (out of scope)

- `composer test:unit` points at `tests/phpunit.xml`, which does not exist — a pre-existing dead script. The working configs are `phpunit.xml` (needs a Nextcloud tree) and `phpunit-unit.xml` (standalone).
- `.phpunit.cache/test-results` is **tracked** in git even though `.gitignore` lists it, so any local test run dirties the tree.
- `openspec/` and `docs/` mention AGPL in prose describing this very rule — left alone; they are documentation, not declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)