### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@codemirror/lang-json": "^6.0.0",
-        "@conduction/nextcloud-vue": "2.2.0-vue3.3",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.7",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.3",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.3.tgz",
-      "integrity": "sha512-kO6qtFPnQx1gNFZO/l5YVaSnpnsJspaqazWn5pWiwpma1DbTO9Oa6Jfk5svzFOfR85QB37HKqDqL0JnHpKiXJw==",
+      "version": "2.2.0-vue3.7",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.7.tgz",
+      "integrity": "sha512-x0aj0ACfLUDIak3/A51jVyxCPWPIFYfhv7FG2WIQA5+WKfxfJ2rzt8mIl65AmW646PZxsOz4iPo1pCm3EUeuIQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.29.0",
     "@codemirror/lang-json": "^6.0.0",
-    "@conduction/nextcloud-vue": "2.2.0-vue3.3",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.7",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
## What

Hard-pins `@conduction/nextcloud-vue` to exactly **`2.2.0-vue3.7`** (from `2.2.0-vue3.3`), the current `vue3` dist-tag head.

No caret, no range: `^2.2.0` does **not** match `2.2.0-vue3.7` (caret ranges do not cross prerelease boundaries), and `latest`/`beta` are the retired Vue 2 lineage.

## Lockfile control (run first)

Regenerated with the pin **unchanged** before applying the bump:

| | result |
|---|---|
| control (pin unchanged) | **0 lines** |
| after bump | 8 lock lines + 2 package.json lines |

The whole lock diff is this bump. No other package added, removed or re-resolved.

## Verification

- **Off disk** after a real `npm ci`: exactly **one** copy, `2.2.0-vue3.7`, peer `vue ^3.5.0`.
- **Registry controls**: `2.2.0-vue3.7` resolves; `3.0.0` / `3.0.0-vue3.0` return **E404** (3.x depublished).

| | before (`vue3.3`) | after (`vue3.7`) |
|---|---|---|
| `npm ci` | exit 0 | exit 0 |
| `npm run build` | exit 0, 3 warnings | exit 0, 3 warnings |
| `npm run test:unit` (vitest) | 20 files / **220 passed** | 20 files / **220 passed** |
| `npm test` (jest) | 9 suites / **120 passed** | 9 suites / **120 passed** |
| bundle (`js/`) | 103,593,858 B | 103,623,216 B |

Bundle delta: **+29,358 B (+0.03%)**.

Part of a fleet-wide pin to `2.2.0-vue3.7` across 8 repos.
