### PR TITLE
fix(auth): four admin actions were reachable by any authenticated user

### DIFF
--- a/lib/Controller/GebruikController.php
+++ b/lib/Controller/GebruikController.php
@@ -288,6 +288,33 @@ class GebruikController extends Controller {
 
 		$orgUuid = $this->config->getUserValue(userId: $user->getUID(), appName: 'core', key: 'organisation');
 
+		// Fail CLOSED on a missing organisation, as the app's canonical
+		// deelnemers-scoped read already does in
+		// AangebodenGebruikService::getGebruiksWhereDeelnemers(). getUserValue()
+		// returns '' rather than null when the user-value was never set, so
+		// without this the scope below degrades to `deelnemers: ['']` — and the
+		// query runs with `_rbac: false, _multitenancy: false`, so an empty
+		// predicate that OpenRegister chooses to ignore would return every
+		// organisation's gebruik data rather than none.
+		if ($orgUuid === '') {
+			return new JSONResponse(
+				['message' => 'No organisation is set for this account'],
+				Http::STATUS_FORBIDDEN
+			);
+		}
+
+		// The scope is forced AFTER getParams(), so a caller cannot supply or
+		// override `deelnemers` and read another organisation's usage.
+		//
+		// ⚠️ OPEN, and deliberately not "fixed" by guessing: this passes an
+		// ARRAY where the canonical sibling passes a SCALAR, and whether
+		// OpenRegister honours array-containment matching on a `related-object`
+		// array property is unverified. If it silently ignores the array form
+		// this scope is vacuous. It could not be settled here — the instance
+		// available has zero gebruik rows, so a live A/B would have returned
+		// empty under both forms and proved nothing. Filed rather than changed:
+		// swapping the filter form on a working endpoint could equally break
+		// it, and an unmeasured change to a scope is not a fix.
 		$options = $this->request->getParams();
 		$options['deelnemers'] = [$orgUuid];
 

--- a/lib/Controller/ReviewController.php
+++ b/lib/Controller/ReviewController.php
@@ -108,6 +108,19 @@ class ReviewController extends Controller {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @no-admin-idor-exempt The lookup IS constrained to the scope this
+	 *      endpoint declares public, which is the remedy for
+	 *      `publicpage-unscoped-object-lookup` (there is no session identity on
+	 *      a public page, so an ownership check is not available and not the
+	 *      fix). `$subjectId` never reaches storage: the query in
+	 *      ReviewAggregateService::fetchApprovedReviews() is keyed on
+	 *      `@self.register` / `@self.schema` plus `status = approved` — with
+	 *      the metadata filters correctly nested under `@self` — and the
+	 *      subject is matched in memory afterwards. `status` is then re-checked
+	 *      in PHP over every row, which that method's own comment names as the
+	 *      real enforcement point because `_rbac: false` bypasses
+	 *      OpenRegister's enforcement of the predicate. So an arbitrary
+	 *      `subjectId` can only ever select from already-approved reviews.
 	 * @spec           openspec/specs/catalog-ratings/spec.md#requirement-module-and-dienst-detail-pages-must-display-an-aggregate-rating-computed-only-from-approved-reviews
 	 */
 	#[PublicPage]

--- a/lib/Controller/SbomController.php
+++ b/lib/Controller/SbomController.php
@@ -279,6 +279,11 @@ class SbomController extends Controller {
 			return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
 		}
 
+		$readError = $this->authorizeRead(moduleVersieUuid: $moduleVersieUuid);
+		if ($readError !== null) {
+			return $readError;
+		}
+
 		$operationId = $this->request->getParam('operationId');
 		if (is_string($operationId) === false) {
 			$operationId = null;
@@ -298,6 +303,62 @@ class SbomController extends Controller {
 			);
 		}
 	}//end getSbomImportStatus()
+
+	/**
+	 * Read-ACL authorization guard (IDOR guard) for the import-status read.
+	 *
+	 * `getSbomImportStatus()` took a caller-supplied `moduleVersieUuid` all the
+	 * way to `SbomImportService::getStatus()`, whose lookup runs with
+	 * `_rbac: false, _multitenancy: false` — so the object reference was never
+	 * scoped to the caller and any authenticated user could read any
+	 * moduleVersie's import provenance by substituting a uuid.
+	 *
+	 * This is `authorizeManage()`'s read tier: the same two building blocks
+	 * (`resolveParentModuleUuid` + `userCanReadModule`) minus the editor-group
+	 * membership requirement, because reading a status is not managing an
+	 * import. `userCanReadModule()` resolves with `_rbac: true,
+	 * _multitenancy: true`, and — checked rather than assumed — the `module`
+	 * schema carries a real `authorization.read` ACL (group tiers plus an
+	 * `_organisation` match), so this is a genuine scope rather than the
+	 * default-open case an authorization-less schema would give.
+	 *
+	 * Refuses with 404, not 403, deliberately: the sibling not-found path
+	 * already answers 404 for an unknown uuid, and matching it keeps the
+	 * endpoint from becoming an existence oracle for other tenants' ids.
+	 *
+	 * @param string $moduleVersieUuid The target moduleVersie's uuid.
+	 *
+	 * @return JSONResponse|null Error response, or null when authorized.
+	 *
+	 * @spec openspec/specs/sbom-import/spec.md#requirement-moduleversie-records-sbom-import-provenance
+	 */
+	private function authorizeRead(string $moduleVersieUuid): ?JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+		}
+
+		if ($this->groupManager->isAdmin($user->getUID()) === true) {
+			return null;
+		}
+
+		$moduleUuid = $this->importService->resolveParentModuleUuid($moduleVersieUuid);
+		if ($moduleUuid === null || $this->importService->userCanReadModule($moduleUuid) === false) {
+			$this->logger->warning(
+				'SbomController: status read refused (no read access to the parent module)',
+				['moduleVersieUuid' => $moduleVersieUuid, 'uid' => $user->getUID()]
+			);
+			return new JSONResponse(
+				data: [
+					'message' => 'moduleVersie not found: ' . $moduleVersieUuid,
+					'error' => 'MODULE_VERSION_NOT_FOUND',
+				],
+				statusCode: Http::STATUS_NOT_FOUND
+			);
+		}
+
+		return null;
+	}//end authorizeRead()
 
 	/**
 	 * Manage-ACL authorization guard (IDOR guard). Returns a JSONResponse to

--- a/lib/Controller/SbomController.php
+++ b/lib/Controller/SbomController.php
@@ -279,17 +279,25 @@ class SbomController extends Controller {
 			return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
 		}
 
-		$readError = $this->authorizeRead(moduleVersieUuid: $moduleVersieUuid);
-		if ($readError !== null) {
-			return $readError;
-		}
-
 		$operationId = $this->request->getParam('operationId');
 		if (is_string($operationId) === false) {
 			$operationId = null;
 		}
 
+		// The guard goes INSIDE the try, for the reason importSbom()'s docblock
+		// already records: authorizeRead() reaches
+		// SbomImportService::resolveParentModuleUuid(), and OpenRegister's real
+		// ObjectService::find() RE-THROWS DoesNotExistException for a
+		// well-formed but non-existent uuid rather than returning null. Guarding
+		// outside the try would therefore turn this endpoint's clean 404 into a
+		// 500 for exactly the callers the guard was added for — non-admins
+		// passing an unknown id.
 		try {
+			$readError = $this->authorizeRead(moduleVersieUuid: $moduleVersieUuid);
+			if ($readError !== null) {
+				return $readError;
+			}
+
 			return new JSONResponse(
 				data: $this->importService->getStatus(
 					moduleVersieUuid: $moduleVersieUuid,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -827,6 +827,11 @@ class SettingsController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @no-admin-idor-exempt Takes no object reference. The only parameter is a
+	 *      typed `int $minutesBack` time window, and
+	 *      OrganizationSyncService::getSyncStatusWithErrorHandling() accepts no
+	 *      object id either — it reports aggregate sync timing, not a record.
+	 *      There is nothing for a caller to substitute.
 	 *
 	 * @spec openspec/specs/method-decomposition/spec.md
 	 */
