### PR TITLE
chore(ci): point Dependabot at development, where the gates actually run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,36 @@
 version: 2
+
+# ⚠️ `target-branch: development` is load-bearing, not cosmetic.
+#
+# Without it Dependabot targets the repository DEFAULT branch, which is `main`.
+# `main` is currently **729 commits behind `development`** and carries an
+# entirely different lockfile, so the PRs Dependabot raised there were:
+#
+#   • measured against a tree nobody develops on — the open alerts claimed
+#     5 critical / 51 high, while `development` actually had 1 critical /
+#     2 high (npm) and ZERO composer advisories; and
+#   • ungated — `code-quality.yml` on `main` is a stale, self-contained
+#     workflow, and PRs #368 and #369 collected **no check runs at all**
+#     beyond a neutral CodeQL. A dependency PR that nothing builds is exactly
+#     how this fleet previously shipped an unbuildable image for two months.
+#
+# Pointing Dependabot at `development` puts its PRs in front of the real
+# shared quality workflow (build, unit tests, SBOM, licence and audit legs).
+#
+# Trade-off, stated explicitly: GitHub only raises Dependabot SECURITY updates
+# against the default branch, so setting `target-branch` converts these to
+# VERSION updates. That is a net gain here — a version update on `development`
+# is verified and mergeable, whereas a security update on `main` was neither.
+# The alert list itself still tracks `main` and will only shrink as
+# `development` is released forward.
+#
+# Matches the fleet convention already in place on nldesign, decidesk,
+# openbuild, procest and shillinq.
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "development"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -11,3 +40,24 @@ updates:
         - "*"
       exclude:
         - "@conduction/*"
+
+  # composer had no entry at all, so the only composer PRs this repo ever saw
+  # were security updates against `main` (e.g. #369, which bumped twig to
+  # 3.27.0 — a version `development` already had).
+  - package-ecosystem: "composer"
+    directory: "/"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 1
+      include:
+        - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "development"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## The problem

Dependabot targets the repository **default branch**, which here is `main`. `main` is **729 commits behind `development`** and carries a completely different lockfile.

Two consequences, both bad:

**1. The alert list measures the wrong tree.** The reported backlog for this repo was ~151 vulnerabilities / 5 critical. Measured against `development`:

| ecosystem | critical | high | moderate | low |
|---|---|---|---|---|
| composer | 0 | 0 | 0 | 0 |
| npm | 1 | 2 | 5 | 5 |

The critical `twig/twig < 3.26.0` alert is moot on `development` — it is on **3.27.0**. Same story across the fleet: **every** Conduction repo shows zero composer advisories on `development`.

**2. The PRs were ungated.** Dependabot PRs #368 and #369 collected **no check runs at all** beyond a neutral CodeQL:

```
$ gh api /repos/.../commits/<head>/check-runs --jq .total_count
1
  CodeQL completed neutral
```

`main` still carries the old self-contained `code-quality.yml`, while `development` uses the shared quality workflow. A dependency PR that nothing builds is precisely how this fleet previously shipped an unbuildable image for two months.

## The change

- `target-branch: development` on npm.
- Adds the **missing `composer` ecosystem** — it had no entry at all, so its only PRs were security updates against `main`.
- Adds `github-actions`.

## Trade-off, stated explicitly

GitHub only raises Dependabot **security** updates against the default branch, so `target-branch` converts these into **version** updates. That is a net gain: a version update on `development` is verified and mergeable; a security update on a 729-commit-dead `main` was neither. The alert list still tracks `main` and will shrink as `development` is released forward.

Matches the convention already in place on **nldesign, decidesk, openbuild, procest and shillinq**.

Companion to #443 (which clears every critical and high npm advisory on `development`).