### PR TITLE
fix(security): bump phpcsstandards/phpcsutils to 1.2.3 for CVE-2026-65954

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5206,16 +5206,16 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
-                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/5f35d9408c54d7b529501f3c688b6eae562aea1f",
+                "reference": "5f35d9408c54d7b529501f3c688b6eae562aea1f",
                 "shasum": ""
             },
             "require": {
@@ -5295,7 +5295,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-12-08T14:27:58+00:00"
+            "time": "2026-07-27T10:28:41+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -9871,9 +9871,9 @@
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## What

Bumps `phpcsstandards/phpcsutils` **1.2.2 → 1.2.3**. Lock-only change: 0 installs, 1 update, 0 removals.

## Why

`phpcsstandards/phpcsutils < 1.2.3` carries **CVE-2026-65954** (arbitrary code execution, [GHSA-r6hr-vr92-vv28](https://github.com/PHPCSStandards/PHPCSUtils/security/advisories/GHSA-r6hr-vr92-vv28), affected `>=1.0.0-alpha1,<1.2.3`). The advisory was published today, so `composer audit` turns red on a lock file that has not changed. The `Security (composer)` job in run `31520758535` passed at 18:10Z only because it ran before the advisory landed — the next run on this branch would have gone red without any diff to explain it.

## Evidence

Negative control first, on this tree:

```
composer audit --locked
-> Found 1 security vulnerability advisory affecting 1 package:
   phpcsstandards/phpcsutils / CVE-2026-65954 / exit 1
```

After `composer update phpcsstandards/phpcsutils --no-install --no-scripts`:

```
composer audit --locked
-> No security vulnerability advisories found / exit 0
```

**The bump is exercised, not merely locked.** phpcs was run against the new library on PHP 8.4:

```
A TOTAL OF 0 ERRORS AND 87 WARNINGS WERE FOUND IN 50 FILES
exit 0
```

so no sniff regressed on the upgrade.

## Scope

This does **not** address this repo's remaining Hydra Gates failure. `gate-19` (e2e-coverage) is still **112** against `origin/beta`, and it is the *only* other red cell — the `development → beta` run has `61 of 64 declared gates reported a result (61 of 61 applicable gates ran)` with `gate-19` the sole `FAIL`. That work is separate and is not affected by this lock bump.