@@ -910,6 +915,10 @@ class SettingsController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @no-admin-idor-exempt An availability probe that touches no storage. The
+	 *      body reads one `timestamp` request param, logs it at debug level and
+	 *      echoes it back; there is no mapper, service or object lookup on the
+	 *      path at all, so there is no direct object reference to substitute.
 	 *
 	 * @spec openspec/specs/method-decomposition/spec.md
 	 */
@@ -1591,8 +1600,20 @@ class SettingsController extends Controller {
 	 * @spec openspec/specs/settings-admin-controller/spec.md
 	 */
 	public function exportArchiMate(): Response {
-		if ($this->userSession->getUser() === null) {
+		$currentUser = $this->userSession->getUser();
+		if ($currentUser === null) {
 			return new JSONResponse(['message' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		// Same guard as the sibling exportOrgArchiMate(), which has carried it
+		// all along. This endpoint exports the WHOLE register while the sibling
+		// exports one organisation, so it was the broader of the two and the
+		// only one unguarded. @NoAdminRequired is kept deliberately: the helper
+		// grants organisation-admins as well as admins, which is the tier the
+		// admin UI relies on and which the annotation's removal would drop.
+		$permissionError = $this->verifyOrgExportPermission(currentUser: $currentUser);
+		if ($permissionError !== null) {
+			return $permissionError;
 		}
 
 		try {
@@ -1771,6 +1792,13 @@ class SettingsController extends Controller {
 	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
+	 * @no-admin-idor-exempt The scope is in the RECEIVER, not in an argument.
+	 *      `$fileName` is resolved against
+	 *      `IRootFolder::getUserFolder($userSession->getUser()->getUID())`, so
+	 *      it can only ever name a file in the caller's own home; and `..` and
+	 *      `/` are rejected outright before that, so it cannot escape it. A
+	 *      substituted filename reaches a different file only if the caller
+	 *      already owns that file.
 	 * @spec            openspec/specs/settings-admin-controller/spec.md
 	 */
 	public function downloadArchiMate(string $fileName): Response {
@@ -1868,7 +1896,13 @@ class SettingsController extends Controller {
 	/**
 	 * Test email connection (separate from sending test email)
 	 *
-	 * @NoAdminRequired
+	 * Admin-only: the caller-supplied smtpHost/smtpPort reach a DSN in
+	 * SettingsService::testEmailConnection(), and the server then opens an
+	 * outbound TCP connection to whatever host and port were named. For a
+	 * non-admin that is an SSRF and internal port-scan primitive, so the
+	 * endpoint must not declare @NoAdminRequired. Its sibling sendTestEmail()
+	 * already omits it, as does every other action on this controller.
+	 *
 	 * @NoCSRFRequired
 	 *
 	 * @return JSONResponse Test connection result
@@ -2083,7 +2117,12 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse Template content.
 	 *
-	 * @NoAdminRequired
+	 * Admin-only, to match the write it pairs with. It reads admin-authored
+	 * mail templates out of app configuration, and no frontend code calls this
+	 * route at all — the settings UI reads templates from the bulk settings
+	 * payload instead (verified with a positive control on a route that IS
+	 * called). Leaving it open bought nothing and exposed admin content.
+	 *
 	 * @NoCSRFRequired
 	 * @spec            openspec/specs/settings-admin-controller/spec.md
 	 */
@@ -2126,7 +2165,14 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse Update result.
 	 *
-	 * @NoAdminRequired
+	 * Admin-only: this writes app configuration —
+	 * setValueString($appName, "email_template_{$templateName}", $content) —
+	 * and the stored HTML is rendered into real outbound mail. It was the only
+	 * write on this controller declaring @NoAdminRequired, so any authenticated
+	 * user could rewrite the templates every recipient receives, and mint
+	 * unbounded `email_template_*` config rows besides. Its sibling
+	 * updateEmailSettings() already omits the annotation.
+	 *
 	 * @NoCSRFRequired
 	 * @spec            openspec/specs/settings-admin-controller/spec.md
 	 */
@@ -2185,7 +2231,9 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse Default template content.
 	 *
-	 * @NoAdminRequired
+	 * Admin-only, for the same reason as getEmailTemplate(): it belongs to the
+	 * admin mail-template surface and has no non-admin consumer.
+	 *
 	 * @NoCSRFRequired
 	 * @spec            openspec/specs/settings-admin-controller/spec.md
 	 */
@@ -2228,7 +2276,9 @@ class SettingsController extends Controller {
 	 *
 	 * @return JSONResponse Available variables for template.
 	 *
-	 * @NoAdminRequired
+	 * Admin-only, for the same reason as getEmailTemplate(): it belongs to the
+	 * admin mail-template surface and has no non-admin consumer.
+	 *
 	 * @NoCSRFRequired
 	 * @spec            openspec/specs/settings-admin-controller/spec.md
 	 */
@@ -3448,7 +3498,20 @@ class SettingsController extends Controller {
 	/**
 	 * Sync OpenRegister organisations to voorzieningen register
 	 *
-	 * @NoAdminRequired
+	 * Admin-only: this triggers a register-wide write sync with a
+	 * caller-chosen batch size, so the endpoint must not carry the
+	 * no-admin-required annotation. Its siblings performSync(),
+	 * bulkSyncStandards() and triggerEolSync() already omit it — the
+	 * annotation's absence IS the check on this controller, which is why none
+	 * of them carries an in-body one.
+	 *
+	 * The annotation is deliberately NOT spelled out above. Nextcloud's own
+	 * ControllerMethodReflector matches `^\h+\*\h+@([A-Z]\w+)` against the raw
+	 * docblock, so writing "must not declare @NoAdminRequired" at the start of
+	 * a comment line RE-DECLARES it — the sentence explaining the removal
+	 * undoes the removal, in the framework and not merely in a linter. Gate-7
+	 * caught it here; nothing else would have.
+	 *
 	 * @NoCSRFRequired
 	 *
 	 * @return JSONResponse The sync results

--- a/tests/Unit/Controller/AdminAuthPostureTest.php
+++ b/tests/Unit/Controller/AdminAuthPostureTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * Auth-posture regression tests for the endpoints hardened alongside #492.
+ *
+ * WHY THIS TEST IS A SOURCE PARSER AND NOT A REQUEST TEST
+ * ------------------------------------------------------
+ * The thing being pinned is a DECLARATION, not a behaviour. Nextcloud's
+ * middleware decides admin-vs-not by reading the docblock before the controller
+ * body ever runs, so the property "this endpoint is admin-only" lives in the
+ * annotation set and nowhere else. A request-level test would need the whole
+ * framework to observe what one regex decides.
+ *
+ * THE REGEX IS COPIED FROM NEXTCLOUD ON PURPOSE
+ * ---------------------------------------------
+ * `OC\AppFramework\Utility\ControllerMethodReflector::reflect()` uses
+ *
+ *     /^\h+\*\h+@(?P<annotation>[A-Z]\w+)((?P<parameter>.*))?$/m
+ *
+ * and this file uses the same one, because the near-miss it exists to catch is
+ * invisible to a looser check. While writing the fix these methods documented
+ * their own hardening with the sentence "the endpoint must not declare
+ * @NoAdminRequired" — and that token, sitting at the start of a comment line,
+ * MATCHES. Nextcloud would have gone on treating the endpoint as
+ * non-admin-required: the sentence explaining the removal would have undone the
+ * removal, and the change would have read as a security fix while being a no-op.
+ *
+ * A test that searched for the attribute form, or that stripped comments first,
+ * would pass over exactly that mistake. So the assertion is deliberately made
+ * against the same bytes the framework reads.
+ *
+ * SPDX-License-Identifier: EUPL-1.2
+ * SPDX-FileCopyrightText: 2026 Conduction B.V.
+ *
+ * @category Tests
+ * @package  OCA\SoftwareCatalog\Tests\Unit\Controller
+ *
+ * @author    Conduction Development Team <dev@conduction.nl>
+ * @copyright 2026 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git-id>
+ *
+ * @link https://conduction.nl
+ */
+
+declare(strict_types=1);
+
+namespace OCA\SoftwareCatalog\Tests\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class AdminAuthPostureTest extends TestCase {
+	/**
+	 * Nextcloud's own annotation regex, byte for byte.
+	 *
+	 * @var string
+	 */
+	private const NC_ANNOTATION_RE = '/^\h+\*\h+@(?P<annotation>[A-Z]\w+)((?P<parameter>.*))?$/m';
+
+	/**
+	 * Absolute path to a controller source file.
+	 *
+	 * @param string $name Class file name without extension.
+	 *
+	 * @return string
+	 */
+	private function controllerPath(string $name): string {
+		return __DIR__ . '/../../../lib/Controller/' . $name . '.php';
+	}
+
+	/**
+	 * The raw docblock immediately preceding a method declaration.
+	 *
+	 * Returns the comment block only — the search starts from the method's
+	 * `public function <name>(` and walks back to the nearest `/**`.
+	 *
+	 * @param string $source The whole file.
+	 * @param string $method The method name.
+	 *
+	 * @return string|null The docblock, or null when the method is absent.
+	 */
+	private function docblockFor(string $source, string $method): ?string {
+		$declPos = strpos($source, 'public function ' . $method . '(');
+		if ($declPos === false) {
+			return null;
+		}
+
+		$open = strrpos(substr($source, 0, $declPos), '/**');
+		if ($open === false) {
+			return null;
+		}
+
+		return substr($source, $open, ($declPos - $open));
+	}
+
+	/**
+	 * Annotation names Nextcloud would parse out of a method's docblock.
+	 *
+	 * @param string $source The whole file.
+	 * @param string $method The method name.
+	 *
+	 * @return array<int, string>
+	 */
+	private function annotationsFor(string $source, string $method): array {
+		$doc = $this->docblockFor($source, $method);
+		self::assertNotNull($doc, "Method $method not found — this test's target moved");
+
+		$matches = [];
+		preg_match_all(self::NC_ANNOTATION_RE, $doc, $matches);
+
+		return $matches['annotation'];
+	}
+
+	/**
+	 * The body text of a method, up to the next method declaration.
+	 *
+	 * @param string $source The whole file.
+	 * @param string $method The method name.
+	 *
+	 * @return string
+	 */
+	private function bodyFor(string $source, string $method): string {
+		$declPos = strpos($source, 'public function ' . $method . '(');
+		self::assertNotFalse($declPos, "Method $method not found — this test's target moved");
+
+		$next = strpos($source, "\n\tpublic function ", ($declPos + 10));
+		$next = $next === false ? strlen($source) : $next;
+
+		return substr($source, $declPos, ($next - $declPos));
+	}
+
+	/**
+	 * POSITIVE CONTROL — the parser can find the annotation when it IS there.
+	 *
+	 * Without this, a typo in the regex or a broken docblock walk would make
+	 * every "must not be present" assertion below pass over an empty array, and
+	 * the whole file would be green while asserting nothing. `getSyncStatus`
+	 * legitimately keeps the annotation (it takes no object reference), so it is
+	 * the natural control and it lives in the same file as the subjects.
+	 *
+	 * @return void
+	 */
+	public function testTheParserCanActuallyFindTheAnnotation(): void {
+		$source = (string)file_get_contents($this->controllerPath('SettingsController'));
+
+		self::assertContains(
+			'NoAdminRequired',
+			$this->annotationsFor($source, 'getSyncStatus'),
+			'The control failed: the parser cannot see an annotation that IS present, '
+			. 'so every absence assertion in this file would be vacuous'
+		);
+	}
+
+	/**
+	 * The four admin actions must NOT be reachable by an ordinary user.
+	 *
+	 * Each one either writes app configuration, drives an outbound connection to
+	 * a caller-named host, or triggers a register-wide sync.
+	 *
+	 * @return void
+	 */
+	public function testAdminActionsDoNotDeclareNoAdminRequired(): void {
+		$source = (string)file_get_contents($this->controllerPath('SettingsController'));
+
+		$adminOnly = [
+			'testEmailConnection' => 'opens an outbound connection to a caller-supplied host and port',
+			'updateEmailTemplate' => 'writes app configuration rendered into outbound mail',
+			'syncOrganisations' => 'triggers a register-wide write sync',
+		];
+
+		foreach ($adminOnly as $method => $why) {
+			self::assertNotContains(
+				'NoAdminRequired',
+				$this->annotationsFor($source, $method),
+				"$method $why, so it must not be reachable without admin. "
+				. 'Note this also fails if the annotation appears only inside PROSE at the '
+				. 'start of a docblock line — which is exactly how it was nearly reinstated.'
+			);
+		}
+	}
+
+	/**
+	 * The mail-template reads move with the write they belong to.
+	 *
+	 * They expose admin-authored templates and have no non-admin consumer: no
+	 * frontend code calls these routes at all.
+	 *
+	 * @return void
+	 */
+	public function testEmailTemplateReadsAreAdminOnly(): void {
+		$source = (string)file_get_contents($this->controllerPath('SettingsController'));
+
+		foreach (['getEmailTemplate', 'getEmailTemplateDefault', 'getEmailTemplateVariables'] as $method) {
+			self::assertNotContains(
+				'NoAdminRequired',
+				$this->annotationsFor($source, $method),
+				"$method reads admin-authored mail templates and must not be public to any authenticated user"
+			);
+		}
+	}
+
+	/**
+	 * exportArchiMate KEEPS the annotation and gains the permission helper.
+	 *
+	 * Both halves matter and they pull in opposite directions. The helper grants
+	 * organisation-admins as well as admins, which is the tier the admin UI
+	 * relies on — so removing the annotation would have been the WRONG fix here,
+	 * even though it was the right fix for its neighbours. Its sibling
+	 * exportOrgArchiMate has carried the same helper all along; this endpoint
+	 * exports the whole register and was the unguarded one.
+	 *
+	 * @return void
+	 */
+	public function testExportArchiMateIsGuardedRatherThanClosed(): void {
+		$source = (string)file_get_contents($this->controllerPath('SettingsController'));
+
+		self::assertContains(
+			'NoAdminRequired',
+			$this->annotationsFor($source, 'exportArchiMate'),
+			'exportArchiMate must stay reachable by organisation-admins; the guard is the helper, not the annotation'
+		);
+
+		self::assertStringContainsString(
+			'verifyOrgExportPermission',
+			$this->bodyFor($source, 'exportArchiMate'),
+			'exportArchiMate exports the WHOLE register and must run its sibling\'s permission check'
+		);
+	}
+
+	/**
+	 * The SBOM import-status read is scoped to the caller.
+	 *
+	 * `SbomImportService::getStatus()` resolves with RBAC and multitenancy both
+	 * off, so without this guard a caller-supplied moduleVersieUuid reached
+	 * storage unscoped.
+	 *
+	 * @return void
+	 */
+	public function testSbomImportStatusIsGuarded(): void {
+		$source = (string)file_get_contents($this->controllerPath('SbomController'));
+		$body = $this->bodyFor($source, 'getSbomImportStatus');
+
+		// Anchored on the CALL, `$this->authorizeRead(`, not the bare name.
+		// The first draft asserted on the bare token and failed — because the
+		// comment in the controller EXPLAINING the ordering names the method,
+		// and that mention sits above the `try`. A positional assertion over a
+		// corpus that includes prose measures the prose. Same family as the
+		// docblock trap this whole file exists to pin, one level down.
+		self::assertStringContainsString(
+			'$this->authorizeRead(',
+			$body,
+			'getSbomImportStatus takes a caller-supplied uuid to a lookup that bypasses RBAC; it needs its read guard'
+		);
+
+		// The guard must sit INSIDE the try. authorizeRead() reaches
+		// ObjectService::find(), which RE-THROWS DoesNotExistException for a
+		// well-formed but unknown uuid — guarding ahead of the try turns this
+		// endpoint's clean 404 into a 500 for exactly the callers the guard was
+		// added for.
+		self::assertLessThan(
+			strpos($body, '$this->authorizeRead('),
+			strpos($body, 'try {'),
+			'The read guard must sit inside the try block, or an unknown uuid 500s instead of 404ing'
+		);
+	}
+}


### PR DESCRIPTION
## What this does

Hand-read all thirteen `no-admin-idor` findings rather than treating the count as a work queue. Outcome: **1 real IDOR, 4 semantic-auth mismatches, 2 guarded downstream, 5 with no object reference, 1 scoped through its receiver** — and **1 deliberately left open**.

## The serious half: four admin actions any authenticated user could invoke

`SettingsController` has a consistent convention — every mutator is admin-required, only readers carry the no-admin annotation. These were the exceptions:

- **`testEmailConnection`** — caller-supplied `smtpHost`/`smtpPort` reach a DSN and the server opens an outbound TCP connection to whatever was named. For a non-admin that is an SSRF and internal port-scan primitive.
- **`updateEmailTemplate`** — the only write in the entire class carrying the annotation. It writes app configuration, and the stored HTML is rendered into real outbound mail, so any authenticated user could rewrite the templates every recipient receives, and mint unbounded `email_template_*` config rows besides.
- **`syncOrganisations`** — triggers a register-wide write sync with a caller-chosen batch size.
- **`exportArchiMate`** — exports the **whole** register while its sibling `exportOrgArchiMate` exports one organisation, and the sibling has carried `verifyOrgExportPermission` all along. The broader endpoint was the unguarded one. Here the annotation is **kept** deliberately: that helper grants organisation-admins as well as admins, which is the tier the admin UI relies on and which removing the annotation would drop.

The three email-template **reads** move with their write. No frontend code calls any of those routes — the settings UI reads templates from the bulk settings payload — verified with a positive control on a route that *is* called, so nothing breaks.

## The one real IDOR

`getSbomImportStatus` took a caller-supplied `moduleVersieUuid` to `SbomImportService::getStatus()`, whose lookup runs with RBAC and multitenancy both off. Guarded with `authorizeManage()`'s **read tier** — the same two building blocks minus the editor-group requirement, since reading a status is not managing an import.

Checked rather than assumed: the `module` schema carries a real `authorization.read` ACL (group tiers plus an `_organisation` match), so this is a genuine scope, not the default-open case an authorization-less schema would give. It refuses **404, not 403**, so it cannot become an existence oracle. No frontend code GETs this route.

## One finding deliberately LEFT OPEN

`getGebruikenForDeelnemer` forces its organisation filter *after* `getParams()`, so a caller cannot forge it. But it passes an **array** where the app's canonical sibling passes a **scalar**, and the query runs with RBAC and multitenancy off. Whether OpenRegister honours array-containment matching on a `related-object` array property is unverified — and if it silently ignores the array form, that scope is vacuous.

It could not be settled here: the available instance has **zero** gebruik rows, so a live A/B would have returned empty under both forms and proved nothing. It gets the fail-closed guard its canonical sibling already has, and **keeps the finding**. Exempting it would have manufactured the coverage.

## A trap worth reading, because it nearly shipped

My first draft explained each removal with the sentence *"the endpoint must not declare @NoAdminRequired"*. Nextcloud's `ControllerMethodReflector` matches `^\h+\*\h+@([A-Z]\w+)` against the raw docblock — so putting that token at the start of a comment line **re-declares the annotation**. The sentence explaining the removal would have undone the removal, in the framework itself and not merely in a linter.

The mechanical check caught it; nothing else would have. The surviving comment says so, and spells the annotation only in prose.

## Safety

**Nothing here makes anything return 200 that previously errored** — every change is deny-only: an annotation removed (adding a middleware rejection) or a refusing branch inserted ahead of an already-succeeding body.

`exportArchiMate`'s `$organization` parameter is a **dead filter** end to end — used only in a log line, never passed to the query. That is a real functional bug found on the way and is **not** repaired here: it is a feature repair sitting behind a missing guard, and it belongs in a separate change after the guard lands.

Every exemption names the code path that makes it safe, not a state of the world.

---

## Added after the first CI run: the auth-posture test

The first push came back with gate-7 reading **1** instead of 13, exactly as measured locally — and one **new** failure: the security-change-has-tests gate, because this diff moved auth posture in `lib/` and touched no test. That is a failure this change caused, so it is fixed rather than merged over.

`tests/Unit/Controller/AdminAuthPostureTest.php` parses the controller source with **Nextcloud's own annotation regex, copied byte for byte** from `ControllerMethodReflector::reflect()`. That is deliberate: the near-miss described above is invisible to anything looser. A test looking for the `#[NoAdminRequired]` attribute form, or one that stripped comments first, would pass straight over a prose re-declaration.

Five tests:

- **A positive control first** — the parser must find the annotation where it legitimately remains (`getSyncStatus`). Without it, a typo in the regex or the docblock walk would make every *absence* assertion pass over an empty array, and the file would be green while asserting nothing.
- The four admin actions must not carry it.
- The three mail-template reads must not carry it.
- **`exportArchiMate` is pinned in both directions**, because they pull opposite ways: it must **keep** the annotation (the helper grants organisation-admins, a tier that removing it would drop) **and** must call `verifyOrgExportPermission`. The right fix for its neighbours was the wrong fix for it.
- `getSbomImportStatus` is pinned for guard presence **and guard position** — inside the `try`, since `authorizeRead()` reaches `ObjectService::find()`, which re-throws for an unknown uuid.

**Proven able to fail, prediction written first:** re-planting the prose form of the annotation reddens exactly the admin-actions test and nothing else. Reverted byte-identically.

One note worth keeping: the positional assertion failed on its own first attempt because it anchored on the bare name `authorizeRead`, which the controller's own explanatory comment uses *above* the `try`. A positional assertion over a corpus that includes prose measures the prose. It anchors on the call now.
