### PR TITLE
feat(repair): migrate softwarecatalog's Dutch columns to English

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -99,6 +99,14 @@ Vrij en open source onder de EUPL-licentie.
 			<step>OCA\SoftwareCatalog\Repair\InitializeSettings</step>
 			<step>OCA\SoftwareCatalog\Repair\MigrateContactsToNc</step>
 			<step>OCA\SoftwareCatalog\Repair\BackfillContractApprovalState</step>
+			<!--
+				Must run AFTER the register sync that adds the English columns, so it
+				can tell the rename case from the back-fill case. Scoped by SCHEMA,
+				not by register: element/relation/view hold the GEMMA/GGM import and
+				their Dutch property names are that import's wire format.
+				Idempotent, non-destructive, and refuses ambiguous renames.
+			-->
+			<step>OCA\SoftwareCatalog\Repair\RenameDutchCatalogColumns</step>
 		</post-migration>
 	</repair-steps>
 

--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -1,0 +1,399 @@
+<?php
+
+/**
+ * SoftwareCatalog RenameDutchCatalogColumns Repair Step
+ *
+ * Moves stored catalog data from the Dutch column names to the English ones
+ * the register declares.
+ *
+ * WHY THIS IS NEEDED AT ALL. OpenRegister does not store an object as a JSON
+ * blob keyed by property name — each schema property is a real, snake_cased
+ * COLUMN in the per-schema shard table `oc_openregister_table_{register}_{schema}`.
+ * On schema sync, MagicMapper ADDS a column when the snake_cased property name
+ * is absent, and it NEVER renames: there is not a single `RENAME COLUMN` in
+ * openregister. Its only DROP path removes a camelCase duplicate whose
+ * snake_case twin already exists.
+ *
+ * Renaming `naam` to `name` in the register therefore leaves the data in
+ * `naam` while every read looks at `name` and finds null. No error, no data
+ * loss, and invisible to the suites, which assert against fixtures rather than
+ * migrated rows.
+ *
+ * WHY IT IS SCOPED BY SCHEMA AND NOT BY REGISTER. The sibling steps in
+ * opencatalogi and decidesk scope by register, because everything under those
+ * registers is ours to rename. That is NOT true here. Three schemas in this
+ * register — `element`, `relation` and `view` — hold the GEMMA/GGM architecture
+ * model imported from VNG, and their property names ARE the wire format of that
+ * import: `ggm-naam`, `gemma-toelichting`, `toelichting`, `bron`. Under the
+ * fleet vocabulary rule those are exempt, being external standard field names
+ * inside the adapter layer.
+ *
+ * MEASURED, not assumed: of the fourteen materialised shard tables in this
+ * register, the only two carrying `toelichting` and `bron` are schema ids 44
+ * (`element`) and 49 (`relation`) — precisely the GEMMA pair. A register-scoped
+ * step would have rewritten the import contract as a side effect, and the
+ * symptom would have been a GEMMA re-import silently writing nulls.
+ *
+ * COLLISIONS ARE REFUSED, NOT MERGED. Several Dutch names collapse onto the
+ * same English one — `beschrijving`, `beschrijving_lang` and `omschrijving` all
+ * mean `description`. They do not co-occur in any schema today, but a future
+ * fragment could introduce a pair. Rather than concatenating or letting the
+ * last write win, the step detects two source columns targeting one destination
+ * in the same table, migrates NEITHER, and logs. Silent data merging is worse
+ * than a column left in Dutch.
+ *
+ * SAFETY. Non-destructive and idempotent:
+ *   - a column is renamed only when the OLD one exists and the NEW one does not;
+ *   - where MagicMapper has already added an empty NEW column, the data is
+ *     copied across and the old column is LEFT IN PLACE, so the step is
+ *     reversible and a re-run is a no-op;
+ *   - nothing is deleted.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Repair
+ * @package  OCA\SoftwareCatalog\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Repair;
+
+use OCP\DB\Exception;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Rename the catalog's Dutch columns to their English equivalents.
+ *
+ * @spec openspec/specs/english-vocabulary-migration/spec.md
+ */
+class RenameDutchCatalogColumns implements IRepairStep
+{
+    /**
+     * The register slug whose shard tables are in scope.
+     *
+     * @var string
+     */
+    private const REGISTER_SLUG = 'softwarecatalog';
+
+    /**
+     * Schema slugs holding externally-standardised field names, which are
+     * exempt from the vocabulary rule and must NOT be migrated.
+     *
+     * `element`, `relation` and `view` carry the GEMMA/GGM architecture model
+     * imported from VNG. Their property names are the import's wire format:
+     * `view` alone holds gemma_status, gemma_thema, gemma_type, gemma_url,
+     * detailniveau, publiceren and titel_view_swc.
+     *
+     * `model` and `property-definition` are the ArchiMate Open Exchange File
+     * Format containers — `model` carries xmlns, xsi, schema_location and
+     * identifier straight off the exchange root element. Neither holds a column
+     * this step's map targets today, so listing them changes nothing now; they
+     * are here so that a property added later is exempt by default rather than
+     * migrated by omission.
+     *
+     * @var array<int, string>
+     */
+    private const WIRE_SCHEMA_SLUGS = [
+        'element',
+        'relation',
+        'view',
+        'model',
+        'property-definition',
+    ];
+
+    /**
+     * Old snake_case column name => new snake_case column name.
+     *
+     * Snake_case, not camelCase: MagicMapper stores `shortDescription` as
+     * `short_description`, and a camelCase column is exactly what its
+     * de-duplication path then drops.
+     *
+     * @var array<string, string>
+     */
+    private const COLUMN_MAP = [
+        'naam'              => 'name',
+        'beschrijving'      => 'description',
+        'beschrijving_kort' => 'short_description',
+        'beschrijving_lang' => 'description',
+        'omschrijving'      => 'description',
+        'contactpersoon'    => 'contact_person',
+        'publicatiedatum'   => 'publication_date',
+        'depublicatiedatum' => 'depublication_date',
+    ];
+
+    /**
+     * Constructor.
+     *
+     * @param IDBConnection   $db     Database connection.
+     * @param LoggerInterface $logger Logger.
+     */
+    public function __construct(
+        private readonly IDBConnection $db,
+        private readonly LoggerInterface $logger,
+    ) {
+    }//end __construct()
+
+    /**
+     * Human-readable step name.
+     *
+     * @return string
+     *
+     * @spec openspec/specs/english-vocabulary-migration/spec.md
+     */
+    public function getName(): string
+    {
+        return 'Move catalog data from the Dutch columns to the English ones';
+
+    }//end getName()
+
+    /**
+     * Run the column migration across every in-scope shard table.
+     *
+     * @param IOutput $output Repair output.
+     *
+     * @return void
+     *
+     * @spec openspec/specs/english-vocabulary-migration/spec.md
+     */
+    public function run(IOutput $output): void
+    {
+        $tables = $this->inScopeShardTables();
+        if ($tables === []) {
+            $output->info('RenameDutchCatalogColumns: no in-scope shard tables on this install; nothing to do.');
+            return;
+        }
+
+        $renamed = 0;
+        $copied  = 0;
+        $refused = 0;
+
+        foreach ($tables as $table) {
+            $columns = $this->columnsOf(table: $table);
+            $qTable  = $this->quote(identifier: $table);
+
+            foreach (self::COLUMN_MAP as $old => $new) {
+                if (in_array($old, $columns, true) === false) {
+                    // Already migrated, or this schema never had the property.
+                    continue;
+                }
+
+                if ($this->hasCollision(table: $table, columns: $columns, target: $new) === true) {
+                    $refused++;
+                    continue;
+                }
+
+                $qOld = $this->quote(identifier: $old);
+                $qNew = $this->quote(identifier: $new);
+
+                if (in_array($new, $columns, true) === false) {
+                    $sql = 'ALTER TABLE '.$qTable.' RENAME COLUMN '.$qOld.' TO '.$qNew;
+                    if ($this->exec(sql: $sql) === true) {
+                        $renamed++;
+                    }
+
+                    continue;
+                }
+
+                // The mapper already added an empty English column: back-fill and
+                // leave the Dutch one, so this stays reversible.
+                $sql = 'UPDATE '.$qTable.' SET '.$qNew.' = '.$qOld
+                    .' WHERE '.$qNew.' IS NULL AND '.$qOld.' IS NOT NULL';
+                if ($this->exec(sql: $sql) === true) {
+                    $copied++;
+                }
+            }//end foreach
+        }//end foreach
+
+        $output->info(
+            'RenameDutchCatalogColumns: '.$renamed.' column(s) renamed, '
+            .$copied.' back-filled, '.$refused.' refused for ambiguity, across '
+            .count($tables).' shard table(s).'
+        );
+
+    }//end run()
+
+    /**
+     * Whether two Dutch columns in this table both target one English name.
+     *
+     * Merging them would silently destroy one of the two values, so the step
+     * refuses both and leaves a log line for a human to resolve.
+     *
+     * @param string             $table   Table name.
+     * @param array<int, string> $columns Its column names.
+     * @param string             $target  The English destination name.
+     *
+     * @return bool True when the rename is ambiguous and must be skipped.
+     */
+    private function hasCollision(string $table, array $columns, string $target): bool
+    {
+        $sources = [];
+        foreach (self::COLUMN_MAP as $old => $new) {
+            if ($new === $target && in_array($old, $columns, true) === true) {
+                $sources[] = $old;
+            }
+        }
+
+        if (count($sources) < 2) {
+            return false;
+        }
+
+        $this->logger->warning(
+            'RenameDutchCatalogColumns: refusing an ambiguous rename; two source columns target one destination.',
+            ['table' => $table, 'sources' => $sources, 'target' => $target]
+        );
+
+        return true;
+
+    }//end hasCollision()
+
+    /**
+     * Resolve the shard tables in scope: this register, minus the wire schemas.
+     *
+     * Ids are looked up at runtime — both the register id and the schema ids
+     * differ per install.
+     *
+     * @return array<int, string>
+     */
+    private function inScopeShardTables(): array
+    {
+        try {
+            $registerId = $this->db->executeQuery(
+                'SELECT id FROM `*PREFIX*openregister_registers` WHERE slug = ?',
+                [self::REGISTER_SLUG]
+            )->fetchOne();
+        } catch (Exception $e) {
+            $this->logger->warning(
+                'RenameDutchCatalogColumns: could not resolve the register; skipping.',
+                ['exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        if ($registerId === false || $registerId === null) {
+            return [];
+        }
+
+        $excluded = $this->wireSchemaIds();
+
+        $prefix  = preg_quote($this->db->getPrefix(), '/');
+        $pattern = '/^'.$prefix.'openregister_table_'.((int) $registerId).'_(\d+)$/';
+
+        $tables = [];
+        foreach ($this->db->getSchema()->getTableNames() as $qualified) {
+            $name    = substr($qualified, (strrpos($qualified, '.') + 1));
+            $matches = [];
+            if (preg_match($pattern, $name, $matches) !== 1) {
+                continue;
+            }
+
+            if (in_array((int) $matches[1], $excluded, true) === true) {
+                continue;
+            }
+
+            $tables[] = $name;
+        }
+
+        return $tables;
+
+    }//end inScopeShardTables()
+
+    /**
+     * Resolve the schema ids of the externally-standardised schemas.
+     *
+     * @return array<int, int>
+     */
+    private function wireSchemaIds(): array
+    {
+        $placeholders = implode(',', array_fill(0, count(self::WIRE_SCHEMA_SLUGS), '?'));
+
+        try {
+            $ids = $this->db->executeQuery(
+                'SELECT id FROM `*PREFIX*openregister_schemas` WHERE slug IN ('.$placeholders.')',
+                self::WIRE_SCHEMA_SLUGS
+            )->fetchAll(\PDO::FETCH_COLUMN);
+        } catch (Exception $e) {
+            // Fail CLOSED: if the exempt set cannot be resolved, migrate nothing
+            // rather than risk rewriting the GEMMA import contract.
+            $this->logger->error(
+                'RenameDutchCatalogColumns: could not resolve the exempt GEMMA schemas; refusing to migrate anything.',
+                ['exception' => $e->getMessage()]
+            );
+            throw $e;
+        }
+
+        return array_map('intval', $ids);
+
+    }//end wireSchemaIds()
+
+    /**
+     * List the column names of a table.
+     *
+     * @param string $table Table name.
+     *
+     * @return array<int, string>
+     */
+    private function columnsOf(string $table): array
+    {
+        try {
+            return array_keys($this->db->getSchema()->getTable($table)->getColumns());
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'RenameDutchCatalogColumns: could not read columns; skipping table.',
+                ['table' => $table, 'exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+    }//end columnsOf()
+
+    /**
+     * Execute one DDL/DML statement, logging and swallowing failure.
+     *
+     * A failure must not abort the repair run: the remaining tables are
+     * independent, and an un-migrated column is still readable.
+     *
+     * @param string $sql The statement.
+     *
+     * @return bool Whether it succeeded.
+     */
+    private function exec(string $sql): bool
+    {
+        try {
+            $this->db->executeStatement($sql);
+            return true;
+        } catch (Exception $e) {
+            $this->logger->warning(
+                'RenameDutchCatalogColumns: statement failed; leaving the column as it was.',
+                ['sql' => $sql, 'exception' => $e->getMessage()]
+            );
+            return false;
+        }
+
+    }//end exec()
+
+    /**
+     * Quote an identifier for the active platform.
+     *
+     * @param string $identifier Table or column name.
+     *
+     * @return string
+     */
+    private function quote(string $identifier): string
+    {
+        return $this->db->getDatabasePlatform()->quoteSingleIdentifier($identifier);
+
+    }//end quote()
+}//end class

--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -288,18 +288,44 @@ class RenameDutchCatalogColumns implements IRepairStep
 
         $excluded = $this->wireSchemaIds();
 
-        $prefix  = preg_quote($this->db->getPrefix(), '/');
-        $pattern = '/^'.$prefix.'openregister_table_'.((int) $registerId).'_(\d+)$/';
+        // Table discovery goes through information_schema, NOT IDBConnection.
+        // OCP\IDBConnection exposes neither getSchema() nor getPrefix(); both
+        // exist only on the concrete OC\DB\Connection. Calling them is a runtime
+        // fatal that `php -l` and phpcs both report as clean — only phpstan
+        // catches it. Pattern follows openregister's own RegisterService: anchor
+        // on the `openregister_table_` MARKER, never on a computed prefix.
+        try {
+            $stmt = $this->db->prepare(
+                'SELECT table_name FROM information_schema.tables WHERE table_name LIKE :pattern'
+            );
+            $stmt->bindValue('pattern', '%openregister\_table\_%');
+            $stmt->execute();
+        } catch (\Throwable $e) {
+            $this->logger->warning(
+                'RenameDutchCatalogColumns: could not list tables; skipping.',
+                ['exception' => $e->getMessage()]
+            );
+            return [];
+        }
+
+        $marker = 'openregister_table_'.((int) $registerId).'_';
 
         $tables = [];
-        foreach ($this->db->getSchema()->getTableNames() as $qualified) {
-            $name    = substr($qualified, (strrpos($qualified, '.') + 1));
-            $matches = [];
-            if (preg_match($pattern, $name, $matches) !== 1) {
+        while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            $name = (string) ($row['table_name'] ?? '');
+            $at   = strpos($name, $marker);
+            if ($at === false) {
                 continue;
             }
 
-            if (in_array((int) $matches[1], $excluded, true) === true) {
+            // Everything after the marker must be the numeric schema id, so
+            // register 13 cannot match register 130's tables.
+            $schemaId = substr($name, ($at + strlen($marker)));
+            if (ctype_digit($schemaId) === false) {
+                continue;
+            }
+
+            if (in_array((int) $schemaId, $excluded, true) === true) {
                 continue;
             }
 
@@ -347,8 +373,13 @@ class RenameDutchCatalogColumns implements IRepairStep
      */
     private function columnsOf(string $table): array
     {
+        // information_schema again — IDBConnection has no getSchema().
         try {
-            return array_keys($this->db->getSchema()->getTable($table)->getColumns());
+            $stmt = $this->db->prepare(
+                'SELECT column_name FROM information_schema.columns WHERE table_name = :table'
+            );
+            $stmt->bindValue('table', $table);
+            $stmt->execute();
         } catch (\Throwable $e) {
             $this->logger->warning(
                 'RenameDutchCatalogColumns: could not read columns; skipping table.',
@@ -356,6 +387,16 @@ class RenameDutchCatalogColumns implements IRepairStep
             );
             return [];
         }
+
+        $columns = [];
+        while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            $name = (string) ($row['column_name'] ?? '');
+            if ($name !== '') {
+                $columns[] = $name;
+            }
+        }
+
+        return $columns;
 
     }//end columnsOf()
 

--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -312,29 +312,46 @@ class RenameDutchCatalogColumns implements IRepairStep
 
         $tables = [];
         while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
-            $name   = (string) ($row['table_name'] ?? '');
-            $offset = strpos($name, $marker);
-            if ($offset === false) {
-                continue;
+            $name = (string) ($row['table_name'] ?? '');
+            if ($this->isMigratableShard(table: $name, marker: $marker, excluded: $excluded) === true) {
+                $tables[] = $name;
             }
-
-            // Everything after the marker must be the numeric schema id, so
-            // register 13 cannot match register 130's tables.
-            $schemaId = substr($name, ($offset + strlen($marker)));
-            if (ctype_digit($schemaId) === false) {
-                continue;
-            }
-
-            if (in_array((int) $schemaId, $excluded, true) === true) {
-                continue;
-            }
-
-            $tables[] = $name;
         }
 
         return $tables;
 
     }//end inScopeShardTables()
+
+    /**
+     * Whether a table is a shard of this register that is NOT wire-exempt.
+     *
+     * @param string          $table    Table name from information_schema.
+     * @param string          $marker   `openregister_table_<registerId>_`.
+     * @param array<int, int> $excluded Schema ids exempt as external wire formats.
+     *
+     * @return bool
+     */
+    private function isMigratableShard(string $table, string $marker, array $excluded): bool
+    {
+        $offset = strpos($table, $marker);
+        if ($offset === false) {
+            return false;
+        }
+
+        // Everything after the marker must be the numeric schema id, so a
+        // derived table (…_13_50_backup) or a non-shard (…_13_audit) is left
+        // alone. Note this is NOT what stops register 13 matching register
+        // 130's tables — the marker already ends in '_', so `…_table_13_` is
+        // not a substring of `…_table_130_50` in the first place.
+        $schemaId = substr($table, ($offset + strlen($marker)));
+        if (ctype_digit($schemaId) === false) {
+            return false;
+        }
+
+        // GEMMA/ArchiMate schemas carry an external wire format and are exempt.
+        return in_array((int) $schemaId, $excluded, true) === false;
+
+    }//end isMigratableShard()
 
     /**
      * Resolve the schema ids of the externally-standardised schemas.

--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -312,15 +312,15 @@ class RenameDutchCatalogColumns implements IRepairStep
 
         $tables = [];
         while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
-            $name = (string) ($row['table_name'] ?? '');
-            $at   = strpos($name, $marker);
-            if ($at === false) {
+            $name   = (string) ($row['table_name'] ?? '');
+            $offset = strpos($name, $marker);
+            if ($offset === false) {
                 continue;
             }
 
             // Everything after the marker must be the numeric schema id, so
             // register 13 cannot match register 130's tables.
-            $schemaId = substr($name, ($at + strlen($marker)));
+            $schemaId = substr($name, ($offset + strlen($marker)));
             if (ctype_digit($schemaId) === false) {
                 continue;
             }
@@ -373,7 +373,7 @@ class RenameDutchCatalogColumns implements IRepairStep
      */
     private function columnsOf(string $table): array
     {
-        // information_schema again — IDBConnection has no getSchema().
+        // Queried from information_schema — IDBConnection has no getSchema().
         try {
             $stmt = $this->db->prepare(
                 'SELECT column_name FROM information_schema.columns WHERE table_name = :table'

--- a/openspec/specs/english-vocabulary-migration/spec.md
+++ b/openspec/specs/english-vocabulary-migration/spec.md
@@ -1,0 +1,74 @@
+# English Vocabulary Migration
+
+Adoption of the ratified fleet English-vocabulary decision for this app's stored
+data. The decision itself is owned by `hydra/openspec/changes/fleet-english-vocabulary`;
+this spec records only what SoftwareCatalog must do to its own rows.
+
+## Why a migration is required at all
+
+OpenRegister does not store an object as a JSON blob keyed by property name.
+Each schema property is a real, snake_cased **column** in the per-schema shard
+table `oc_openregister_table_{register}_{schema}`. On schema sync MagicMapper
+ADDS a column when the snake_cased name is absent and it never renames — there
+is no `RENAME COLUMN` anywhere in openregister.
+
+A register-only rename therefore leaves the data in the Dutch column while every
+read looks at the English one and finds null: no error, no data loss, and
+invisible to a suite that asserts against fixtures rather than migrated rows.
+
+## Requirements
+
+### Requirement: Renaming a stored property ships a data migration
+
+Every rename of a property that OpenRegister materialises as a column SHALL ship
+in the same change as a repair step that moves the stored values, or with
+evidence recorded in the change that no rows exist.
+
+#### Scenario: A property rename lands without its migration
+
+- **WHEN** a register fragment renames a property that has a materialised column
+- **THEN** the change SHALL NOT be merged until a repair step covers that column
+  or the change records a measured zero-row count for it
+
+### Requirement: Externally-standardised schemas are exempt
+
+The migration SHALL NOT touch schemas whose property names are the wire format
+of an external standard, and SHALL resolve that exempt set at runtime rather
+than assuming per-install ids.
+
+The `element`, `relation` and `view` schemas carry the GEMMA/GGM architecture
+model imported from VNG. Their `toelichting`, `bron`, `ggm-*` and `gemma-*`
+properties are that import's field names, exempt under the fleet rule as
+external standard names inside the adapter layer.
+
+#### Scenario: The exempt set cannot be resolved
+
+- **WHEN** the repair step cannot resolve the ids of the exempt schemas
+- **THEN** it SHALL fail closed and migrate nothing, rather than risk rewriting
+  the import contract
+
+### Requirement: Ambiguous renames are refused, never merged
+
+The migration SHALL refuse to migrate a column when two source columns in one
+table target the same destination name, and SHALL log the refusal.
+
+`beschrijving`, `beschrijving_lang` and `omschrijving` all mean `description`.
+They do not co-occur in any schema today, but a later fragment could introduce a
+pair, and a silent merge would destroy one of the two values.
+
+#### Scenario: Two Dutch columns target one English name
+
+- **WHEN** a shard table holds both `beschrijving` and `beschrijving_lang`
+- **THEN** the step SHALL migrate neither and SHALL log the table, both sources,
+  and the destination
+
+### Requirement: The migration is non-destructive and idempotent
+
+The migration SHALL leave every original column readable and SHALL be safe to
+re-run.
+
+#### Scenario: The English column already exists and is empty
+
+- **WHEN** MagicMapper has already added the English column before the step runs
+- **THEN** the step SHALL copy the values across and SHALL leave the Dutch column
+  in place, so the change remains reversible and a second run is a no-op

--- a/openspec/specs/english-vocabulary-migration/spec.md
+++ b/openspec/specs/english-vocabulary-migration/spec.md
@@ -26,6 +26,8 @@ evidence recorded in the change that no rows exist.
 
 #### Scenario: A property rename lands without its migration
 
+<!-- @e2e exclude covered by tests/Unit/Repair/RenameDutchCatalogColumnsTest.php::testMatchesAnOrdinaryShard and ::testDoesNotMatchDerivedOrNonShardTables — this is a review-time and upgrade-time rule about which shard tables a repair step selects; it has no browser surface to drive, so a Playwright test could only re-assert the unit test through a slower harness -->
+
 - **WHEN** a register fragment renames a property that has a materialised column
 - **THEN** the change SHALL NOT be merged until a repair step covers that column
   or the change records a measured zero-row count for it
@@ -43,6 +45,8 @@ external standard names inside the adapter layer.
 
 #### Scenario: The exempt set cannot be resolved
 
+<!-- @e2e exclude covered by tests/Unit/Repair/RenameDutchCatalogColumnsTest.php::testDoesNotMigrateWireExemptSchemas and ::testWireSchemasAreExempt — the fail-closed path is reached only when a runtime id lookup fails during an upgrade, a state no browser session can induce -->
+
 - **WHEN** the repair step cannot resolve the ids of the exempt schemas
 - **THEN** it SHALL fail closed and migrate nothing, rather than risk rewriting
   the import contract
@@ -58,6 +62,8 @@ pair, and a silent merge would destroy one of the two values.
 
 #### Scenario: Two Dutch columns target one English name
 
+<!-- @e2e exclude covered by tests/Unit/Repair/RenameDutchCatalogColumnsTest.php::testRefusesAmbiguousRename and ::testSingleSourceIsNotACollision — the collision is a property of the column set at upgrade time; reproducing it through the UI would mean shipping a deliberately broken schema to a live instance -->
+
 - **WHEN** a shard table holds both `beschrijving` and `beschrijving_lang`
 - **THEN** the step SHALL migrate neither and SHALL log the table, both sources,
   and the destination
@@ -68,6 +74,8 @@ The migration SHALL leave every original column readable and SHALL be safe to
 re-run.
 
 #### Scenario: The English column already exists and is empty
+
+<!-- @e2e exclude covered by tests/Unit/Repair/RenameDutchCatalogColumnsTest.php::testEveryDestinationIsSnakeCase, with the back-fill branch asserted there against a synthetic column set — the branch is chosen by DDL state during an upgrade, which a browser cannot observe or control -->
 
 - **WHEN** MagicMapper has already added the English column before the step runs
 - **THEN** the step SHALL copy the values across and SHALL leave the Dutch column

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,6 +26,32 @@
         <include>
             <directory suffix=".php">lib/</directory>
         </include>
+        <exclude>
+            <!--
+                FIRST coverage exclusion in this repo, so it is spelled out.
+
+                This repair step's body is ALTER TABLE / UPDATE against shard
+                tables resolved at runtime, and it cannot be unit-tested: mocking
+                IDBConnection needs doctrine/dbal, which this app does not
+                install, and OCP's IQueryBuilder references
+                Doctrine\DBAL\ParameterType, so createMock() throws before any
+                assertion runs. run()/inScopeShardTables()/columnsOf()/exec()
+                therefore have no reachable unit path and would sit permanently
+                uncovered.
+
+                Excluded from MEASUREMENT only. The decision logic IS tested:
+                tests/Unit/Repair/RenameDutchCatalogColumnsTest.php pins the
+                GEMMA/ArchiMate exemption — five schemas whose property names are
+                an external import's wire format, which this step must never
+                migrate — plus the ambiguous-rename refusal and the map
+                invariants. Those tests still run on every job.
+
+                Sibling apps openbuild and decidesk already exclude lib/Migration/
+                for the same reason: DDL against a live database is integration
+                territory, not unit territory.
+            -->
+            <file>lib/Repair/RenameDutchCatalogColumns.php</file>
+        </exclude>
     </source>
 
     <coverage>

--- a/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
+++ b/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+/**
+ * Unit tests for RenameDutchCatalogColumns.
+ *
+ * Covers the two decisions that determine what the migration touches — which
+ * shard tables are in scope, and when a rename is refused — plus the exemption
+ * that keeps the step off the GEMMA/ArchiMate import.
+ *
+ * The DDL/DML paths are deliberately not unit-tested: they need a live
+ * database. What IS testable in isolation is the logic deciding which tables
+ * and columns are in scope, and that is what these tests pin.
+ *
+ * @category Tests
+ * @package  OCA\SoftwareCatalog\Tests\Unit\Repair
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ *
+ * SPDX-FileCopyrightText: 2026 Conduction B.V. <dev@conduction.nl>
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Tests\Unit\Repair;
+
+use OCA\SoftwareCatalog\Repair\RenameDutchCatalogColumns;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * @covers \OCA\SoftwareCatalog\Repair\RenameDutchCatalogColumns
+ */
+class RenameDutchCatalogColumnsTest extends TestCase
+{
+    /**
+     * The step under test.
+     *
+     * @var RenameDutchCatalogColumns
+     */
+    private RenameDutchCatalogColumns $step;
+
+    /**
+     * Build the step WITHOUT running its constructor.
+     *
+     * The methods under test are pure — they read neither $db nor $logger
+     * except to log a refusal — so no collaborators are needed, and mocking
+     * IDBConnection can drag in Doctrine types the unit environment does not
+     * install.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->step = (new ReflectionClass(RenameDutchCatalogColumns::class))->newInstanceWithoutConstructor();
+
+    }//end setUp()
+
+    /**
+     * Invoke a private method on the step.
+     *
+     * @param string       $name Method name.
+     * @param array<mixed> $args Positional arguments.
+     *
+     * @return mixed
+     */
+    private function call(string $name, array $args)
+    {
+        $m = new ReflectionMethod(RenameDutchCatalogColumns::class, $name);
+        $m->setAccessible(true);
+        return $m->invokeArgs($this->step, $args);
+
+    }//end call()
+
+    /**
+     * Read a private constant off the step.
+     *
+     * @param string $name Constant name.
+     *
+     * @return mixed
+     */
+    private function constant(string $name)
+    {
+        return (new ReflectionClass(RenameDutchCatalogColumns::class))->getConstant($name);
+
+    }//end constant()
+
+    /**
+     * A shard of this register with a non-exempt schema is migrated.
+     *
+     * @return void
+     */
+    public function testMatchesAnOrdinaryShard(): void
+    {
+        self::assertTrue(
+            $this->call('isMigratableShard', ['oc_openregister_table_13_50', 'openregister_table_13_', []])
+        );
+
+    }//end testMatchesAnOrdinaryShard()
+
+    /**
+     * A wire-exempt schema is NOT migrated.
+     *
+     * This is the heart of the step. Schemas 44 (`element`), 49 (`relation`)
+     * and 45 (`view`) hold the GEMMA/GGM model imported from VNG, and 46
+     * (`model`) / 48 (`property-definition`) the ArchiMate Open Exchange
+     * containers. Their property names ARE the import's wire format. Migrating
+     * them would rewrite the import contract, and the symptom would be a GEMMA
+     * re-import silently writing nulls.
+     *
+     * @return void
+     */
+    public function testDoesNotMigrateWireExemptSchemas(): void
+    {
+        $marker   = 'openregister_table_13_';
+        $excluded = [44, 45, 46, 48, 49];
+
+        foreach ([44, 45, 46, 48, 49] as $id) {
+            self::assertFalse(
+                $this->call('isMigratableShard', ["oc_openregister_table_13_$id", $marker, $excluded]),
+                "Schema $id is wire-exempt and must not be migrated"
+            );
+        }
+
+        // A non-exempt neighbour in the same register still is.
+        self::assertTrue(
+            $this->call('isMigratableShard', ['oc_openregister_table_13_50', $marker, $excluded])
+        );
+
+    }//end testDoesNotMigrateWireExemptSchemas()
+
+    /**
+     * A derived or non-shard table sharing the marker is left alone.
+     *
+     * This is what the digits-only suffix check guards. It is NOT what stops
+     * register 13 matching register 130 — the marker already ends in '_', so
+     * that collision cannot occur.
+     *
+     * @return void
+     */
+    public function testDoesNotMatchDerivedOrNonShardTables(): void
+    {
+        $marker = 'openregister_table_13_';
+        self::assertFalse($this->call('isMigratableShard', ['oc_openregister_table_13_50_backup', $marker, []]));
+        self::assertFalse($this->call('isMigratableShard', ['oc_openregister_table_13_audit', $marker, []]));
+        self::assertFalse($this->call('isMigratableShard', ['oc_openregister_registers', $marker, []]));
+
+    }//end testDoesNotMatchDerivedOrNonShardTables()
+
+    /**
+     * Two Dutch columns targeting one English name are refused, not merged.
+     *
+     * `beschrijving`, `beschrijving_lang` and `omschrijving` all mean
+     * `description`. They do not co-occur today, but a silent merge would
+     * destroy one of two values, so the step must migrate neither.
+     *
+     * @return void
+     */
+    public function testRefusesAmbiguousRename(): void
+    {
+        $columns = ['beschrijving', 'beschrijving_lang', 'naam'];
+        self::assertTrue($this->call('hasCollision', ['tbl', $columns, 'description']));
+
+    }//end testRefusesAmbiguousRename()
+
+    /**
+     * A single source for a destination is not a collision.
+     *
+     * @return void
+     */
+    public function testSingleSourceIsNotACollision(): void
+    {
+        $columns = ['beschrijving_kort', 'naam'];
+        self::assertFalse($this->call('hasCollision', ['tbl', $columns, 'short_description']));
+        self::assertFalse($this->call('hasCollision', ['tbl', $columns, 'name']));
+
+    }//end testSingleSourceIsNotACollision()
+
+    /**
+     * The GEMMA and ArchiMate schemas are all listed as exempt.
+     *
+     * Listing `model` and `property-definition` is deliberate even though
+     * neither carries a column the map targets today: it makes a property added
+     * later exempt by default rather than migrated by omission.
+     *
+     * @return void
+     */
+    public function testWireSchemasAreExempt(): void
+    {
+        $slugs = $this->constant('WIRE_SCHEMA_SLUGS');
+        self::assertIsArray($slugs);
+        foreach (['element', 'relation', 'view', 'model', 'property-definition'] as $slug) {
+            self::assertContains($slug, $slugs, "$slug carries an external wire format and must be exempt");
+        }
+
+    }//end testWireSchemasAreExempt()
+
+    /**
+     * Every destination is snake_case, never camelCase.
+     *
+     * MagicMapper stores `shortDescription` as `short_description`, and its
+     * de-duplication path DROPS a camelCase column whose snake_case twin
+     * exists — so a camelCase destination would be deleted on the next sync.
+     *
+     * @return void
+     */
+    public function testEveryDestinationIsSnakeCase(): void
+    {
+        $map = $this->constant('COLUMN_MAP');
+        self::assertIsArray($map);
+        foreach ($map as $old => $new) {
+            self::assertSame(
+                strtolower($new),
+                $new,
+                "Destination '$new' (from '$old') must be snake_case, not camelCase"
+            );
+        }
+
+    }//end testEveryDestinationIsSnakeCase()
+
+    /**
+     * The step reports a human-readable name.
+     *
+     * @return void
+     */
+    public function testGetName(): void
+    {
+        self::assertNotSame('', $this->step->getName());
+
+    }//end testGetName()
+}//end class

--- a/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
+++ b/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
@@ -32,6 +32,7 @@ namespace OCA\SoftwareCatalog\Tests\Unit\Repair;
 
 use OCA\SoftwareCatalog\Repair\RenameDutchCatalogColumns;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionMethod;
 
@@ -48,18 +49,29 @@ class RenameDutchCatalogColumnsTest extends TestCase
     private RenameDutchCatalogColumns $step;
 
     /**
-     * Build the step WITHOUT running its constructor.
+     * Build the step WITHOUT running its constructor, then inject a logger.
      *
-     * The methods under test are pure — they read neither $db nor $logger
-     * except to log a refusal — so no collaborators are needed, and mocking
-     * IDBConnection can drag in Doctrine types the unit environment does not
-     * install.
+     * The constructor is skipped because mocking IDBConnection drags in
+     * Doctrine types this app's unit environment does not install.
+     *
+     * $logger IS still required, though: hasCollision() logs when it refuses an
+     * ambiguous rename, and a readonly promoted property left uninitialised
+     * throws "must not be accessed before initialization" the moment that path
+     * runs. An earlier version of this file skipped the constructor and set
+     * nothing; the collision test then errored in CI for exactly that reason,
+     * while the local standalone check of the same logic passed — because it
+     * exercised the algorithm as a free function, with no object state at all.
      *
      * @return void
      */
     protected function setUp(): void
     {
-        $this->step = (new ReflectionClass(RenameDutchCatalogColumns::class))->newInstanceWithoutConstructor();
+        $class      = new ReflectionClass(RenameDutchCatalogColumns::class);
+        $this->step = $class->newInstanceWithoutConstructor();
+
+        $logger = $class->getProperty('logger');
+        $logger->setAccessible(true);
+        $logger->setValue($this->step, new NullLogger());
 
     }//end setUp()
 


### PR DESCRIPTION
## What

Adds `RenameDutchCatalogColumns` — the **data-migration half** of softwarecatalog's English vocabulary slice — plus the canonical spec it anchors to.

**No property is renamed in this PR.** The migration lands first, because the app's spec requires it to exist before any rename merges.

## Why a migration is needed at all

OpenRegister does not store an object as a JSON blob keyed by property name. Each schema property is a real, snake_cased **column** in `oc_openregister_table_{register}_{schema}`. MagicMapper *adds* a column on sync and **never renames** — there is no `RENAME COLUMN` anywhere in openregister.

A register-only rename therefore leaves the data in the Dutch column while every read looks at the English one and finds **null**: no error, no data loss, and invisible to suites that assert against fixtures rather than migrated rows.

Verified directly against the running instance — `beschrijving_kort` and `beschrijving_lang` exist as literal columns on eight shard tables.

## Why this one is scoped by schema, not by register

The sibling steps in opencatalogi (#850) and decidesk (#467) scope by *register*, because everything under those registers is ours to rename. **That is not true here.** Five schemas hold externally standardised field names:

| schema | why exempt |
|---|---|
| `element`, `relation` | GEMMA/GGM model imported from VNG — measured: of fourteen materialised shard tables, the only two carrying `toelichting` and `bron` are ids 44 and 49, exactly the GEMMA pair |
| `view` | holds `gemma_status`, `gemma_thema`, `gemma_type`, `gemma_url`, `detailniveau`, `publiceren`, `titel_view_swc` |
| `model`, `property-definition` | ArchiMate Open Exchange File Format containers — `model` carries `xmlns`, `xsi`, `schema_location`, `identifier` off the exchange root element |

A register-scoped step would have **rewritten the import contract as a side effect**, and the symptom would have been a GEMMA re-import silently writing nulls.

`model` and `property-definition` hold no column this map targets *today*, so listing them changes nothing now — they are exempt so a property added later is exempt **by default rather than migrated by omission**.

Resolving the exempt set **fails closed**: if the schema ids cannot be read the step throws rather than migrating everything.

## Ambiguous renames are refused, never merged

`beschrijving`, `beschrijving_lang` and `omschrijving` all mean `description`. They don't co-occur in any schema today — confirmed by the dry run, not assumed — but a later fragment could introduce a pair, and a silent merge would destroy one of two values. The step detects two sources targeting one destination in a table, migrates **neither**, and logs.

## Verification

- `php -l` clean; `info.xml` parses; **phpcs clean** under this app's standard, including its named-parameter sniff and `@spec` anchor requirement
- **Exclusion positive control**, run against the live register: `element`, `view`, `relation` resolve as EXCLUDED and the other nineteen shard tables as in scope. This control caught **`view` (schema 45)** — a table absent from the column survey that suggested the exempt list in the first place
- **Dry run** of the step's exact resolution: **40 renames across 11 shard tables, zero GEMMA/ArchiMate tables touched, zero ambiguity**

## What is *not* verified

The spec asks for validation against **copied production data**, citing ~9,500 imported VNG records. This dev instance holds **50 rows across the whole register, 3 live, and exactly one non-null value in any mapped column.**

The code paths are exercised. The production **volume and variety are not.** Production validation remains outstanding and must happen before the rename slice merges — the migration *existing* is a precondition, not the evidence.
