### PR TITLE
ci: publish an installable build of development

### DIFF
--- a/.github/workflows/release-development.yml
+++ b/.github/workflows/release-development.yml
@@ -1,0 +1,36 @@
+# Publishes an installable build of the development branch.
+#
+# Beta and stable reach people through the Nextcloud app store. Development
+# reached nobody: releases only fire on a push to beta or main, so the
+# newest installable build was months behind the branch and trying out
+# unreleased work meant building it yourself.
+#
+# This publishes a GitHub prerelease with a .tar.gz on every push to
+# development. The App Versions app reads a repository's releases from the
+# forge API and installs from that asset, and it already trusts
+# github:ConductionNL/* by default, so nothing needs configuring on the
+# Nextcloud side.
+#
+# Deliberately never uploaded to the app store: the shared workflow skips
+# that step for this channel. A dev build is for people who asked for one.
+name: Development Release
+
+on:
+  push:
+    branches: [development]
+  workflow_dispatch:
+
+# A push during a running build supersedes it. Without this, a busy morning
+# produces a queue of releases that are obsolete before they finish, and
+# the tag each one cuts sticks around.
+concurrency:
+  group: development-release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    uses: ConductionNL/.github/.github/workflows/release-beta.yml@main
+    with:
+      app-name: softwarecatalog
+      channel: dev
+    secrets: inherit


### PR DESCRIPTION
Beta and stable reach people through the Nextcloud app store. Development reached nobody: releases only fire on a push to `beta` or `main`, so the newest installable build was months behind the branch.

Every push to `development` now publishes a **GitHub prerelease** with a `.tar.gz` plus a `.sha256`. The App Versions app reads releases from the forge API and installs from that asset, and already trusts `github:ConductionNL/*` by default, so nothing needs configuring on the Nextcloud side.

**Never uploaded to the app store** — the shared workflow skips that step for this channel, which is the only difference between dev and beta. Packaging is identical on purpose.

Proven end to end on Pipelinq first: the release published, the digest matched the archive, and the packaged `appinfo/info.xml` carried the matching version.

Depends on ConductionNL/.github#186 and #187 (both merged).