### PR TITLE
chore: raise the Nextcloud floor to 32

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,7 +71,7 @@ Vrij en open source onder de EUPL-licentie.
     <screenshot>https://codeberg.org/Conduction/softwarecatalog/raw/branch/main/img/screenshot-connections.png</screenshot>
 
     <dependencies>
-        <nextcloud min-version="28" max-version="34"/>
+        <nextcloud min-version="32" max-version="34"/>
         <php min-version="8.3" min-int-size="64"/>
         <database min-version="10">pgsql</database>
         <database>sqlite</database>


### PR DESCRIPTION
Raises the declared Nextcloud floor to 32, matching what we build and test against. CI runs nextcloud:32-apache and the dev stack is on 34; nothing exercised 28-31. Only the <nextcloud min-version> attribute changes; max-version untouched.