### PR TITLE
chore(deps): pin @conduction/nextcloud-vue to 2.2.0-vue3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@codemirror/lang-json": "^6.0.0",
-        "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+        "@conduction/nextcloud-vue": "2.2.0-vue3.16",
         "@nextcloud/auth": "^2.6.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.1",
@@ -2221,9 +2221,9 @@
       }
     },
     "node_modules/@conduction/nextcloud-vue": {
-      "version": "2.2.0-vue3.9",
-      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.9.tgz",
-      "integrity": "sha512-9HC1dhYfCqw7JeZ3mn4Zr260iBCWlWa/1slrPTdmIbODvbWlf82guAZEnMq17XvWmDJRcAVNBzYtIT2kWwZutA==",
+      "version": "2.2.0-vue3.16",
+      "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-2.2.0-vue3.16.tgz",
+      "integrity": "sha512-eqKSYzS8hrvqzedbgwAch5M/rn2uPEBDBccZZPIRVZ/XrQMYd0yzseTCLyalsBDrWtdb9HoTOp5OBW+p2WFdwQ==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@babel/core": "^7.29.0",
     "@codemirror/lang-json": "^6.0.0",
-    "@conduction/nextcloud-vue": "2.2.0-vue3.9",
+    "@conduction/nextcloud-vue": "2.2.0-vue3.16",
     "@nextcloud/auth": "^2.6.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.1",


### PR DESCRIPTION
Moves the `@conduction/nextcloud-vue` pin from `2.2.0-vue3.9` to `2.2.0-vue3.16`, the current `vue3` dist-tag. Exact pin kept (no caret — on a prerelease line a caret silently pulls in component changes).

Seven prereleases of component change, so this is a real dependency bump rather than a config edit.

## Lockfile

Regenerated with **npm 10.8.2**, matching `engines: { npm: "^10.0.0" }` and the npm version CI runs. `npm ci` was then verified from a clean `node_modules` — the exact operation CI performs — and succeeded.

## Verification (measured locally on this branch)

| check | result |
|---|---|
| `npm ci` (npm 10.8.2, from clean `node_modules`) | pass |
| `npm run build` | pass, 3 webpack warnings |
| `prebuild` → `check:vue-demi` | pass — worth calling out, since this guard is exactly what a component-library bump could trip |
| `npm test` | 9 suites / 120 tests pass |
| `npm run lint` (eslint) | 0 errors, 473 warnings |
| `npm run stylelint` | pass |

Everything is green, so no `development` comparison run was needed to attribute a failure.

No call sites needed migrating — no component API this app uses moved across the seven prereleases.

## Note on gate-24 (integration-parity)

This repo carries no `scripts/check-integration-parity.sh`, and gate-24 is guarded by the presence of that file, so gate-24 does not execute here either before or after this bump.
