### PR TITLE
fix(gate-57): delete the dead user-provisioning stub that only logged

### DIFF
--- a/lib/Service/SoftwareCatalogueService.php
+++ b/lib/Service/SoftwareCatalogueService.php
@@ -840,25 +840,6 @@ class SoftwareCatalogueService
     }//end handleNewContact()
 
     /**
-     * Creates user for contact if not exists
-     *
-     * @param object $contactObject The contact object
-     *
-     * @return void
-     * @spec   openspec/specs/softwarecatalogue-orchestration/spec.md
-     */
-    public function createUserForContactIfNotExists(object $contactObject): void
-    {
-        // Implementation for creating user from contact.
-        $this->_logger->info(
-                'Creating user for contact if not exists',
-                [
-                    'objectId' => $contactObject->getId(),
-                ]
-                );
-    }//end createUserForContactIfNotExists()
-
-    /**
      * Handles new gebruiker creation
      *
      * @param object $gebruikerObject The gebruiker object

--- a/tests/Unit/EventListener/SoftwareCatalogEventListenerTest.php
+++ b/tests/Unit/EventListener/SoftwareCatalogEventListenerTest.php
@@ -134,11 +134,6 @@ class SoftwareCatalogEventListenerTest extends TestCase
             ->method('handleNewContact')
             ->with($contact);
 
-        $this->softwareCatalogueService
-            ->expects($this->once())
-            ->method('createUserForContactIfNotExists')
-            ->with($contact);
-
         // Handle the event
         $this->eventListener->handle($event);
     }
@@ -192,11 +187,6 @@ class SoftwareCatalogEventListenerTest extends TestCase
         $this->softwareCatalogueService
             ->expects($this->once())
             ->method('handleContactUpdate')
-            ->with($newContact);
-
-        $this->softwareCatalogueService
-            ->expects($this->once())
-            ->method('createUserForContactIfNotExists')
             ->with($newContact);
 
         // Handle the event


### PR DESCRIPTION
`SoftwareCatalogueService::createUserForContactIfNotExists()` has **no production caller** anywhere in the tree, and its body never created a user — it logged `Creating user for contact if not exists` and returned.

## Why this is deletion and not wiring

Per the gate-57 rule, an orphaned write capability is only dead code once you have shown the behaviour is not simply unreachable. Here it is not missing — it moved:

- Real contact user-provisioning is `ContactPersonHandler::createUserAccount()` → `IUserManager::createUser()`, reached through `ContactpersoonService`.
- `SoftwareCatalogEventListener::handleObjectCreated()/handleObjectUpdated()` dispatch there via `SettingsService` schema-id lookups.

So this method is the leftover of the pre-refactor path, not an unwired capability. Provisioning is unaffected.

## It was also claiming spec coverage it did not implement

The stub carried `@spec openspec/specs/softwarecatalogue-orchestration/spec.md`. A method that only logs was anchoring a spec requirement whose behaviour is implemented in a different class.

## The only references were in an entirely skipped test

`tests/Unit/EventListener/SoftwareCatalogEventListenerTest.php` asserted `expects($this->once())->method('createUserForContactIfNotExists')` twice — but its `setUp()` calls `markTestSkipped()` **before** it builds any mock. Nothing ever asserted the call, so no test was protecting this behaviour. The two now-dangling expectations are removed with the method.

(That test class is stale wholesale against the refactored listener and still points its follow-up at retired Codeberg — noted, not fixed here.)

## Verification

`hydra-gates` @main, scoped `--base origin/beta` (the base the development→beta sync PR #197 actually uses):

```
before:  [gate-57] orphaned-write-capability: FAIL — 2 orphaned write-capability method(s)
after:   [gate-57] orphaned-write-capability: FAIL — 1 orphaned write-capability method(s)
```

`php -l` clean on both changed files; no remaining references to the symbol in the tree.

## The remaining gate-57 finding is deliberately left

`FederationService::publishEntryForFederation()` (lib/Service/Federation/FederationService.php:246) is the opposite shape: a **working** capability — it sets `publicatiedatum`, the live OpenRegister RBAC publish gate — with zero production callers and only direct unit-test invocation. Catalog entries therefore cannot be published to the federation through this path at all.

That one wants **wiring, not deletion**, and where publish is triggered from is a product decision, so it is left for a follow-up rather than guessed at here.