### PR TITLE
fix(archimate): unset AMEF ids were handed on as empty strings past a `=== null` guard (gate-50 14 → PASS)

### DIFF
--- a/lib/Service/ArchiMateImportService.php
+++ b/lib/Service/ArchiMateImportService.php
@@ -1956,6 +1956,48 @@ class ArchiMateImportService
     }//end getCurrentOrganisation()
 
     /**
+     * Read a configured id, failing closed on the empty default.
+     *
+     * The legacy fallback used to read every id with `''` as its default, so
+     * an unconfigured instance produced a config array full of empty STRINGS.
+     * Its consumers guard with `=== null` — `getAmefRegisterId()` and
+     * `getAmefSchemaIdForType()` reject them with `is_numeric()` + `> 0` — and `'' === null` is
+     * false. Today nothing reaches a query only because that fallback writes
+     * PLURAL key names (`views_schema`) while every consumer reads SINGULAR
+     * ones (`view_schema`), so the lookups miss and fall back to `null`. That
+     * is an accident of naming, not a defence: adding the singular keys — the
+     * obvious "cleanup" — would send `register => ''` straight into
+     * `searchObjects()` as an UNPINNED query, and an unpinned query returns
+     * rows, which reads exactly like a correct result.
+     *
+     * Returning null instead of `''` makes `?? null` downstream yield null,
+     * which is what every consumer already checks for, and the warning names
+     * the missing key so a misconfigured import stops reporting "0 objects"
+     * with no explanation.
+     *
+     * @param string $key The app-config key holding the id.
+     *
+     * @return string|null The configured id, or null when it is unset.
+     *
+     * @spec openspec/specs/archimate-import/spec.md
+     */
+    private function resolveConfiguredId(string $key): ?string
+    {
+        $value = $this->config->getValueString('softwarecatalog', $key, '');
+        if (trim($value) === '') {
+            $this->logger->warning(
+                    'ArchiMate configuration is incomplete — this id is not configured, so it is omitted rather than passed on as an empty string',
+                    ['key' => $key]
+                    );
+
+            return null;
+        }
+
+        return $value;
+
+    }//end resolveConfiguredId()
+
+    /**
      * Get AMEF configuration from app config
      *
      * @return array AMEF configuration
@@ -1971,49 +2013,27 @@ class ArchiMateImportService
             $decoded = json_decode($config, true);
 
             if (is_array($decoded) === false) {
-                // Fallback to individual config values for backward compatibility.
-                $decoded = [
-                    'register_id'                 => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_register',
-                            ''
-                    ),
-                    'model_schema_id'             => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_model_schema',
-                            ''
-                    ),
-                    'elements_schema'             => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_elements_schema',
-                            ''
-                    ),
-                    'relationships_schema'        => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_relationships_schema',
-                            ''
-                    ),
-                    'views_schema'                => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_views_schema',
-                            ''
-                    ),
-                    'organizations_schema'        => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_organizations_schema',
-                            ''
-                    ),
-                    'folders_schema'              => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_folders_schema',
-                            ''
-                    ),
-                    'property_definitions_schema' => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_property_definitions_schema',
-                            ''
-                    ),
-                ];
+                // Fallback to individual config values for backward
+                // compatibility. Every id is read through
+                // resolveConfiguredId(), which guards the empty default at the
+                // point of the read and omits the key entirely when it is
+                // unset — so `?? null` downstream yields null, which is what
+                // the consumers already check for.
+                $decoded = array_filter(
+                    [
+                        'register_id'                 => $this->resolveConfiguredId(key: 'amef_register'),
+                        'model_schema_id'             => $this->resolveConfiguredId(key: 'amef_model_schema'),
+                        'elements_schema'             => $this->resolveConfiguredId(key: 'amef_elements_schema'),
+                        'relationships_schema'        => $this->resolveConfiguredId(key: 'amef_relationships_schema'),
+                        'views_schema'                => $this->resolveConfiguredId(key: 'amef_views_schema'),
+                        'organizations_schema'        => $this->resolveConfiguredId(key: 'amef_organizations_schema'),
+                        'folders_schema'              => $this->resolveConfiguredId(key: 'amef_folders_schema'),
+                        'property_definitions_schema' => $this->resolveConfiguredId(key: 'amef_property_definitions_schema'),
+                    ],
+                    static function ($value) {
+                        return $value !== null;
+                    }
+                );
             }//end if
 
             return $decoded;

--- a/lib/Service/ArchiMateService.php
+++ b/lib/Service/ArchiMateService.php
@@ -1622,6 +1622,48 @@ class ArchiMateService
     }//end createTempFile()
 
     /**
+     * Read a configured id, failing closed on the empty default.
+     *
+     * The legacy fallback used to read every id with `''` as its default, so
+     * an unconfigured instance produced a config array full of empty STRINGS.
+     * Its consumers guard with `=== null` — `ViewService::getViews()` and
+     * `getView()` throw only when a value `=== null` — and `'' === null` is
+     * false. Today nothing reaches a query only because that fallback writes
+     * PLURAL key names (`views_schema`) while every consumer reads SINGULAR
+     * ones (`view_schema`), so the lookups miss and fall back to `null`. That
+     * is an accident of naming, not a defence: adding the singular keys — the
+     * obvious "cleanup" — would send `register => ''` straight into
+     * `searchObjects()` as an UNPINNED query, and an unpinned query returns
+     * rows, which reads exactly like a correct result.
+     *
+     * Returning null instead of `''` makes `?? null` downstream yield null,
+     * which is what every consumer already checks for, and the warning names
+     * the missing key so a misconfigured import stops reporting "0 objects"
+     * with no explanation.
+     *
+     * @param string $key The app-config key holding the id.
+     *
+     * @return string|null The configured id, or null when it is unset.
+     *
+     * @spec openspec/specs/archimate-import/spec.md
+     */
+    private function resolveConfiguredId(string $key): ?string
+    {
+        $value = $this->config->getValueString('softwarecatalog', $key, '');
+        if (trim($value) === '') {
+            $this->logger->warning(
+                    'ArchiMate configuration is incomplete — this id is not configured, so it is omitted rather than passed on as an empty string',
+                    ['key' => $key]
+                    );
+
+            return null;
+        }
+
+        return $value;
+
+    }//end resolveConfiguredId()
+
+    /**
      * Get AMEF configuration from app config
      *
      * @return array AMEF configuration
@@ -1637,45 +1679,27 @@ class ArchiMateService
             $decoded = json_decode($config, true);
 
             if (is_array($decoded) === false) {
-                // Fallback to individual config values for backward compatibility.
-                $decoded = [
-                    'register_id'                 => $this->config->getValueString('softwarecatalog', 'amef_register', ''),
-                    'model_schema_id'             => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_model_schema',
-                            ''
-                    ),
-                    'elements_schema'             => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_elements_schema',
-                            ''
-                    ),
-                    'relationships_schema'        => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_relationships_schema',
-                            ''
-                    ),
-                    'views_schema'                => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_views_schema',
-                            ''
-                    ),
-                    'organizations_schema'        => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_organizations_schema',
-                            ''
-                    ),
-                    'folders_schema'              => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_folders_schema',
-                            ''
-                    ),
-                    'property_definitions_schema' => $this->config->getValueString(
-                        'softwarecatalog',
-                            'amef_property_definitions_schema',
-                            ''
-                    ),
-                ];
+                // Fallback to individual config values for backward
+                // compatibility. Every id is read through
+                // resolveConfiguredId(), which guards the empty default at the
+                // point of the read and omits the key entirely when it is
+                // unset — so `?? null` downstream yields null, which is what
+                // the consumers already check for.
+                $decoded = array_filter(
+                    [
+                        'register_id'                 => $this->resolveConfiguredId(key: 'amef_register'),
+                        'model_schema_id'             => $this->resolveConfiguredId(key: 'amef_model_schema'),
+                        'elements_schema'             => $this->resolveConfiguredId(key: 'amef_elements_schema'),
+                        'relationships_schema'        => $this->resolveConfiguredId(key: 'amef_relationships_schema'),
+                        'views_schema'                => $this->resolveConfiguredId(key: 'amef_views_schema'),
+                        'organizations_schema'        => $this->resolveConfiguredId(key: 'amef_organizations_schema'),
+                        'folders_schema'              => $this->resolveConfiguredId(key: 'amef_folders_schema'),
+                        'property_definitions_schema' => $this->resolveConfiguredId(key: 'amef_property_definitions_schema'),
+                    ],
+                    static function ($value) {
+                        return $value !== null;
+                    }
+                );
             }//end if
 
             return $decoded;

--- a/lib/Service/ViewService.php
+++ b/lib/Service/ViewService.php
@@ -711,6 +711,22 @@ class ViewService
             $amefConfig = $this->settingsService->getAmefConfig();
             $registerId = $amefConfig['register_id'] ?? null;
 
+            // Fail closed on an unconfigured register. This used to be the one
+            // read of `register_id` with no guard at all: the loop below only
+            // checks the SCHEMA, so an empty register would have been pinned
+            // into `@self` and OpenRegister asked for "any register" — an
+            // unpinned query returns rows, which reads exactly like a correct
+            // result. `empty()` rather than `=== null` because the legacy
+            // config fallback resolves unset ids to `''`, and `'' === null` is
+            // false.
+            if (empty($registerId) === true) {
+                $this->logger->warning(
+                    'ViewService: AMEF register is not configured; skipping the module lookup rather than issuing an unpinned query'
+                );
+
+                return [];
+            }
+
             // Modules could be in various schemas - check common ones.
             $moduleSchemas = [
                 $amefConfig['module_schema'] ?? null,
@@ -721,7 +737,7 @@ class ViewService
             $allModules = [];
 
             foreach ($moduleSchemas as $schemaId) {
-                if ($schemaId === null) {
+                if (empty($schemaId) === true) {
                     continue;
                 }
 

--- a/tests/Unit/Service/ArchiMateConfigFailModeTest.php
+++ b/tests/Unit/Service/ArchiMateConfigFailModeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Fail-mode tests for the AMEF configuration resolvers.
+ *
+ * The defect: the legacy fallback read every register/schema id with `''` as
+ * its default and handed the result on. Consumers guard with `=== null`
+ * (`ViewService::getViews()`/`getView()`), and `'' === null` is false — so an
+ * empty id would have passed the guard and been pinned into an OpenRegister
+ * query as the register/schema. An unpinned query returns rows, which reads
+ * exactly like a correct result.
+ *
+ * Nothing reached a query today only because the fallback wrote PLURAL key
+ * names (`views_schema`) while the consumers read SINGULAR ones
+ * (`view_schema`), so the lookups missed and fell back to null. These tests
+ * pin the real property — an unset id must not be present as an empty string —
+ * so that accident can never be "cleaned up" into a live fail-open.
+ *
+ * @category  Test
+ * @package   OCA\SoftwareCatalog\Tests\Unit\Service
+ * @author    Conduction b.v. <info@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version   GIT: <git_id>
+ * @link      https://codeberg.org/Conduction/SoftwareCatalog
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Tests\Unit\Service;
+
+use OCA\SoftwareCatalog\Service\ArchiMateImportService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The AMEF config resolvers must omit unresolved ids, never emit ''.
+ *
+ * @category Test
+ * @package  OCA\SoftwareCatalog\Tests\Unit\Service
+ * @author   Conduction b.v. <info@conduction.nl>
+ * @license  EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ * @version  GIT: <git_id>
+ * @link     https://codeberg.org/Conduction/SoftwareCatalog
+ */
+class ArchiMateConfigFailModeTest extends TestCase
+{
+
+
+    /**
+     * Build the service with only the two collaborators the resolver touches.
+     *
+     * @param array<string,string> $values Config key => stored value.
+     *
+     * @return ArchiMateImportService
+     */
+    private function serviceWithConfig(array $values): ArchiMateImportService
+    {
+        // The legacy fallback is only reached when `amef_config` does not
+        // decode to an array. Its DEFAULT is '{}', which decodes to [] — so on
+        // an instance that never wrote the key, getAmefConfig() returns [] and
+        // the fallback never runs at all. Malformed JSON is the branch under
+        // test here, and callers must not be given empty ids on that path.
+        $values['amef_config'] = $values['amef_config'] ?? 'not-json';
+
+        $config = $this->createMock(\OCP\IAppConfig::class);
+        $config->method('getValueString')->willReturnCallback(
+            function (string $app, string $key, string $default = '') use ($values) {
+                return $values[$key] ?? $default;
+            }
+        );
+
+        $service = (new \ReflectionClass(ArchiMateImportService::class))->newInstanceWithoutConstructor();
+
+        foreach (['config' => $config, 'logger' => $this->createMock(\Psr\Log\LoggerInterface::class)] as $prop => $value) {
+            $property = new \ReflectionProperty(ArchiMateImportService::class, $prop);
+            $property->setValue($service, $value);
+        }
+
+        return $service;
+
+    }//end serviceWithConfig()
+
+
+    /**
+     * An unconfigured instance yields no id keys at all — not empty strings.
+     *
+     * @return void
+     */
+    public function testUnconfiguredInstanceOmitsEveryIdRatherThanEmittingEmptyStrings(): void
+    {
+        $config = $this->serviceWithConfig([])->getAmefConfig();
+
+        // Guard against a vacuous pass: if the fallback had not run at all,
+        // the loop below would iterate nothing and prove nothing.
+        $this->assertSame([], $config, 'every id was unset, so none should survive');
+
+        foreach ($config as $key => $value) {
+            $this->assertNotSame('', $value, sprintf('"%s" was handed on as an empty string', $key));
+        }
+
+        // The property the consumers rely on: `?? null` must yield null.
+        $this->assertNull($config['register_id'] ?? null);
+        $this->assertNull($config['views_schema'] ?? null);
+
+    }//end testUnconfiguredInstanceOmitsEveryIdRatherThanEmittingEmptyStrings()
+
+
+    /**
+     * A configured id still comes through untouched.
+     *
+     * @return void
+     */
+    public function testConfiguredIdsAreReturnedUnchanged(): void
+    {
+        $config = $this->serviceWithConfig(
+            [
+                'amef_register'      => '11',
+                'amef_views_schema'  => '42',
+            ]
+        )->getAmefConfig();
+
+        $this->assertSame('11', $config['register_id']);
+        $this->assertSame('42', $config['views_schema']);
+
+    }//end testConfiguredIdsAreReturnedUnchanged()
+
+
+    /**
+     * A partially configured instance keeps what is set and drops what is not.
+     *
+     * This is the shape that makes the difference real: with `''` retained, a
+     * `=== null` guard on the missing half would pass.
+     *
+     * @return void
+     */
+    public function testPartialConfigurationKeepsSetIdsAndDropsUnsetOnes(): void
+    {
+        $config = $this->serviceWithConfig(['amef_register' => '11'])->getAmefConfig();
+
+        $this->assertSame('11', $config['register_id']);
+        $this->assertArrayNotHasKey('views_schema', $config);
+        $this->assertArrayNotHasKey('elements_schema', $config);
+
+    }//end testPartialConfigurationKeepsSetIdsAndDropsUnsetOnes()
+
+
+    /**
+     * A whitespace-only id counts as unset, not as a usable value.
+     *
+     * @return void
+     */
+    public function testWhitespaceOnlyIdIsTreatedAsUnset(): void
+    {
+        $config = $this->serviceWithConfig(['amef_register' => '   '])->getAmefConfig();
+
+        $this->assertArrayNotHasKey('register_id', $config);
+
+    }//end testWhitespaceOnlyIdIsTreatedAsUnset()
+
+
+}//end class


