### PR TITLE
fix: declare NC 32 as the floor — openregister cannot install below it

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,7 +71,23 @@ Vrij en open source onder de EUPL-licentie.
     <screenshot>https://codeberg.org/Conduction/softwarecatalog/raw/branch/main/img/screenshot-connections.png</screenshot>
 
     <dependencies>
-        <nextcloud min-version="28" max-version="34"/>
+        <!--
+        App dependency (not expressible in app-info.xsd): OpenRegister — every
+        Software Catalog entity is an OpenRegister object, and src/manifest.json
+        lists "openregister" as a required dependency.
+
+        min-version is therefore 32, NOT 28: openregister declares min-version="32"
+        because its lib/ContextChat/ContentProvider.php implements
+        OCP\ContextChat\IContentProvider, an interface core does not have before
+        Nextcloud 32. On NC 28-31 openregister refuses to install ("cannot be
+        installed because it is not compatible with this version of the server"), so
+        the app cannot function there. Declaring 28 advertised a range this app
+        cannot deliver. Same defect as openconnector#1173.
+
+        CI already tests stable32 only, so this changes the advertised app-store
+        range and nothing about what runs.
+        -->
+        <nextcloud min-version="32" max-version="34"/>
         <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>


### PR DESCRIPTION
## What changed

**`appinfo/info.xml` `min-version` 28 → 32.** `src/manifest.json` lists `"openregister"` as a required dependency.

**CI is unchanged** — this repo already pins `nextcloud-test-refs: ["stable32"]`, so nothing about what runs changes. What changes is the range advertised in the **app store**, which currently promises NC28 for an app whose data layer cannot install there.

## The defect

openregister raised its own floor this morning — `<nextcloud min-version="32" max-version="34"/>`, commit `8d5181f7a` (openregister#2378), *"require Nextcloud 32, which is where the ContextChat interfaces exist"*. Its `lib/ContextChat/ContentProvider.php` implements `OCP\ContextChat\IContentProvider`, and core does not have that interface before NC32. **That raise is correct and is not being reverted here.**

The consequence lands on every app that depends on openregister but still tests on `stable31`:

```
Enabling app: openregister
App "Open Register" cannot be installed because it is not compatible with this version of the server.
##[warning]Failed to enable openregister, continuing...
```

The enable failure is only a `::warning::` (shared `quality.yml`, "Install Nextcloud" step), so the run **continues without its data layer** and every `/apps/openregister/...` call returns Nextcloud's HTML 404 page.

## This was measured, not inferred

- One **unchanged commit's** job passed at 08:05 and failed at 08:35, with zero code change in between — the only thing that moved was openregister's floor.
- Re-running `development`'s own Newman on yesterday's commits: **decidesk 93 → 191** failures, **larpingapp 10 → 22**.
- docudesk was immune, and only because it already tests `stable32` only.

## `stable31` is removed, not "dropped for coverage"

A `stable31` leg was exercising a configuration that **cannot exist**: the app under test declares openregister as a hard dependency, and openregister cannot install there. Nothing was being covered on that leg — its red said nothing about this app's code. Removing it corrects an impossible configuration. It does not reduce coverage.

The matrix is **not widened** either: no `stable33` is added where it was not already present.

## The ordering bug in the same family

Membership was not the only problem. In the shared `quality.yml`, three jobs pin the **first** entry rather than iterating the list:

| job | line | server |
|---|---|---|
| `newman` | 1748 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `playwright` | 2024 | `fromJSON(inputs.nextcloud-test-refs)[0]` |
| `journeydoc-capture` | 2775 | `fromJSON(inputs.nextcloud-test-refs)[0]` |

(`phpunit` iterates the whole list, so it was broken by *membership*; the coverage-guard and coverage-artifact steps at 1644/1671/1684 are also `[0]`-pinned.)

So wherever `stable31` sat **first**, those three jobs ran *entirely* on the version openregister cannot load. doriath had already reordered for exactly this reason.

## Precedent

This is the same defect as **openconnector#1173**, which declared `min-version="28"` while its own `<app>openregister</app>` dependency required 32 — advertising, in the app store, a range it could not deliver. This PR follows that shape.

## Scope

No app version bump — only the supported-server range and the CI matrix change, so there are no `occ upgrade` implications.