### PR TITLE
fix(install): import the register on a FRESH install, not only on upgrade

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -115,6 +115,24 @@ Vrij en open source onder de EUPL-licentie.
 			-->
 			<step>OCA\SoftwareCatalog\Repair\RenameDutchCatalogColumns</step>
 		</post-migration>
+		<!--
+			FRESH INSTALL. Nextcloud does NOT run post-migration on a first install:
+			`Installer::installAppLastSteps()` guards both the pre-migration and
+			post-migration blocks with `if ($previousVersion !== '')`, and only
+			`repair-steps/install` runs unconditionally afterwards. Until this block
+			existed a brand-new SoftwareCatalog install ran NONE of the steps above,
+			so InitializeSettings never fired and the register was never imported —
+			despite that step's own docblock saying it initialises settings "on
+			install/upgrade".
+
+			Only InitializeSettings belongs here. MigrateContactsToNc,
+			BackfillContractApprovalState and RenameDutchCatalogColumns are all
+			migrations or backfills over data a fresh install does not yet have, so
+			they stay upgrade-only rather than running against an empty database.
+		-->
+		<install>
+			<step>OCA\SoftwareCatalog\Repair\InitializeSettings</step>
+		</install>
 	</repair-steps>
 
 	<settings>


### PR DESCRIPTION
`InitializeSettings` — whose own docblock says it initialises settings **"on install/upgrade"** — was declared only under `<post-migration>`, so it never ran on install.

## Why post-migration never runs on a first install

`\OC\Installer::installAppLastSteps`:

```php
$previousVersion = $this->config->getAppValue($info["id"], "installed_version", "");
if ($previousVersion !== "") { executeRepairSteps(…, "pre-migration"); }
$ms->migrate("latest", $previousVersion === "");     // schema-only on first install
if ($previousVersion !== "") { executeRepairSteps(…, "post-migration"); }
…
executeRepairSteps($info["id"], $info["repair-steps"]["install"]);   // UNCONDITIONAL
```

On a first install `$previousVersion` is `""`, so both pre- and post-migration are skipped. The upgrade path (`AppManager::upgradeApp`) runs pre/post-migration and *not* `install`. An app needs **both** blocks carrying the same baseline steps, each idempotent.

Effect: a fresh SoftwareCatalog instance had no register until someone happened to upgrade the app.

## Scope

Only `InitializeSettings` is added. `MigrateContactsToNc`, `BackfillContractApprovalState` and `RenameDutchCatalogColumns` are migrations or backfills over data a fresh install does not have — running them against an empty database is at best a no-op and at worst install-breaking.

`<install>` sits after `</post-migration>` per the `info.xsd` sequence, verified against the schema (including a control confirming the schema rejects the block placed earlier).

Part of a sweep; openconnector and shillinq already carry this block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)