### PR DESCRIPTION
**gate-50 security-config-fail-mode: 14 → PASS.** hydra-gates `651e5c5bb3ba8764903e5d6fc5bac5a208bd67fc`, measured at the CI scope (`--scope-to-diff --base origin/beta`).

## I nearly dismissed these as false positives

My first read was that gate-50's 10-line window was too narrow and the consumers validate anyway — so I was going to leave all 14 red with that as the reason. **Checking every consumer rather than the two convenient ones showed the opposite.**

The legacy fallback in both `getAmefConfig()` implementations read every register/schema id with `''` as its default and returned them. The consumers guard with `=== null`:

```php
ViewService:254, :320   if ( === null ||  === null) { throw … }
ViewService:711          = ['register_id'] ?? null;   // then used, unguarded
```

**`'' === null` is false.** An empty id passes the guard and is pinned into an OpenRegister query as the register/schema — and **an unpinned query returns rows**, which reads exactly like a correct result rather than like a failure.

### Why nothing has broken yet

The fallback writes **plural** key names (`views_schema`, `elements_schema`) while every consumer reads **singular** ones (`view_schema`, `element_schema`). Measured producer/consumer overlap: **the empty set**. So the lookups miss and fall back to `null`, and the throw fires.

That is an accident of naming, not a defence. Adding the singular keys — the obvious cleanup, and something I nearly did myself earlier in this session — converts it into a live fail-open.

