### PR TITLE
fix(register): drop the unresolvable $ref on the cross-app decisions relation (gate-54 1 → PASS)

### DIFF
--- a/lib/Settings/softwarecatalogus_register.json
+++ b/lib/Settings/softwarecatalogus_register.json
@@ -3328,10 +3328,10 @@
             "type": "array",
             "title": "Decisions",
             "description": "Approval/renewal decisions for this contract. References decidesk Decision objects (ADR-066); Decidesk owns the making and eIDAS signing.",
+            "x-external-register": "decidesk",
             "items": {
               "type": "string",
               "format": "uuid",
-              "$ref": "Decision",
               "x-external-register": "decidesk"
             },
             "referenceType": "decision",


### PR DESCRIPTION
**gate-54 relation-dialect: 1 → PASS.** hydra-gates `365fa31d09a26f980e6dc76cb0800575ef005a4e`, measured at the CI scope (`--scope-to-diff --base origin/beta`).

## The defect

`contract.decisions` references decidesk `Decision` objects (ADR-066). It carried **both** `x-external-register: "decidesk"` **and** `$ref: "Decision"`.

OpenRegister resolves `$ref` inside **one** register set and can never reach another app's schema, so that `$ref` is dead weight — it names a target nothing will ever look up.

## I had this wrong earlier today, and I am correcting it

Measuring the same finding against package `651e5c5`, I concluded it was an **unclosable gate gap** and left it red on that basis — and I added my instance to [.github#305](https://github.com/ConductionNL/.github/issues/305) arguing the gate could not express a sanctioned ADR-066 relation.

**That conclusion is now wrong.** [.github#286](https://github.com/ConductionNL/.github/pull/286) landed hours later and gave the cross-app case a dialect. The gate is right; the register was wrong. I have followed up on #305 rather than leaving my earlier comment as the last word there.

## The sanctioned form, and why the old message fired

`_is_external_ref()` reads `x-external-register` **on the property**. This register had it on `items` only — invisible to the gate — which is why the generic *"$ref 'Decision' does not resolve to a schema key"* fired instead of the new, actionable cross-app message.

```diff
 "decisions": {
   "type": "array",
+  "x-external-register": "decidesk",
   "items": {
     "type": "string",
     "format": "uuid",
-    "$ref": "Decision",
     "x-external-register": "decidesk"
   },
```

The annotation is kept on `items` too — it documents the item, and the exemption is what the property carries.

## Can-fail proof

Restoring the `$ref` puts gate-54 straight back to **1 finding**.

## Other measurements

- gate-51 schema-property-titles stays **PASS**.
- The register still parses (`json.load`).
- No other gate count moved.