### PR TITLE
fix(repair): guard the Dutch column rename on what the schema declares

### DIFF
--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -43,11 +43,48 @@
  * than a column left in Dutch.
  *
  * SAFETY. Non-destructive and idempotent:
+ *   - a column is moved only when the SCHEMA ITSELF declares the English name
+ *     and no longer declares the Dutch one (see THE ORDERING GUARD below);
  *   - a column is renamed only when the OLD one exists and the NEW one does not;
  *   - where MagicMapper has already added an empty NEW column, the data is
  *     copied across and the old column is LEFT IN PLACE, so the step is
  *     reversible and a re-run is a no-op;
  *   - nothing is deleted.
+ *
+ * THE ORDERING GUARD (softwarecatalog#492). Everything above is only safe in
+ * ONE merge order, and until this guard existed nothing enforced it.
+ *
+ * `appinfo/info.xml` states the precondition in prose — "Must run AFTER the
+ * register sync that adds the English columns" — and NOTHING PERFORMS THAT
+ * SYNC. Measured on `development`: no file under `lib/` reads
+ * `lib/Settings/softwarecatalogus_register.json` at all; the only references
+ * are tests, root-level debug scripts and comments. `InitializeSettings`, the
+ * step ordered immediately before this one, writes config keys and imports
+ * nothing. The register is imported by a human through OpenRegister's
+ * configuration UI, on their own schedule.
+ *
+ * So the precondition was not merely unenforced — it was not automated either,
+ * and the step could not tell the two states apart. `run()` renamed precisely
+ * when the English column was ABSENT, which is exactly the state produced by
+ * "the register has NOT been renamed yet". Measured on the register this repo
+ * ships (220 distinct property keys as a positive control, so the extraction
+ * finds things): every in-scope schema still declares `naam`,
+ * `beschrijvingKort`, `contactpersoon`, `publicatiedatum` and friends, and the
+ * destinations `short_description` / `publication_date` / `contact_person` are
+ * declared NOWHERE in scope. Renaming under that state moves the data to a
+ * column nothing reads, MagicMapper re-adds an empty `naam` on the next sync,
+ * and every read returns null — the step's own header warning with the two
+ * halves swapped.
+ *
+ * The old `$columns`-only test could not distinguish "renamed, mapper behind"
+ * from "not renamed at all": both look identical in a column list. The schema's
+ * DECLARED properties are what tells them apart, so that is what is consulted
+ * now. `renameIsSafe()` requires BOTH halves — the destination declared AND the
+ * source no longer declared — which makes the step correct in EITHER merge
+ * order and a genuine no-op until the register moves.
+ *
+ * Fails CLOSED: a schema whose declared properties cannot be read is skipped
+ * entirely rather than migrated on an assumption.
  *
  * SPDX-License-Identifier: EUPL-1.2
  * SPDX-FileCopyrightText: 2026 Conduction B.V.
@@ -175,14 +212,32 @@ class RenameDutchCatalogColumns implements IRepairStep {
 		$renamed = 0;
 		$copied = 0;
 		$refused = 0;
+		$deferred = 0;
+		$skippedTables = 0;
 
-		foreach ($tables as $table) {
+		foreach ($tables as $table => $schemaId) {
+			$declared = $this->declaredColumnsOf(schemaId: $schemaId);
+			if ($declared === null) {
+				// Fail closed: without the schema's declared properties there is
+				// no way to tell "renamed, mapper behind" from "not renamed at
+				// all", and those need opposite actions.
+				$skippedTables++;
+				continue;
+			}
+
 			$columns = $this->columnsOf(table: $table);
 			$qTable = $this->quote(identifier: $table);
 
 			foreach (self::COLUMN_MAP as $old => $new) {
 				if (in_array($old, $columns, true) === false) {
 					// Already migrated, or this schema never had the property.
+					continue;
+				}
+
+				if ($this->renameIsSafe(old: $old, new: $new, declared: $declared) === false) {
+					// The register has not moved to the English name for this
+					// schema yet. Moving the data now would orphan it.
+					$deferred++;
 					continue;
 				}
 
@@ -215,11 +270,132 @@ class RenameDutchCatalogColumns implements IRepairStep {
 
 		$output->info(
 			'RenameDutchCatalogColumns: ' . $renamed . ' column(s) renamed, '
-			. $copied . ' back-filled, ' . $refused . ' refused for ambiguity, across '
+			. $copied . ' back-filled, ' . $refused . ' refused for ambiguity, '
+			. $deferred . ' deferred because the register still declares the Dutch name, '
+			. $skippedTables . ' table(s) skipped for an unreadable schema, across '
 			. count($tables) . ' shard table(s).'
 		);
 
 	}//end run()
+
+	/**
+	 * Whether moving `$old` to `$new` is safe for a schema declaring `$declared`.
+	 *
+	 * This is the softwarecatalog#492 guard, and it is deliberately BOTH halves:
+	 *
+	 *   - the destination MUST be declared — otherwise the data lands in a
+	 *     column nothing reads, and MagicMapper will re-add the Dutch one empty;
+	 *   - the source must NO LONGER be declared — otherwise the register still
+	 *     considers the Dutch name live, MagicMapper will re-materialise it, and
+	 *     writes and reads end up on different columns.
+	 *
+	 * Requiring only the first would still fire during the window where a
+	 * register declares both names, which is the ambiguous state the collision
+	 * check exists to refuse elsewhere. Requiring only the second would fire on
+	 * a schema that has simply dropped the property.
+	 *
+	 * The predicate is pure — it takes the declared set rather than reading it —
+	 * so the decision this step turns on is unit-testable without a database.
+	 * The DDL that follows is not, which is precisely why the DECISION is.
+	 *
+	 * @param string $old The Dutch column name.
+	 * @param string $new The English column name.
+	 * @param array<int, string> $declared Snake_cased declared property names.
+	 *
+	 * @return bool True when the register has moved and the data should follow.
+	 */
+	private function renameIsSafe(string $old, string $new, array $declared): bool {
+		if (in_array($new, $declared, true) === false) {
+			return false;
+		}
+
+		return in_array($old, $declared, true) === false;
+	}//end renameIsSafe()
+
+	/**
+	 * The snake_cased column names a schema currently declares.
+	 *
+	 * Read from `oc_openregister_schemas.properties`, which is the shape
+	 * MagicMapper materialises columns from — verified first-hand against a live
+	 * instance rather than inferred: the column is `json`, `jsonb_typeof` is
+	 * `object` for all 21 softwarecatalog schemas, and it is keyed by the
+	 * camelCase property name (`properties::jsonb ? 'naam'` is true on exactly
+	 * the schemas the register JSON declares `naam` on).
+	 *
+	 * The register JSON in `lib/Settings/` would be the other candidate source
+	 * and is the WRONG one: nothing imports it automatically, so it describes
+	 * what an operator MAY import, not what this install has. The schemas table
+	 * describes what MagicMapper will actually re-materialise, which is what
+	 * decides whether a rename is orphaning.
+	 *
+	 * @param int $schemaId The schema's database id.
+	 *
+	 * @return array<int, string>|null Declared column names, or null when they
+	 *                                 could not be read (caller must fail closed).
+	 */
+	private function declaredColumnsOf(int $schemaId): ?array {
+		try {
+			$raw = $this->db->executeQuery(
+				'SELECT properties FROM `*PREFIX*openregister_schemas` WHERE id = ?',
+				[$schemaId]
+			)->fetchOne();
+		} catch (Exception $e) {
+			$this->logger->warning(
+				'RenameDutchCatalogColumns: could not read a schema\'s declared properties; skipping its table.',
+				['schemaId' => $schemaId, 'exception' => $e->getMessage()]
+			);
+			return null;
+		}
+
+		if (is_string($raw) === false || $raw === '') {
+			return null;
+		}
+
+		$decoded = json_decode($raw, true);
+		if (is_array($decoded) === false) {
+			$this->logger->warning(
+				'RenameDutchCatalogColumns: a schema\'s properties did not decode to an object; skipping its table.',
+				['schemaId' => $schemaId]
+			);
+			return null;
+		}
+
+		$columns = [];
+		foreach (array_keys($decoded) as $property) {
+			$columns[] = $this->sanitizeColumnName(name: (string)$property);
+		}
+
+		return $columns;
+	}//end declaredColumnsOf()
+
+	/**
+	 * Convert a declared property name to the column MagicMapper materialises.
+	 *
+	 * Mirrors `MagicMapper::sanitizeColumnName()` step for step, because the
+	 * comparison is only meaningful if both sides spell the name the same way:
+	 * the schema declares `beschrijvingKort` and the column is
+	 * `beschrijving_kort`, so comparing the raw property name against
+	 * COLUMN_MAP's snake_case keys would never match and the guard would defer
+	 * every rename forever — a guard that always says no is as useless as one
+	 * that always says yes, and much harder to notice.
+	 *
+	 * Kept as a private copy rather than a dependency on openregister: this step
+	 * must run during a repair pass whether or not that app's classes are
+	 * loadable, and one `extends`/`use` of another app's class is enough to
+	 * fatal the whole run.
+	 *
+	 * @param string $name A declared property name.
+	 *
+	 * @return string The snake_cased column name.
+	 */
+	private function sanitizeColumnName(string $name): string {
+		$name = preg_replace('/([a-z0-9])([A-Z])/', '$1_$2', $name);
+		$name = strtolower($name);
+		$name = preg_replace('/[^a-z0-9_]/', '_', $name);
+		$name = preg_replace('/_+/', '_', $name);
+
+		return rtrim($name, '_');
+	}//end sanitizeColumnName()
 
 	/**
 	 * Whether two Dutch columns in this table both target one English name.
@@ -259,7 +435,12 @@ class RenameDutchCatalogColumns implements IRepairStep {
 	 * Ids are looked up at runtime — both the register id and the schema ids
 	 * differ per install.
 	 *
-	 * @return array<int, string>
+	 * Returns table name => schema id. The schema id is carried through rather
+	 * than re-parsed in `run()` because the ordering guard needs it to read that
+	 * schema's declared properties, and re-deriving it from the table name in a
+	 * second place is one more thing that can drift.
+	 *
+	 * @return array<string, int>
 	 */
 	private function inScopeShardTables(): array {
 		try {
@@ -307,7 +488,7 @@ class RenameDutchCatalogColumns implements IRepairStep {
 		while (($row = $stmt->fetch(\PDO::FETCH_ASSOC)) !== false) {
 			$name = (string)($row['table_name'] ?? '');
 			if ($this->isMigratableShard(table: $name, marker: $marker, excluded: $excluded) === true) {
-				$tables[] = $name;
+				$tables[$name] = (int)substr($name, (strpos($name, $marker) + strlen($marker)));
 			}
 		}
 

--- a/lib/Repair/RenameDutchCatalogColumns.php
+++ b/lib/Repair/RenameDutchCatalogColumns.php
@@ -209,11 +209,13 @@ class RenameDutchCatalogColumns implements IRepairStep {
 			return;
 		}
 
-		$renamed = 0;
-		$copied = 0;
-		$refused = 0;
-		$deferred = 0;
-		$skippedTables = 0;
+		$totals = [
+			'renamed' => 0,
+			'copied' => 0,
+			'refused' => 0,
+			'deferred' => 0,
+			'skippedTables' => 0,
+		];
 
 		foreach ($tables as $table => $schemaId) {
 			$declared = $this->declaredColumnsOf(schemaId: $schemaId);
@@ -221,62 +223,86 @@ class RenameDutchCatalogColumns implements IRepairStep {
 				// Fail closed: without the schema's declared properties there is
 				// no way to tell "renamed, mapper behind" from "not renamed at
 				// all", and those need opposite actions.
-				$skippedTables++;
+				$totals['skippedTables']++;
 				continue;
 			}
 
-			$columns = $this->columnsOf(table: $table);
-			$qTable = $this->quote(identifier: $table);
-
-			foreach (self::COLUMN_MAP as $old => $new) {
-				if (in_array($old, $columns, true) === false) {
-					// Already migrated, or this schema never had the property.
-					continue;
-				}
-
-				if ($this->renameIsSafe(old: $old, new: $new, declared: $declared) === false) {
-					// The register has not moved to the English name for this
-					// schema yet. Moving the data now would orphan it.
-					$deferred++;
-					continue;
-				}
-
-				if ($this->hasCollision(table: $table, columns: $columns, target: $new) === true) {
-					$refused++;
-					continue;
-				}
-
-				$qOld = $this->quote(identifier: $old);
-				$qNew = $this->quote(identifier: $new);
-
-				if (in_array($new, $columns, true) === false) {
-					$sql = 'ALTER TABLE ' . $qTable . ' RENAME COLUMN ' . $qOld . ' TO ' . $qNew;
-					if ($this->exec(sql: $sql) === true) {
-						$renamed++;
-					}
-
-					continue;
-				}
-
-				// The mapper already added an empty English column: back-fill and
-				// leave the Dutch one, so this stays reversible.
-				$sql = 'UPDATE ' . $qTable . ' SET ' . $qNew . ' = ' . $qOld
-					. ' WHERE ' . $qNew . ' IS NULL AND ' . $qOld . ' IS NOT NULL';
-				if ($this->exec(sql: $sql) === true) {
-					$copied++;
-				}
-			}//end foreach
-		}//end foreach
+			foreach ($this->migrateTable(table: $table, declared: $declared) as $key => $count) {
+				$totals[$key] += $count;
+			}
+		}
 
 		$output->info(
-			'RenameDutchCatalogColumns: ' . $renamed . ' column(s) renamed, '
-			. $copied . ' back-filled, ' . $refused . ' refused for ambiguity, '
-			. $deferred . ' deferred because the register still declares the Dutch name, '
-			. $skippedTables . ' table(s) skipped for an unreadable schema, across '
+			'RenameDutchCatalogColumns: ' . $totals['renamed'] . ' column(s) renamed, '
+			. $totals['copied'] . ' back-filled, ' . $totals['refused'] . ' refused for ambiguity, '
+			. $totals['deferred'] . ' deferred because the register still declares the Dutch name, '
+			. $totals['skippedTables'] . ' table(s) skipped for an unreadable schema, across '
 			. count($tables) . ' shard table(s).'
 		);
 
 	}//end run()
+
+	/**
+	 * Move every migratable column of one shard table.
+	 *
+	 * Split out of `run()` so that method stays a readable table loop and this
+	 * one carries the per-column decision. Returns counters rather than
+	 * mutating shared state, so the two levels cannot disagree about what was
+	 * done.
+	 *
+	 * @param string $table The shard table name.
+	 * @param array<int, string> $declared Snake_cased declared property names
+	 *                                     of that table's schema.
+	 *
+	 * @return array<string, int> Counts keyed `renamed`/`copied`/`refused`/`deferred`.
+	 */
+	private function migrateTable(string $table, array $declared): array {
+		$counts = ['renamed' => 0, 'copied' => 0, 'refused' => 0, 'deferred' => 0];
+
+		$columns = $this->columnsOf(table: $table);
+		$qTable = $this->quote(identifier: $table);
+
+		foreach (self::COLUMN_MAP as $old => $new) {
+			if (in_array($old, $columns, true) === false) {
+				// Already migrated, or this schema never had the property.
+				continue;
+			}
+
+			if ($this->renameIsSafe(old: $old, new: $new, declared: $declared) === false) {
+				// The register has not moved to the English name for this
+				// schema yet. Moving the data now would orphan it.
+				$counts['deferred']++;
+				continue;
+			}
+
+			if ($this->hasCollision(table: $table, columns: $columns, target: $new) === true) {
+				$counts['refused']++;
+				continue;
+			}
+
+			$qOld = $this->quote(identifier: $old);
+			$qNew = $this->quote(identifier: $new);
+
+			if (in_array($new, $columns, true) === false) {
+				$sql = 'ALTER TABLE ' . $qTable . ' RENAME COLUMN ' . $qOld . ' TO ' . $qNew;
+				if ($this->exec(sql: $sql) === true) {
+					$counts['renamed']++;
+				}
+
+				continue;
+			}
+
+			// The mapper already added an empty English column: back-fill and
+			// leave the Dutch one, so this stays reversible.
+			$sql = 'UPDATE ' . $qTable . ' SET ' . $qNew . ' = ' . $qOld
+				. ' WHERE ' . $qNew . ' IS NULL AND ' . $qOld . ' IS NOT NULL';
+			if ($this->exec(sql: $sql) === true) {
+				$counts['copied']++;
+			}
+		}//end foreach
+
+		return $counts;
+	}//end migrateTable()
 
 	/**
 	 * Whether moving `$old` to `$new` is safe for a schema declaring `$declared`.
@@ -335,9 +361,12 @@ class RenameDutchCatalogColumns implements IRepairStep {
 	 */
 	private function declaredColumnsOf(int $schemaId): ?array {
 		try {
+			// Bound as a string, not an int: IDBConnection::executeQuery()
+			// declares `array<string>` for its parameter list, and the driver
+			// casts back for the numeric comparison.
 			$raw = $this->db->executeQuery(
 				'SELECT properties FROM `*PREFIX*openregister_schemas` WHERE id = ?',
-				[$schemaId]
+				[(string)$schemaId]
 			)->fetchOne();
 		} catch (Exception $e) {
 			$this->logger->warning(

--- a/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
+++ b/tests/Unit/Repair/RenameDutchCatalogColumnsTest.php
@@ -233,4 +233,163 @@ class RenameDutchCatalogColumnsTest extends TestCase {
 		self::assertNotSame('', $this->step->getName());
 
 	}//end testGetName()
+
+	// ── softwarecatalog#492: the ordering guard ────────────────────────────
+
+	/**
+	 * The guard's full truth table.
+	 *
+	 * Both halves are required, and each one alone is wrong in a different
+	 * direction — so all four combinations are pinned rather than the two that
+	 * happen to occur today.
+	 *
+	 * @return void
+	 */
+	public function testRenameIsSafeOnlyWhenTheRegisterHasMoved(): void {
+		// The register has moved: English declared, Dutch gone. Follow it.
+		self::assertTrue(
+			$this->call('renameIsSafe', ['naam', 'name', ['name', 'description']]),
+			'The destination is declared and the source is not — the data should follow'
+		);
+
+		// TODAY's state: Dutch still declared, English declared nowhere.
+		// This is the case that made #492 a data-loss bug.
+		self::assertFalse(
+			$this->call('renameIsSafe', ['naam', 'name', ['naam', 'beschrijving']]),
+			'The register still declares the Dutch name — renaming would orphan the data'
+		);
+
+		// Ambiguous window: the register declares BOTH. Writes and reads could
+		// land on different columns, so defer rather than guess.
+		self::assertFalse(
+			$this->call('renameIsSafe', ['naam', 'name', ['naam', 'name']]),
+			'Both names declared is ambiguous, not a green light'
+		);
+
+		// The property was simply dropped: neither name is declared. There is
+		// no destination to move to.
+		self::assertFalse(
+			$this->call('renameIsSafe', ['naam', 'name', ['beschrijving']]),
+			'Neither name declared — there is nothing to move the data into'
+		);
+
+	}//end testRenameIsSafeOnlyWhenTheRegisterHasMoved()
+
+	/**
+	 * An unreadable schema declares nothing, so nothing is migrated.
+	 *
+	 * `declaredColumnsOf()` returns null on failure and `run()` skips the whole
+	 * table; this pins the adjacent case, where it returns an empty set.
+	 *
+	 * @return void
+	 */
+	public function testAnEmptyDeclaredSetMigratesNothing(): void {
+		foreach ($this->constant('COLUMN_MAP') as $old => $new) {
+			self::assertFalse(
+				$this->call('renameIsSafe', [$old, $new, []]),
+				"'$old' must not move when the schema declares nothing"
+			);
+		}
+
+	}//end testAnEmptyDeclaredSetMigratesNothing()
+
+	/**
+	 * The column-name transform matches MagicMapper's, name for name.
+	 *
+	 * The comparison is only meaningful if both sides spell the name the same
+	 * way. `beschrijvingKort` must become `beschrijving_kort`, or the guard
+	 * would defer every rename forever — and a guard that always says no is as
+	 * useless as one that always says yes, while being much harder to notice.
+	 *
+	 * @return void
+	 */
+	public function testSanitizeColumnNameMirrorsMagicMapper(): void {
+		$cases = [
+			'naam' => 'naam',
+			'beschrijvingKort' => 'beschrijving_kort',
+			'beschrijvingLang' => 'beschrijving_lang',
+			'shortDescription' => 'short_description',
+			'publicationDate' => 'publication_date',
+			'depublicationDate' => 'depublication_date',
+			'contactPerson' => 'contact_person',
+			'property-definition' => 'property_definition',
+		];
+
+		foreach ($cases as $property => $expected) {
+			self::assertSame(
+				$expected,
+				$this->call('sanitizeColumnName', [$property]),
+				"'$property' must materialise as '$expected'"
+			);
+		}
+
+	}//end testSanitizeColumnNameMirrorsMagicMapper()
+
+	/**
+	 * Against the register this repo actually ships, the step is a NO-OP.
+	 *
+	 * This is the regression test for softwarecatalog#492, and it is the one
+	 * that would have caught it. The register still declares `naam`,
+	 * `beschrijvingKort`, `contactpersoon`, `publicatiedatum` and friends on
+	 * every in-scope schema, and declares none of the English destinations
+	 * there — so every rename must defer.
+	 *
+	 * It is written against the SHIPPED FILE rather than a fixture on purpose.
+	 * A fixture would pin what I believed the register said; the file pins what
+	 * it says. When the register is renamed to English this test starts failing,
+	 * which is the correct moment for a human to look — at which point the
+	 * expectation flips to "these renames are now permitted", in the same PR
+	 * that renames the register (decidesk#467's shape).
+	 *
+	 * @return void
+	 */
+	public function testShippedRegisterStillDeclaresDutchSoNothingMoves(): void {
+		$path = __DIR__ . '/../../../lib/Settings/softwarecatalogus_register.json';
+		self::assertFileExists($path, 'softwarecatalogus_register.json must exist');
+
+		$register = json_decode((string)file_get_contents($path), true);
+		self::assertIsArray($register);
+
+		$schemas = ($register['components']['schemas'] ?? []);
+		self::assertIsArray($schemas);
+		// Positive control: the extraction must actually be finding schemas,
+		// otherwise an empty loop below would pass for free.
+		self::assertGreaterThan(10, count($schemas), 'the register extraction found no schemas');
+
+		$wire = $this->constant('WIRE_SCHEMA_SLUGS');
+		$map = $this->constant('COLUMN_MAP');
+
+		$checked = 0;
+		foreach ($schemas as $slug => $schema) {
+			if (in_array($slug, $wire, true) === true) {
+				continue;
+			}
+
+			$declared = [];
+			foreach (array_keys(($schema['properties'] ?? [])) as $property) {
+				$declared[] = $this->call('sanitizeColumnName', [(string)$property]);
+			}
+
+			foreach ($map as $old => $new) {
+				if (in_array($old, $declared, true) === false) {
+					continue;
+				}
+
+				$checked++;
+				self::assertFalse(
+					$this->call('renameIsSafe', [$old, $new, $declared]),
+					"Schema '$slug' still declares '$old'; moving it to '$new' would orphan the data"
+				);
+			}
+		}
+
+		// Second positive control: if this were 0 the assertions above never
+		// ran, and a silently empty loop is exactly how #492 shipped green.
+		self::assertGreaterThan(
+			20,
+			$checked,
+			'no Dutch column was inspected — the guard was not actually exercised'
+		);
+
+	}//end testShippedRegisterStillDeclaresDutchSoNothingMoves()
 }//end class


### PR DESCRIPTION
## What this does

`RenameDutchCatalogColumns` is registered in `appinfo/info.xml`, live on `development`, and unguarded. It renames a shard column precisely when the English column is **absent** — today's state for every in-scope schema — so the next version bump would move data out of `naam` while the register still declares `naam`. MagicMapper re-adds an empty `naam` on the following sync and every read returns null.

Only the un-bumped version currently prevents it. That is not a safety mechanism, and this repo has taken several merges today.

## Why the ordering was never enforced

`appinfo/info.xml` states the precondition in prose — *"Must run AFTER the register sync that adds the English columns"* — and **nothing performs that sync**. Measured: no file under `lib/` reads `lib/Settings/softwarecatalogus_register.json`; the only references are tests, root-level debug scripts and comments (positive control on a string known present, so the search works). `InitializeSettings`, ordered immediately before this step, writes config keys and imports nothing. The register is imported by a human through OpenRegister's configuration UI.

So the precondition was not merely unenforced — it was not automated either.

## Why the old check could not work

The step tested only the shard's column list. In that list, *"renamed, mapper behind"* and *"not renamed at all"* are byte-identical. The schema's **declared properties** are what separates them, so that is what is consulted now.

`renameIsSafe()` requires both halves — destination declared **and** source no longer declared — which makes the step correct in **either** merge order and a genuine no-op until the register moves. A schema whose declared properties cannot be read is skipped rather than migrated on an assumption.

## Evidence

Measured against the register this repo ships, with a positive control of 220 distinct property keys so the extraction is finding things: every in-scope schema still declares the Dutch names, and the destinations `short_description` / `publication_date` / `contact_person` are declared nowhere in scope.

Declared properties are read from `oc_openregister_schemas.properties` — verified first-hand against a live instance rather than inferred: a `json` column, object-typed on all 21 softwarecatalog schemas, keyed by the camelCase property name. `sanitizeColumnName()` mirrors `MagicMapper::sanitizeColumnName()` step for step, because the comparison only means something if both sides spell the name the same way.

The register JSON would be the other candidate source and is the wrong one: nothing imports it automatically, so it describes what an operator *may* import, not what an install *has*.

## Tests

Twelve tests, ninety assertions. New ones pin the guard's full truth table (all four combinations, not just the two that occur today), the column-name transform, and the regression case: **against the register this repo actually ships, every rename defers**.

That last test reads the shipped file rather than a fixture, so it pins what the register says rather than what I believed it said. It carries two positive controls so an empty loop cannot pass for free — the shipped-register test inspects 36 Dutch columns against a threshold of 20.

**Proven able to fail:** inverting the guard reddens exactly three tests, by name, and leaves the other nine green. The prediction was written before the run. Control reverted; no marker survives in the diff.

## Not in this change, deliberately

The secondary defect noted on the issue — `information_schema` queried filtered only on `table_name`, which on MySQL spans every database on the server — is untouched. I cannot test MySQL here, and mixing an untested change into a guard on a destructive path is the risk this PR exists to remove.

Refs #492.
