### PR TITLE
refactor(archimate): delete the unreachable private getVoorzieningenConfig duplicate (gate-50 17 → 14)

### DIFF
--- a/lib/Service/ArchiMateService.php
+++ b/lib/Service/ArchiMateService.php
@@ -1695,36 +1695,6 @@ class ArchiMateService
     }//end getAmefConfig()
 
     /**
-     * Get Voorzieningen configuration directly from IAppConfig
-     *
-     * @return array The voorzieningen configuration
-     */
-    private function getVoorzieningenConfig(): array
-    {
-        $config  = $this->config->getValueString('softwarecatalog', 'voorzieningen_config', '{}');
-        $decoded = json_decode($config, true);
-
-        if (is_array($decoded) === false) {
-            // Fallback to individual config values for backward compatibility.
-            $decoded = [
-                'register'              => $this->config->getValueString('softwarecatalog', 'voorzieningen_register', ''),
-                'organisatie_schema'    => $this->config->getValueString(
-                    'softwarecatalog',
-                        'voorzieningen_organisatie_schema',
-                        ''
-                ),
-                'contactpersoon_schema' => $this->config->getValueString(
-                    'softwarecatalog',
-                        'voorzieningen_contactpersoon_schema',
-                        ''
-                ),
-            ];
-        }
-
-        return $decoded;
-    }//end getVoorzieningenConfig()
-
-    /**
      * Get the current status of ArchiMate operations
      *
      * @return array Status information including import/export status and object counts


### PR DESCRIPTION
hydra-gates `48c88ba1e0d049f8f38538c33e790d3e603c55d0`. **gate-50 security-config-fail-mode: 17 → 14.**

## What was deleted

`ArchiMateService::getVoorzieningenConfig()` is `private` and has **zero `$this->` call sites in its own file** — the only thing that can reach a private method.

It is not reflected into either. The whole of `lib/` contains **exactly one** `ReflectionMethod` call site (`SettingsService:4644`) and it targets `getAmefConfig`. So this method cannot execute.

It is also a **stale duplicate**: `SettingsService::getVoorzieningenConfig()` is the live resolver (13 references across the app) and it ends with `normalizeVoorzieningenConfig()`, which this copy never had. Anything wired to the copy would have received un-normalised config.

Three of gate-50's seventeen findings go away because the code that made them cannot run — not because a guard was moved into the checker's 10-line window.

## The near-miss worth recording

The obvious read of this file is that **both** `ArchiMateService::getAmefConfig()` and `getVoorzieningenConfig()` are dead — neither has a `->getAmefConfig()` / `->getVoorzieningenConfig()` call site on an `ArchiMateService` instance anywhere in `lib/`, `src/`, `tests/` or `appinfo/routes.php`.

That is wrong for `getAmefConfig()`. `SettingsService::getAmefConfig()` reaches it **by reflection**:

```php
$archiMateService = $this->container->get(ArchiMateService::class);
$reflection = new \ReflectionClass($archiMateService);
$method     = $reflection->getMethod('getAmefConfig');
return $method->invoke($archiMateService);
```

No grep for a method call finds that. **`getAmefConfig()` is live and heavily used; deleting it would have broken every AMEF consumer.** Only the private sibling, which nothing reflects into, is dead.

## The other 14 findings are left RED, deliberately

They are the two  legacy-fallback blocks (7 in `ArchiMateService`, 7 in `ArchiMateImportService`). **The fail-mode is already handled — outside the gate's 10-line window:**

- `getAmefRegisterId()`: `is_numeric((string) $raw) === true` **and** `$id > 0`, else `return null`.
- `getAmefSchemaIdForType()`: same two conditions on every candidate, else `return null`.
- `ArchiMateService:1342`: `throw new \InvalidArgumentException('AMEF register ID is not configured…')`.

Those are **stricter** than the empty-string comparison gate-50 looks for. Restructuring working code so the guard lands within ten lines of the read would be satisfying a window heuristic, not fixing a defect.

### And deleting the reads was checked, and rejected

`getAmefSchemaIdForType()` reads **singular** candidate keys (`element_schema`, `view_schema`, `model_schema`…) while the legacy fallback produces **plural** ones (`elements_schema`, `views_schema`…) — measured overlap between producer and consumer: **empty set**. That looked like six structurally unreachable reads per file.

It is not. `src/store/modules/settings.js:942` reads `ac.elements_schema` as a fallback, and `SettingsService:5723` reads `$amefConfig['elements_schema']` for the configuration-status readout. Deleting them would have broken the admin settings UI's schema pre-selection and the status panel — the same shape as commit `651a055f`, which satisfied PHPMD by deleting sixteen `if` bodies. **Left alone.**

The plural/singular split between what the fallback writes and what `getAmefSchemaIdForType()` reads is a real inconsistency and deserves its own issue; it is not something to resolve inside a quality-gate change.

## Measurements

- Can-fail: restoring `lib/Service/ArchiMateService.php` from `origin/development` puts gate-50 back to **17**; with the deletion it reports **14**.
- phpcs, psalm, phpstan, phpmd (repo baseline): clean.
- Unit suite: **512 tests, 1814 assertions, 0 failures**.
- No other gate count moved.