### PR TITLE
chore(ci): stop pinning hydra-gates — track the package at @main

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -135,48 +135,22 @@ jobs:
       enable-coverage-guard: true
 
       # ── Hydra mechanical gates ───────────────────────────────────────────
-      # `enable-hydra-gates` defaults to FALSE, so this tier has never executed
+      # `enable-hydra-gates` defaults to FALSE, so this tier had never executed
       # here — the job reported `skipped`, which the Quality Report renders
-      # identically to a pass. Pinned to v1.0.1 so a change to the gate package
-      # cannot move this repo's verdict without a commit here.
-      # `enable-axe` deliberately NOT set: a vanilla Nextcloud 34 already carries
-      # serious/critical violations from core's own UI.
-      #
-      # v1.0.1 -> v1.3.0 (ConductionNL/.github#159). Two defects, one bump.
-      #
-      # 1. STALE. v1.0.1 is `f4d9756` (2026-08-03) and predates three gate
-      #    fixes, so every Hydra Gates run this repo has ever made executed a
-      #    script in which 16 gates reported PASS when their helper never ran
-      #    (#147), gate-33 had no axe report to read and never said so (#148),
-      #    and gates 6 and 7 reported PASS on an EMPTY scope (#149). A gate
-      #    that reports PASS without running emits a tick identical to a real
-      #    one, which is why nothing in this repo's history shows it.
-      #
-      # 2. RED. quality.yml is referenced `@main` while this package is
-      #    PINNED, so the two can desync — and on 2026-08-05 they did. #164
-      #    flipped `hydra-gates-require-full-coverage` to default TRUE, but
-      #    the accounting that makes that flag survivable (NOT APPLICABLE, as
-      #    distinct from a structural or a wiring gap) ships in the PACKAGE.
-      #    So every pin older than `f7eaf2a` now fails the coverage assertion
-      #    for gates it has no subject matter for. Measured diff-scoped,
-      #    exactly as CI scopes it:
-      #      v1.0.1  exit 98  FAIL — "GATES THAT DID NOT RUN: 24 33"
-      #      v1.3.0  exit 0   PASS — those gates named NOT APPLICABLE
-      #    The old pin was not merely stale, it was failing this repo's CI for
-      #    a reason that had nothing to do with this repo — and it is what is
-      #    currently blocking #434.
-      #
-      # v1.3.0 is `f7eaf2a` = .github@main, tagged so the ref stays
-      # reproducible and a later gate change cannot move this repo's verdict
-      # without a commit here.
+      # identically to a pass.
       enable-hydra-gates: true
-      hydra-gates-ref: v1.4.0
-      # PIN MOVED v1.3.0 -> v1.4.0 (fleet consumer-ref sweep, 2026-08-05).
-      # A pinned ref is a silent expiry date on every upstream fix: this repo
-      # cannot receive a gate-package fix until this line moves. v1.4.0 is the
-      # latest tag and the FIRST one carrying `hydra-gates/scripts/axe-run.cjs`
-      # (verified absent at v1.3.0), so it is also the first that has #168's
-      # axe DOM scoping and #165's gate-46 fix.
+      # No `hydra-gates-ref` here on purpose. The shared workflow defaults it
+      # to @main, and this workflow is itself consumed at @main, so the two
+      # sides move together and a gate fix reaches this repo without a commit
+      # in this repo. A pin is a silent expiry date: 22 repos sat on v1.0.1 and
+      # 16 gates were dead fleet-wide while every one reported PASS (.github#159),
+      # and a default flipped at @main later reached those old runners and made
+      # them red on gates they had no subject matter for (.github#173) — this
+      # repo felt both, the second one blocking #434.
+      # To hold this repo still for a specific reason, set the input explicitly
+      # and say why — it is still honoured. To roll back for everyone, revert on
+      # ConductionNL/.github main.
+      #
       # `enable-axe` is deliberately still NOT set — a vanilla Nextcloud 34
       # reports serious/critical violations on core's OWN routes that DOM
       # scoping does not remove. Enabling axe is a separate decision.


### PR DESCRIPTION
## What

Deletes the `hydra-gates-ref:` line from `.github/workflows/code-quality.yml`. Nothing replaces it — the input's default in the shared workflow **is already `main`**, so removing the override is the whole change.

`enable-hydra-gates` is untouched. `enable-axe` is untouched.

## Why not just keep (or bump) the pin

This repo consumes `ConductionNL/.github/.github/workflows/quality.yml` **`@main`**. Pinning the *gates package* to a tag while consuming the *workflow* at `@main` splits the two halves apart: the runner moves with upstream, the package it runs does not. We have now been bitten by that split from both directions.

- **Falsely green — `.github#159`.** All 22 repos were pinned to `v1.0.1`, which predated the fixes that made the gates actually execute. **16 gates were dead fleet-wide and every one of them reported PASS.** A check that did not run looks exactly like one that passed.
- **Falsely red — `.github#173`.** A default was flipped at `.github` `main` and reached those same old pinned runners, which had no accounting to honour it with, so they went **red on gates they had no subject matter for**.

Bumping the pin fixes neither — it just resets the clock and guarantees the same two failures on the next release. Unpinned, both sides move together and a gate fix reaches this repo without a commit in this repo.

The pin-justifying comment block (the version history, the reproducibility argument) is replaced with a short note saying why there is deliberately no ref here. The rationale for having the gates on at all is kept.

## Rollback and escape hatch

- **For everyone:** revert on `ConductionNL/.github` `main`. One commit, whole fleet.
- **For this one repo:** set `hydra-gates-ref:` explicitly again with a comment saying why. The input is still honoured — this PR removes an *override*, not a capability.

## Safety net

`ConductionNL/.github#177` adds a **resolve probe** plus the **gates package test suite** gating `.github` `main`, so a gates change that would not resolve, or that would break the runner, is caught before it can reach `@main` consumers like this one.

## Verification

- `grep -n "hydra-gates" .github/workflows/code-quality.yml` — no `hydra-gates-ref:` key remains.
- `yaml.safe_load` on the workflow parses clean.