## The fix

- **`resolveConfiguredId()`** reads each id and returns `null`, with a warning naming the key, when it is empty or whitespace. The guard is now **at the read**, and there is **one** read instead of eight per file.
- The fallback `array_filter`s the nulls out, so `?? null` downstream yields `null` — exactly what every consumer already checks for.
- **`ViewService::getModulesData()`** gains the missing register guard and fails closed rather than issuing an unpinned query; its schema loop now uses `empty()` rather than `=== null` for the same reason.

## Narrower than it first looks — and the tests said so

The fallback is only reached when `amef_config` is **malformed**, because its default `'{}'` is valid JSON and decodes to `[]`. My first draft of the tests failed for exactly that reason and taught me the branch condition; `serviceWithConfig()` now sets `amef_config` to `'not-json'` deliberately, and the unconfigured case asserts `[]` explicitly so it cannot pass vacuously by iterating an empty array.

## Can-fail proof

Reverting the three services to `origin/development`:

```
1) testPartialConfigurationKeepsSetIdsAndDropsUnsetOnes
   Failed asserting that an array does not have the key 'views_schema'.
2) testUnconfiguredInstanceOmitsEveryIdRatherThanEmittingEmptyStrings
   Failed asserting that two arrays are identical.
3) testWhitespaceOnlyIdIsTreatedAsUnset
   Failed asserting that an array does not have the key 'register_id'.
Tests: 4, Assertions: 6, Failures: 3.

[gate-50] security-config-fail-mode: FAIL — 14 unsafe security-config read(s)
```

The fourth test (a configured id comes through unchanged) passes in both directions by design — it is the regression net, not a mirror of the fix.

## Other measurements

- `phpcs lib/` — **0 errors / 87 warnings**, identical to `origin/development`.
- `phpmd` (repo baseline), `psalm`, `phpstan` — clean.
- Unit suite — **523 tests, 1838 assertions, 0 failures**.
- No other gate count moved.